### PR TITLE
Add logging configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ remover entradas expiradas execute:
 python cli.py clear-cache
 ```
 
+### Logs
+
+Use `--log-level` para ajustar a verbosidade (`DEBUG`, `INFO`, `WARNING`, etc.)
+e `--log-format` para escolher entre saída `text` (padrão) ou `json`.
+Exemplo:
+
+```bash
+python cli.py --log-level DEBUG --log-format json scrape --lang pt --category "Programação"
+```
+
 ## API FastAPI
 
 Inicie a API executando:

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 import typer
 
@@ -13,12 +14,18 @@ def main(
     ctx: typer.Context,
     cache_backend: str = typer.Option(None, "--cache-backend", help="Backend de cache", show_default=False),
     cache_ttl: int = typer.Option(None, "--cache-ttl", help="Tempo de vida do cache em segundos", show_default=False),
+    log_level: str = typer.Option(None, "--log-level", help="Nível de log (DEBUG, INFO, WARNING...)", show_default=False),
+    log_format: str = typer.Option("text", "--log-format", help="Formato do log (text ou json)"),
 ):
     if cache_backend is not None:
         scraper_wiki.Config.CACHE_BACKEND = cache_backend
         scraper_wiki.cache = scraper_wiki.init_cache()
     if cache_ttl is not None:
         scraper_wiki.Config.CACHE_TTL = cache_ttl
+
+    if log_level is not None or log_format != "text":
+        level = getattr(logging, log_level.upper(), logging.INFO) if log_level else logging.INFO
+        scraper_wiki.setup_logger("wiki_scraper", "scraper.log", level=level, fmt=log_format)
 
 QUEUE_FILE = Path("jobs_queue.jsonl")
 


### PR DESCRIPTION
## Summary
- allow setting log level and format through CLI
- implement JSON log formatter and setup_logger enhancements
- document new logging options in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685481cbf5e88320971995e9f76ce9fe