### PR TITLE
Implement rate limiter with exponential backoff

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14,10 +14,11 @@ def scrape(
     lang: list[str] = typer.Option(None, "--lang", help="Idioma a processar", show_default=False),
     category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
     fmt: str = typer.Option("all", "--format", help="Formato de saída"),
+    rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
 ):
     """Executa o scraper imediatamente."""
     cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
-    scraper_wiki.main(lang, cats, fmt)
+    scraper_wiki.main(lang, cats, fmt, rate_limit_delay)
 
 @app.command()
 def monitor():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,8 +86,8 @@ def test_queue_command(tmp_path, monkeypatch):
 def test_scrape_command(monkeypatch):
     called = {}
 
-    def fake_main(lang, category, fmt):
-        called["args"] = {"lang": lang, "category": category, "fmt": fmt}
+    def fake_main(lang, category, fmt, rate_limit_delay=None):
+        called["args"] = {"lang": lang, "category": category, "fmt": fmt, "delay": rate_limit_delay}
 
     monkeypatch.setattr(cli.scraper_wiki, "main", fake_main)
     runner = CliRunner()
@@ -97,7 +97,44 @@ def test_scrape_command(monkeypatch):
 
     assert result.exit_code == 0
     assert called["args"] == {
-        "lang": ["pt"], "category": ["AI"], "fmt": "csv"
+        "lang": ["pt"], "category": ["AI"], "fmt": "csv", "delay": None
+    }
+
+
+def test_scrape_command_with_delay(monkeypatch):
+    called = {}
+
+    def fake_main(lang, category, fmt, rate_limit_delay=None):
+        called["args"] = {
+            "lang": lang,
+            "category": category,
+            "fmt": fmt,
+            "delay": rate_limit_delay,
+        }
+
+    monkeypatch.setattr(cli.scraper_wiki, "main", fake_main)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "scrape",
+            "--lang",
+            "pt",
+            "--category",
+            "AI",
+            "--format",
+            "csv",
+            "--rate-limit-delay",
+            "2.5",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert called["args"] == {
+        "lang": ["pt"],
+        "category": ["AI"],
+        "fmt": "csv",
+        "delay": 2.5,
     }
 
 


### PR DESCRIPTION
## Summary
- add `RateLimiter` class to control request pacing
- integrate rate limiter with Wikipedia requests
- expose `--rate-limit-delay` CLI option and env var
- add tests for rate limiting and CLI option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547bc0fb1483209ab53aa09b0905c2