### PR TITLE
Add CLI args and FastAPI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ Use o arquivo `requirements.txt` para instalar as dependências:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Uso via linha de comando
+
+Execute o scraper diretamente especificando idiomas, categorias e formato de saída:
+
+```bash
+python scraper_wiki.py --lang pt --category "Programação" --format json
+```
+
+É possível repetir `--lang` e `--category` para processar múltiplos valores.
+
+## API FastAPI
+
+Inicie a API executando:
+
+```bash
+uvicorn api_app:app --reload
+```
+
+Envie uma requisição `POST /scrape` com um JSON contendo `lang`, `category` e `format` para gerar o dataset.

--- a/api_app.py
+++ b/api_app.py
@@ -1,0 +1,23 @@
+from typing import List, Optional
+from fastapi import FastAPI
+from pydantic import BaseModel
+import scraper_wiki as sw
+
+app = FastAPI()
+
+class ScrapeParams(BaseModel):
+    lang: Optional[List[str]] | Optional[str] = None
+    category: Optional[List[str]] | Optional[str] = None
+    format: str = "all"
+
+@app.post("/scrape")
+async def scrape(params: ScrapeParams):
+    langs = params.lang
+    if isinstance(langs, str):
+        langs = [langs]
+    cats = params.category
+    if isinstance(cats, str):
+        cats = [cats]
+
+    sw.main(langs, cats, params.format)
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ sentence-transformers
 scikit-learn
 sumy
 pyarrow
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add CLI arg parsing to `scraper_wiki.py`
- expose dataset generation via simple FastAPI service
- document command-line usage and API example in README
- include FastAPI dependencies in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685372684fc08320beaa52d8ce9ac90a