### PR TITLE
Implement cache fallback with backoff

### DIFF
--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -141,8 +141,16 @@ def test_fetch_html_content_success(monkeypatch):
 
 
 def test_fetch_html_content_error(monkeypatch):
+    fake_cache = {}
+    monkeypatch.setattr(sw, 'cache', SimpleNamespace(
+        get=lambda k: fake_cache.get(k),
+        set=lambda k, v: fake_cache.__setitem__(k, v),
+        stats=lambda: {}
+    ))
+
     def fake_get(*a, **k):
         raise sw.requests.exceptions.RequestException('fail')
+
     monkeypatch.setattr(sw.requests, 'get', fake_get)
     result = sw.fetch_html_content('Any', 'en')
     assert result == ''


### PR DESCRIPTION
## Summary
- retry HTML fetch, category search and related page retrieval with backoff
- when retries fail, return cached result if available or safe defaults
- update tests to isolate cache usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547d5bc1c883209032eff0f9733c30