### PR TITLE
Add dataset query API and integrate dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ uvicorn api_app:app --reload
 
 Envie uma requisição `POST /scrape` com um JSON contendo `lang`, `category` e `format` para gerar o dataset.
 
+### Consulta de registros
+
+Os dados gerados podem ser recuperados via `GET /records` com filtros opcionais:
+
+```bash
+curl "http://localhost:8000/records?lang=pt&category=Programação"
+```
+
+Para consultas mais flexíveis existe o endpoint `POST /graphql` que aceita
+consultas GraphQL usando `graphene`. Exemplo:
+
+```bash
+curl -X POST http://localhost:8000/graphql -H "Content-Type: application/json" \
+  -d '{"query": "{ records(lang:[\"pt\"]) { title category } }"}'
+```
+
+Informações de progresso podem ser obtidas em `GET /stats`.
+
 ## Dashboard
 
 Para acompanhar o progresso do scraper basta rodar:
@@ -103,6 +121,7 @@ python cli.py monitor
 ```
 
 Essa interface lê `logs/progress.json` e exibe o total de páginas processadas, uso de CPU e memória, além dos clusters, tópicos e idiomas atuais.
+Agora o dashboard também consulta `GET /stats` quando disponível para mostrar as estatísticas em tempo real.
 
 ## Filas e Workers
 

--- a/api_app.py
+++ b/api_app.py
@@ -1,9 +1,55 @@
 from typing import List, Optional
-from fastapi import FastAPI
+from fastapi import FastAPI, Query, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import scraper_wiki as sw
+import os
+import json
+from datetime import datetime
+import graphene
 
 app = FastAPI()
+
+DATA_FILE = os.path.join(sw.Config.OUTPUT_DIR, "wikipedia_qa.json")
+PROGRESS_FILE = os.path.join(sw.Config.LOG_DIR, "progress.json")
+
+
+def load_dataset() -> List[dict]:
+    if not os.path.exists(DATA_FILE):
+        return []
+    with open(DATA_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_progress() -> dict:
+    if not os.path.exists(PROGRESS_FILE):
+        return {}
+    try:
+        with open(PROGRESS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        return {}
+
+
+def filter_dataset(
+    data: List[dict],
+    langs: Optional[List[str]] = None,
+    categories: Optional[List[str]] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> List[dict]:
+    result = data
+    if langs:
+        result = [d for d in result if d.get("language") in langs]
+    if categories:
+        result = [d for d in result if d.get("category") in categories]
+    if start_date:
+        s_dt = datetime.fromisoformat(start_date)
+        result = [d for d in result if "created_at" in d and datetime.fromisoformat(d["created_at"]) >= s_dt]
+    if end_date:
+        e_dt = datetime.fromisoformat(end_date)
+        result = [d for d in result if "created_at" in d and datetime.fromisoformat(d["created_at"]) <= e_dt]
+    return result
 
 class ScrapeParams(BaseModel):
     lang: Optional[List[str]] | Optional[str] = None
@@ -35,3 +81,57 @@ async def scrape(params: ScrapeParams):
             params.format,
         )
     return {"status": "ok"}
+
+
+@app.get("/records")
+async def get_records(
+    lang: Optional[List[str]] | Optional[str] = Query(None),
+    category: Optional[List[str]] | Optional[str] = Query(None),
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+):
+    langs = lang if isinstance(lang, list) else ([lang] if lang else None)
+    cats = category if isinstance(category, list) else ([category] if category else None)
+    data = load_dataset()
+    filtered = filter_dataset(data, langs, cats, start_date, end_date)
+    return filtered
+
+
+@app.get("/stats")
+async def get_stats():
+    return load_progress()
+
+
+class RecordType(graphene.ObjectType):
+    id = graphene.String()
+    title = graphene.String()
+    language = graphene.String()
+    category = graphene.String()
+    topic = graphene.String()
+    subtopic = graphene.String()
+    summary = graphene.String()
+    created_at = graphene.String()
+
+
+class Query(graphene.ObjectType):
+    records = graphene.List(
+        RecordType,
+        lang=graphene.List(graphene.String),
+        category=graphene.List(graphene.String),
+        start_date=graphene.String(),
+        end_date=graphene.String(),
+    )
+
+    def resolve_records(root, info, lang=None, category=None, start_date=None, end_date=None):
+        data = load_dataset()
+        return filter_dataset(data, lang, category, start_date, end_date)
+
+
+schema = graphene.Schema(query=Query)
+
+
+@app.post("/graphql")
+async def graphql_endpoint(request: Request):
+    body = await request.json()
+    result = schema.execute(body.get("query"), variable_values=body.get("variables"))
+    return JSONResponse(result.data)

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,19 +1,27 @@
 import json
+import os
 from pathlib import Path
 
 import streamlit as st
 import psutil
+import requests
 
 PROGRESS_FILE = Path("logs/progress.json")
+API_BASE = os.environ.get("API_BASE", "http://localhost:8000")
 
 
 def load_progress():
-    if PROGRESS_FILE.exists():
-        try:
-            with PROGRESS_FILE.open() as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return {}
+    try:
+        resp = requests.get(f"{API_BASE}/stats", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        if PROGRESS_FILE.exists():
+            try:
+                with PROGRESS_FILE.open() as f:
+                    return json.load(f)
+            except json.JSONDecodeError:
+                return {}
     return {}
 
 


### PR DESCRIPTION
## Summary
- expose progress and dataset querying endpoints
- add simple GraphQL API with graphene
- connect dashboard to the new stats endpoint
- document API examples in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854922708748320b8a5a1b97d811232