### PR TITLE
Add cache TTL management

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Para listar os arquivos gerados e visualizar configurações chave use:
 python cli.py status
 ```
 
+### Cache
+
+Selecione o backend de cache com `--cache-backend` (`file`, `sqlite` ou `redis`)
+e defina o tempo de vida dos registros com `--cache-ttl` (segundos). Para
+remover entradas expiradas execute:
+
+```bash
+python cli.py clear-cache
+```
+
 ## API FastAPI
 
 Inicie a API executando:

--- a/cli.py
+++ b/cli.py
@@ -7,6 +7,19 @@ import dashboard
 
 app = typer.Typer(help="Scraper Wiki command line interface")
 
+
+@app.callback(invoke_without_command=False)
+def main(
+    ctx: typer.Context,
+    cache_backend: str = typer.Option(None, "--cache-backend", help="Backend de cache", show_default=False),
+    cache_ttl: int = typer.Option(None, "--cache-ttl", help="Tempo de vida do cache em segundos", show_default=False),
+):
+    if cache_backend is not None:
+        scraper_wiki.Config.CACHE_BACKEND = cache_backend
+        scraper_wiki.cache = scraper_wiki.init_cache()
+    if cache_ttl is not None:
+        scraper_wiki.Config.CACHE_TTL = cache_ttl
+
 QUEUE_FILE = Path("jobs_queue.jsonl")
 
 @app.command()
@@ -63,6 +76,13 @@ def status():
     }
     for key, value in settings.items():
         typer.echo(f"{key}: {value}")
+
+
+@app.command("clear-cache")
+def clear_cache_cmd():
+    """Remove entradas expiradas do cache."""
+    scraper_wiki.clear_cache()
+    typer.echo("Cache limpo")
 
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,6 +138,31 @@ def test_scrape_command_with_delay(monkeypatch):
     }
 
 
+def test_cache_options(monkeypatch):
+    monkeypatch.setattr(cli.scraper_wiki, "init_cache", lambda: SimpleNamespace())
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["--cache-backend", "sqlite", "--cache-ttl", "60", "status"],
+    )
+    assert result.exit_code == 0
+    assert cli.scraper_wiki.Config.CACHE_BACKEND == "sqlite"
+    assert cli.scraper_wiki.Config.CACHE_TTL == 60
+
+
+def test_clear_cache_command(monkeypatch):
+    called = {}
+
+    def fake_clear():
+        called["ok"] = True
+
+    monkeypatch.setattr(cli.scraper_wiki, "clear_cache", fake_clear)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["clear-cache"])
+    assert result.exit_code == 0
+    assert called.get("ok")
+
+
 
 def test_load_progress(tmp_path, monkeypatch):
     monkeypatch.setattr(cli.dashboard, "PROGRESS_FILE", tmp_path / "prog.json")

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -144,7 +144,7 @@ def test_fetch_html_content_error(monkeypatch):
     fake_cache = {}
     monkeypatch.setattr(sw, 'cache', SimpleNamespace(
         get=lambda k: fake_cache.get(k),
-        set=lambda k, v: fake_cache.__setitem__(k, v),
+        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
         stats=lambda: {}
     ))
 
@@ -257,7 +257,7 @@ def test_search_category(monkeypatch):
     fake_cache = {}
     monkeypatch.setattr(sw, 'cache', SimpleNamespace(
         get=lambda k: fake_cache.get(k),
-        set=lambda k, v: fake_cache.__setitem__(k, v),
+        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
         stats=lambda: {}
     ))
 
@@ -318,7 +318,7 @@ def test_main_collects_pages_unaccented(monkeypatch):
     fake_cache = {}
     monkeypatch.setattr(sw, 'cache', SimpleNamespace(
         get=lambda k: fake_cache.get(k),
-        set=lambda k, v: fake_cache.__setitem__(k, v),
+        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
         stats=lambda: {}
     ))
     original_norm = sw.normalize_category
@@ -371,7 +371,7 @@ def test_main_collects_pages_alias(monkeypatch):
     fake_cache = {}
     monkeypatch.setattr(sw, 'cache', SimpleNamespace(
         get=lambda k: fake_cache.get(k),
-        set=lambda k, v: fake_cache.__setitem__(k, v),
+        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
         stats=lambda: {}
     ))
     from unidecode import unidecode as real_unidecode
@@ -421,7 +421,7 @@ def test_get_category_members_search_requests(monkeypatch):
     fake_cache = {}
     monkeypatch.setattr(sw, 'cache', SimpleNamespace(
         get=lambda k: fake_cache.get(k),
-        set=lambda k, v: fake_cache.__setitem__(k, v),
+        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
         stats=lambda: {}
     ))
 


### PR DESCRIPTION
## Summary
- support `--cache-backend` and `--cache-ttl` options in cli
- implement TTL expiration for SQLite and Redis caches
- provide `clear_cache()` helper and CLI command
- document cache usage in README
- update unit tests for new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547f6189608320a9f940eec7affd29