### PR TITLE
Fix duplicate translations

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -808,8 +808,7 @@ class DatasetBuilder:
                 'What is the role of': 'Qual é o papel de',
                 'Can you explain': 'Você pode explicar',
                 'in the context of': 'no contexto de',
-                'What is the significance of': 'Qual é a importância de',
-                'How does': 'Como é que'
+                'What is the significance of': 'Qual é a importância de'
             },
             'es': {
                 'What is': 'Qué es',
@@ -818,8 +817,7 @@ class DatasetBuilder:
                 'What is the role of': 'Cuál es el papel de',
                 'Can you explain': 'Puedes explicar',
                 'in the context of': 'en el contexto de',
-                'What is the significance of': 'Cuál es la importancia de',
-                'How does': 'Cómo es que'
+                'What is the significance of': 'Cuál es la importancia de'
             },
             'fr': {
                 'What is': 'Qu\'est-ce que',
@@ -828,8 +826,7 @@ class DatasetBuilder:
                 'What is the role of': 'Quel est le rôle de',
                 'Can you explain': 'Pouvez-vous expliquer',
                 'in the context of': 'dans le contexte de',
-                'What is the significance of': 'Quelle est l\'importance de',
-                'How does': 'Comment se fait-il que'
+                'What is the significance of': 'Quelle est l\'importance de'
             }
         }
         

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -74,6 +74,16 @@ def test_translate_question_pt():
     question = qb._translate_question('What is Python?', 'pt')
     assert 'O que é' in question
 
+def test_translate_question_es():
+    qb = sw.DatasetBuilder()
+    question = qb._translate_question('How does Python relate to programacion?', 'es')
+    assert 'Cómo' in question and 'se relaciona con' in question
+
+def test_translate_question_fr():
+    qb = sw.DatasetBuilder()
+    question = qb._translate_question('How does Python relate to programmation?', 'fr')
+    assert 'Comment' in question and 'se rapporte à' in question
+
 def test_classify_topic_ai_nlp():
     qb = sw.DatasetBuilder()
     topic, sub = qb._classify_topic('Deep Learning', 'O processamento de linguagem natural evoluiu', 'pt')


### PR DESCRIPTION
## Summary
- remove duplicate `How does` entries in question translations
- verify translation output for Spanish and French

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685375603f30832098d86b75f338e2bb