### PR TITLE
Add Streamlit dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ uvicorn api_app:app --reload
 ```
 
 Envie uma requisição `POST /scrape` com um JSON contendo `lang`, `category` e `format` para gerar o dataset.
+
+## Dashboard
+
+Para acompanhar o progresso do scraper execute:
+
+```bash
+streamlit run dashboard.py
+```
+
+A aplicação lê `logs/progress.json` e exibe o total de páginas processadas, uso de CPU e memória, além dos clusters, tópicos e idiomas atuais.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+import streamlit as st
+import psutil
+
+PROGRESS_FILE = Path("logs/progress.json")
+
+
+def load_progress():
+    if PROGRESS_FILE.exists():
+        try:
+            with PROGRESS_FILE.open() as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def main():
+    st.title("Scraper Progress Dashboard")
+
+    progress = load_progress()
+    pages_processed = progress.get("pages_processed", 0)
+    clusters = progress.get("clusters", [])
+    topics = progress.get("topics", [])
+    languages = progress.get("languages", [])
+
+    st.metric("Pages processed", pages_processed)
+    cpu = psutil.cpu_percent(interval=1)
+    ram = psutil.virtual_memory().percent
+    st.metric("CPU usage", f"{cpu}%")
+    st.metric("RAM usage", f"{ram}%")
+
+    st.subheader("Clusters")
+    st.write(clusters)
+
+    st.subheader("Topics")
+    st.write(topics)
+
+    st.subheader("Languages")
+    st.write(languages)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ sumy
 pyarrow
 fastapi
 uvicorn
+
+streamlit
+psutil


### PR DESCRIPTION
## Summary
- track scraping progress with a simple `dashboard.py` using Streamlit and psutil
- document how to run the dashboard
- include Streamlit and psutil in requirements

## Testing
- `pip install wikipedia-api psutil streamlit`
- `pip install bs4 requests html2text backoff numpy fastapi uvicorn`
- `pip install numpy requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537b485314832094b13bad683efdb1