### PR TITLE
Implement category normalization

### DIFF
--- a/api_app.py
+++ b/api_app.py
@@ -18,6 +18,8 @@ async def scrape(params: ScrapeParams):
     cats = params.category
     if isinstance(cats, str):
         cats = [cats]
+    if cats is not None:
+        cats = [sw.normalize_category(c) or c for c in cats]
 
     sw.main(langs, cats, params.format)
     return {"status": "ok"}

--- a/cli.py
+++ b/cli.py
@@ -16,7 +16,8 @@ def scrape(
     fmt: str = typer.Option("all", "--format", help="Formato de saída"),
 ):
     """Executa o scraper imediatamente."""
-    scraper_wiki.main(lang, category, fmt)
+    cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
+    scraper_wiki.main(lang, cats, fmt)
 
 @app.command()
 def monitor():
@@ -30,7 +31,8 @@ def queue(
     fmt: str = typer.Option("all", "--format", help="Formato de saída"),
 ):
     """Enfileira um job de scraping."""
-    job = {"lang": lang, "category": category, "format": fmt}
+    cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
+    job = {"lang": lang, "category": cats, "format": fmt}
     QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
     with QUEUE_FILE.open("a", encoding="utf-8") as f:
         f.write(json.dumps(job, ensure_ascii=False) + "\n")

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -130,6 +130,34 @@ class Config:
     def get_random_user_agent(cls):
         return random.choice(cls.USER_AGENTS)
 
+
+# ============================
+# 🗂 Categoria Normalização
+# ============================
+
+# Mapas de alias para nomes canônicos de categorias. As chaves devem estar
+# normalizadas (sem acentos e em minúsculas) para facilitar a busca.
+CATEGORY_ALIASES = {
+    "programacao": "Programação",
+}
+
+
+def normalize_category(name: str) -> Optional[str]:
+    """Retorna o nome canônico de uma categoria.
+
+    A comparação ignora acentos e diferenças de maiúsculas/minúsculas.
+    Se a categoria ou um de seus aliases for encontrado, devolve o nome
+    oficial; caso contrário, ``None``.
+    """
+
+    normalized = unidecode(name).lower()
+
+    for canonical in Config.CATEGORIES:
+        if unidecode(canonical).lower() == normalized:
+            return canonical
+
+    return CATEGORY_ALIASES.get(normalized)
+
 # ============================
 # 📊 Logging Avançado
 # ============================
@@ -1063,7 +1091,8 @@ def main(langs: Optional[List[str]] = None,
     languages = langs or Config.LANGUAGES
     cats = Config.CATEGORIES
     if categories:
-        cats = {c: Config.CATEGORIES.get(c, 1.0) for c in categories}
+        normalized = [normalize_category(c) or c for c in categories]
+        cats = {c: Config.CATEGORIES.get(c, 1.0) for c in normalized}
 
     builder = DatasetBuilder()
 

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -208,3 +208,37 @@ def test_save_dataset_json_csv(tmp_path, monkeypatch):
     assert (tmp_path/'wikipedia_qa.json').exists()
     builder.save_dataset('csv', output_dir=tmp_path)
     assert (tmp_path/'wikipedia_qa.csv').exists()
+
+
+def test_normalize_category_alias():
+    assert sw.normalize_category('programacao') == 'Programação'
+
+
+def test_main_uses_normalized_category(monkeypatch):
+    called = []
+
+    class DummyWiki:
+        def __init__(self, lang):
+            pass
+
+        def get_category_members(self, category_name):
+            called.append(category_name)
+            return []
+
+    class DummyBuilder:
+        def build_from_pages(self, pages, *a, **k):
+            return []
+
+        def enhance_with_clustering(self):
+            pass
+
+        def save_dataset(self, format=None):
+            pass
+
+    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
+    monkeypatch.setattr(sw, 'DatasetBuilder', DummyBuilder)
+    monkeypatch.setattr(sw.time, 'sleep', lambda *a, **k: None)
+
+    sw.main(langs=['pt'], categories=['programacao'], fmt='json')
+
+    assert called == ['Programação']


### PR DESCRIPTION
## Summary
- add CATEGORY_ALIASES and `normalize_category`
- normalize categories passed to `main`, CLI and API
- cover new alias logic in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546831d8988320aab67501e48b5ce0