### PR TITLE
Add configurable parallelism and async utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Exemplo:
 python cli.py --log-level DEBUG --log-format json scrape --lang pt --category "Programação"
 ```
 
+### Paralelismo
+
+Controle o número de threads e processos utilizados pelo scraper com as opções
+`--max-threads` e `--max-processes`. Esses valores também podem ser definidos
+pelas variáveis de ambiente `MAX_THREADS` e `MAX_PROCESSES`.
+
 ## API FastAPI
 
 Inicie a API executando:

--- a/cli.py
+++ b/cli.py
@@ -16,6 +16,8 @@ def main(
     cache_ttl: int = typer.Option(None, "--cache-ttl", help="Tempo de vida do cache em segundos", show_default=False),
     log_level: str = typer.Option(None, "--log-level", help="Nível de log (DEBUG, INFO, WARNING...)", show_default=False),
     log_format: str = typer.Option("text", "--log-format", help="Formato do log (text ou json)"),
+    max_threads: int = typer.Option(None, "--max-threads", help="Número máximo de threads", show_default=False),
+    max_processes: int = typer.Option(None, "--max-processes", help="Número máximo de processos", show_default=False),
 ):
     if cache_backend is not None:
         scraper_wiki.Config.CACHE_BACKEND = cache_backend
@@ -26,6 +28,10 @@ def main(
     if log_level is not None or log_format != "text":
         level = getattr(logging, log_level.upper(), logging.INFO) if log_level else logging.INFO
         scraper_wiki.setup_logger("wiki_scraper", "scraper.log", level=level, fmt=log_format)
+    if max_threads is not None:
+        scraper_wiki.Config.MAX_THREADS = max_threads
+    if max_processes is not None:
+        scraper_wiki.Config.MAX_PROCESSES = max_processes
 
 QUEUE_FILE = Path("jobs_queue.jsonl")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,14 @@ sys.modules.setdefault('spacy', SimpleNamespace(load=lambda *a, **k: None))
 sys.modules.setdefault('unidecode', SimpleNamespace(unidecode=lambda x: x))
 sys.modules.setdefault('tqdm', SimpleNamespace(tqdm=lambda x, **k: x))
 sys.modules.setdefault('html2text', SimpleNamespace())
+wiki_mod = ModuleType('wikipediaapi')
+wiki_mod.WikipediaException = Exception
+wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
+wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
+wiki_mod.WikipediaPage = object
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
+sys.modules.setdefault('wikipediaapi', wiki_mod)
+sys.modules.setdefault('aiohttp', SimpleNamespace(ClientSession=object))
 sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
 
 sklearn_mod = ModuleType('sklearn')
@@ -171,3 +179,14 @@ def test_load_progress(tmp_path, monkeypatch):
 
     loaded = cli.dashboard.load_progress()
     assert loaded == progress_data
+
+
+def test_parallelism_options(monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["--max-threads", "5", "--max-processes", "2", "status"],
+    )
+    assert result.exit_code == 0
+    assert cli.scraper_wiki.Config.MAX_THREADS == 5
+    assert cli.scraper_wiki.Config.MAX_PROCESSES == 2

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -14,6 +14,14 @@ sys.modules.setdefault('spacy', SimpleNamespace(load=lambda *a, **k: None))
 sys.modules.setdefault('unidecode', SimpleNamespace(unidecode=lambda x: x))
 sys.modules.setdefault('tqdm', SimpleNamespace(tqdm=lambda x, **k: x))
 sys.modules.setdefault('html2text', SimpleNamespace())
+wiki_mod = ModuleType('wikipediaapi')
+wiki_mod.WikipediaException = Exception
+wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
+wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
+wiki_mod.WikipediaPage = object
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
+sys.modules.setdefault('wikipediaapi', wiki_mod)
+sys.modules.setdefault('aiohttp', SimpleNamespace(ClientSession=object))
 sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
 sklearn_mod = ModuleType('sklearn')
 sklearn_mod.cluster = SimpleNamespace(KMeans=object)
@@ -472,6 +480,15 @@ def test_rate_limiter_env(monkeypatch):
     sw_reload = importlib.reload(sw)
     assert sw_reload.Config.RATE_LIMIT_DELAY == 1.5
     assert sw_reload.rate_limiter.delay == 1.5
+
+
+def test_parallelism_env(monkeypatch):
+    monkeypatch.setenv("MAX_THREADS", "7")
+    monkeypatch.setenv("MAX_PROCESSES", "3")
+    import importlib
+    sw_reload = importlib.reload(sw)
+    assert sw_reload.Config.MAX_THREADS == 7
+    assert sw_reload.Config.MAX_PROCESSES == 3
 
 
 def test_rate_limiter_backoff(monkeypatch):


### PR DESCRIPTION
## Summary
- allow configuring MAX_THREADS and MAX_PROCESSES via environment or CLI
- log periodic progress while building dataset
- expose async helpers for page fetching and processing
- document new parallelism options
- test CLI and env options for parallelism configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685482c4b50c8320883e1bc7b7bfeda2