### PR TITLE
Add Typer CLI and refactor entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,23 @@ pip install -r requirements.txt
 
 ## Uso via linha de comando
 
-Execute o scraper diretamente especificando idiomas, categorias e formato de saída:
+Utilize o script `cli.py` para interagir com o scraper. Para executar uma coleta imediatamente:
 
 ```bash
-python scraper_wiki.py --lang pt --category "Programação" --format json
+python cli.py scrape --lang pt --category "Programação" --format json
 ```
 
-É possível repetir `--lang` e `--category` para processar múltiplos valores.
+É possível repetir `--lang` e `--category` para processar múltiplos valores. Para monitorar o progresso use:
+
+```bash
+python cli.py monitor
+```
+
+Também é possível enfileirar execuções futuras:
+
+```bash
+python cli.py queue --lang en --category "Algorithms"
+```
 
 ## API FastAPI
 
@@ -31,10 +41,10 @@ Envie uma requisição `POST /scrape` com um JSON contendo `lang`, `category` e 
 
 ## Dashboard
 
-Para acompanhar o progresso do scraper execute:
+Para acompanhar o progresso do scraper basta rodar:
 
 ```bash
-streamlit run dashboard.py
+python cli.py monitor
 ```
 
-A aplicação lê `logs/progress.json` e exibe o total de páginas processadas, uso de CPU e memória, além dos clusters, tópicos e idiomas atuais.
+Essa interface lê `logs/progress.json` e exibe o total de páginas processadas, uso de CPU e memória, além dos clusters, tópicos e idiomas atuais.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import typer
+
+import scraper_wiki
+import dashboard
+
+app = typer.Typer(help="Scraper Wiki command line interface")
+
+QUEUE_FILE = Path("jobs_queue.jsonl")
+
+@app.command()
+def scrape(
+    lang: list[str] = typer.Option(None, "--lang", help="Idioma a processar", show_default=False),
+    category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
+    fmt: str = typer.Option("all", "--format", help="Formato de saída"),
+):
+    """Executa o scraper imediatamente."""
+    scraper_wiki.main(lang, category, fmt)
+
+@app.command()
+def monitor():
+    """Inicia o dashboard para monitoramento."""
+    dashboard.main()
+
+@app.command()
+def queue(
+    lang: list[str] = typer.Option(None, "--lang", help="Idioma a processar", show_default=False),
+    category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
+    fmt: str = typer.Option("all", "--format", help="Formato de saída"),
+):
+    """Enfileira um job de scraping."""
+    job = {"lang": lang, "category": category, "format": fmt}
+    QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with QUEUE_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(job, ensure_ascii=False) + "\n")
+    typer.echo(f"Job enfileirado: {job}")
+
+if __name__ == "__main__":
+    app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ uvicorn
 
 streamlit
 psutil
+typer

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -2,8 +2,6 @@
 # CEO: Fabio | Engenharia de Nível Industrial
 
 import wikipediaapi
-import argparse
-import sys
 import os
 import re
 import time
@@ -1089,17 +1087,4 @@ def main(langs: Optional[List[str]] = None,
     logger.info(f"📊 Estatísticas de cache: {cache.stats()}")
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Gerador de datasets da Wikipedia")
-    parser.add_argument("--lang", action="append", dest="langs", help="Idioma a processar (pode repetir)")
-    parser.add_argument("--category", action="append", dest="categories", help="Categoria específica (pode repetir)")
-    parser.add_argument("--format", dest="fmt", default="all", help="Formato de saída")
-    args = parser.parse_args()
-
-    try:
-        main(args.langs, args.categories, args.fmt)
-    except KeyboardInterrupt:
-        logger.info("⏹️ Execução interrompida pelo usuário")
-        sys.exit(0)
-    except Exception as e:
-        logger.critical(f"❌ Erro crítico: {e}", exc_info=True)
-        sys.exit(1)
+    main()


### PR DESCRIPTION
## Summary
- create `cli.py` with Typer and subcommands `scrape`, `monitor` and `queue`
- refactor `scraper_wiki.py` to expose `main()` and remove argparse CLI
- update requirements with typer
- document new CLI usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537d1cf08883208395772b71fea023