### PR TITLE
Fix spaCy fallback logic

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -224,11 +224,23 @@ class NLPProcessor:
                     cls._instances[lang] = spacy.load(Config.NLP_MODELS[lang])
                     logger.info(f"Carregado modelo NLP para {lang}")
                 except OSError:
-                    logger.warning(f"Modelo NLP para {lang} não encontrado, usando modelo pequeno")
-                    cls._instances[lang] = spacy.load(Config.NLP_MODELS[lang].replace('_lg', '_sm'))
+                    logger.warning(
+                        f"Modelo NLP para {lang} não encontrado, tentando modelo pequeno"
+                    )
+                    try:
+                        cls._instances[lang] = spacy.load(
+                            Config.NLP_MODELS[lang].replace("_lg", "_sm")
+                        )
+                    except OSError:
+                        logger.warning(
+                            f"Modelos lg e sm para {lang} indisponíveis, usando 'en_core_web_sm'"
+                        )
+                        cls._instances[lang] = spacy.load("en_core_web_sm")
             else:
-                logger.warning(f"Modelo NLP para {lang} não configurado, usando inglês")
-                cls._instances[lang] = spacy.load(Config.NLP_MODELS['en'])
+                logger.warning(
+                    f"Modelo NLP para {lang} não configurado, usando inglês"
+                )
+                cls._instances[lang] = spacy.load(Config.NLP_MODELS["en"])
         return cls._instances[lang]
     
     @classmethod


### PR DESCRIPTION
## Summary
- handle missing `_sm` NLP model with nested try/except
- provide final fallback to `en_core_web_sm`
- unit test for triple fallback
- stub heavy modules in tests so they don't need installation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853683db804832099835bd683e2ed6b