### PR TITLE
Implement plugin architecture

### DIFF
--- a/api_app.py
+++ b/api_app.py
@@ -9,6 +9,7 @@ class ScrapeParams(BaseModel):
     lang: Optional[List[str]] | Optional[str] = None
     category: Optional[List[str]] | Optional[str] = None
     format: str = "all"
+    plugin: str = "wikipedia"
 
 @app.post("/scrape")
 async def scrape(params: ScrapeParams):
@@ -21,5 +22,16 @@ async def scrape(params: ScrapeParams):
     if cats is not None:
         cats = [sw.normalize_category(c) or c for c in cats]
 
-    sw.main(langs, cats, params.format)
+    if params.plugin == "wikipedia":
+        sw.main(langs, cats, params.format)
+    else:
+        from plugins import load_plugin, run_plugin
+
+        plg = load_plugin(params.plugin)
+        run_plugin(
+            plg,
+            langs or sw.Config.LANGUAGES,
+            cats or list(sw.Config.CATEGORIES),
+            params.format,
+        )
     return {"status": "ok"}

--- a/cli.py
+++ b/cli.py
@@ -41,10 +41,19 @@ def scrape(
     category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
     fmt: str = typer.Option("all", "--format", help="Formato de saída"),
     rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
+    plugin: str = typer.Option("wikipedia", "--plugin", help="Plugin de scraping"),
 ):
     """Executa o scraper imediatamente."""
     cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
-    scraper_wiki.main(lang, cats, fmt, rate_limit_delay)
+    if plugin == "wikipedia":
+        scraper_wiki.main(lang, cats, fmt, rate_limit_delay)
+    else:
+        from plugins import load_plugin, run_plugin
+
+        plg = load_plugin(plugin)
+        languages = lang or scraper_wiki.Config.LANGUAGES
+        categories = cats or list(scraper_wiki.Config.CATEGORIES)
+        run_plugin(plg, languages, categories, fmt)
 
 @app.command()
 def monitor():

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,2 @@
+from .scraping import WikipediaAdvanced
+from .builder import DatasetBuilder

--- a/core/builder.py
+++ b/core/builder.py
@@ -1,0 +1,5 @@
+"""Parsing and dataset builder utilities."""
+
+from scraper_wiki import DatasetBuilder
+
+__all__ = ["DatasetBuilder"]

--- a/core/scraping.py
+++ b/core/scraping.py
@@ -1,0 +1,5 @@
+"""Scraping utilities."""
+
+from scraper_wiki import WikipediaAdvanced
+
+__all__ = ["WikipediaAdvanced"]

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,26 @@
+"""Plugin utilities."""
+import importlib
+from typing import List
+from core.builder import DatasetBuilder
+from .base import Plugin
+
+
+def load_plugin(name: str) -> Plugin:
+    """Load a plugin by its module name."""
+    module = importlib.import_module(f"plugins.{name}")
+    plugin_cls = getattr(module, "Plugin")
+    return plugin_cls()
+
+
+def run_plugin(plugin: Plugin, langs: List[str], categories: List[str], fmt: str = "all") -> List[dict]:
+    """Execute scraping using a plugin."""
+    builder = DatasetBuilder()
+    for lang in langs:
+        for category in categories:
+            items = plugin.fetch_items(lang, category)
+            for item in items:
+                result = plugin.parse_item(item)
+                if result:
+                    builder.dataset.append(result)
+    builder.save_dataset(fmt)
+    return builder.dataset

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,0 +1,14 @@
+"""Plugin interface definition."""
+from typing import List, Dict, Protocol, runtime_checkable
+
+@runtime_checkable
+class Plugin(Protocol):
+    """Basic scraping plugin."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return raw items for a given language and category."""
+        ...
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Convert a raw item into a dataset entry."""
+        ...

--- a/plugins/stackoverflow.py
+++ b/plugins/stackoverflow.py
@@ -1,0 +1,13 @@
+"""Example StackOverflow plugin."""
+from .base import Plugin
+
+
+class Plugin(Plugin):  # type: ignore[misc]
+    def fetch_items(self, lang: str, category: str):
+        # Placeholder implementation
+        return []
+
+    def parse_item(self, item: dict):
+        # Placeholder implementation
+        return {}
+

--- a/plugins/wikidata.py
+++ b/plugins/wikidata.py
@@ -1,0 +1,13 @@
+"""Example Wikidata plugin."""
+from .base import Plugin
+
+
+class Plugin(Plugin):  # type: ignore[misc]
+    def fetch_items(self, lang: str, category: str):
+        # Placeholder implementation
+        return []
+
+    def parse_item(self, item: dict):
+        # Placeholder implementation
+        return {}
+

--- a/plugins/wikipedia.py
+++ b/plugins/wikipedia.py
@@ -1,0 +1,16 @@
+"""Wikipedia scraping plugin."""
+from core import WikipediaAdvanced, DatasetBuilder
+from .base import Plugin
+
+
+class Plugin(Plugin):  # type: ignore[misc]
+    def __init__(self) -> None:
+        self.builder = DatasetBuilder()
+
+    def fetch_items(self, lang: str, category: str):
+        wiki = WikipediaAdvanced(lang)
+        return wiki.get_category_members(category)
+
+    def parse_item(self, item: dict):
+        return self.builder.process_page(item)
+


### PR DESCRIPTION
## Summary
- add minimal plugin loading utilities and base interface
- implement wikipedia plugin and stub plugins for wikidata and stackoverflow
- expose scraping and builder modules via new `core` package
- load plugins dynamically in CLI and API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685487ab0a508320bfc0c00de6dbb0f5