### PR TITLE
Fix missing WikipediaException fallback

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -2,6 +2,17 @@
 # CEO: Fabio | Engenharia de Nível Industrial
 
 import wikipediaapi
+
+# Some versions of the wikipedia-api package do not expose
+# ``WikipediaException``.  This attribute is referenced throughout the
+# codebase when specifying retry logic for API calls.  To maintain
+# compatibility with those versions we provide a simple fallback to the
+# base ``Exception`` type when the attribute is missing.
+if not hasattr(wikipediaapi, "WikipediaException"):
+    class WikipediaException(Exception):
+        """Fallback exception used when ``wikipediaapi`` lacks one."""
+
+    wikipediaapi.WikipediaException = WikipediaException
 import os
 import re
 import time


### PR DESCRIPTION
## Summary
- add a fallback definition of `WikipediaException` when the package doesn't provide it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f3dd812083208ca296dc565606d8