### PR TITLE
Add dataset training pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,33 @@ Um `Dockerfile.worker` está disponível para criar a imagem do worker e a pasta
 contém o exemplo `cluster.yaml` para configuração de múltiplos nós com Dask ou
 Ray. Em ambientes Kubernetes, basta criar um `Deployment` apontando para essa
 imagem e montar o arquivo de configuração se necessário.
+
+## Integração com frameworks de ML
+
+Os arquivos gerados em `training/` permitem treinar modelos de NLP de forma simples. A seguir alguns exemplos.
+
+### Usando Transformers (PyTorch)
+
+```python
+from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+import json, torch
+
+pairs = json.load(open('datasets_wikipedia_pro/wikipedia_qa_pairs.json'))
+model = AutoModelForSeq2SeqLM.from_pretrained('t5-small')
+tokenizer = AutoTokenizer.from_pretrained('t5-small')
+inputs = tokenizer(pairs[0]['question'], return_tensors='pt')
+with torch.no_grad():
+    output = model.generate(**inputs)
+print(tokenizer.decode(output[0], skip_special_tokens=True))
+```
+
+### Carregando embeddings com TensorFlow
+
+```python
+import json
+import tensorflow as tf
+
+emb = json.load(open('datasets_wikipedia_pro/wikipedia_qa_embeddings.json'))
+emb_tensor = tf.constant([e['embedding'] for e in emb])
+print(emb_tensor.shape)
+```

--- a/cli.py
+++ b/cli.py
@@ -45,11 +45,17 @@ def scrape(
     fmt: str = typer.Option("all", "--format", help="Formato de saída"),
     rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
     plugin: str = typer.Option("wikipedia", "--plugin", help="Plugin de scraping"),
+    train: bool = typer.Option(False, "--train", help="Executa conversões para treinamento"),
 ):
     """Executa o scraper imediatamente."""
     cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
     if plugin == "wikipedia":
         scraper_wiki.main(lang, cats, fmt, rate_limit_delay)
+        if train:
+            from training import pipeline
+            dataset_file = Path(scraper_wiki.Config.OUTPUT_DIR) / "wikipedia_qa.json"
+            if dataset_file.exists():
+                pipeline.run_pipeline(dataset_file)
     else:
         from plugins import load_plugin, run_plugin
 

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,0 +1,1 @@
+from .pipeline import run_pipeline

--- a/training/pipeline.py
+++ b/training/pipeline.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+
+def load_dataset(path: str | Path) -> List[Dict]:
+    """Load dataset from JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(data, path: str | Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def convert_to_conversation_pairs(records: List[Dict]) -> List[Dict]:
+    """Return conversation pairs from dataset."""
+    pairs = []
+    for rec in records:
+        qs = rec.get("questions", [])
+        ans = rec.get("answers", [])
+        for q, a in zip(qs, ans):
+            q_text = q["text"] if isinstance(q, dict) else q
+            a_text = a["text"] if isinstance(a, dict) else a
+            pairs.append({"question": q_text, "answer": a_text})
+    return pairs
+
+
+def convert_to_embeddings(records: List[Dict]) -> List[Dict]:
+    """Extract embeddings from dataset."""
+    emb = []
+    for rec in records:
+        emb.append({
+            "id": rec.get("id"),
+            "embedding": rec.get("content_embedding")
+        })
+    return emb
+
+
+def convert_to_triples(records: List[Dict]) -> List[Dict]:
+    """Generate knowledge triples using keywords."""
+    triples = []
+    for rec in records:
+        subj = rec.get("title")
+        for kw in rec.get("keywords", []):
+            triples.append({"subject": subj, "relation": "related_to", "object": kw})
+    return triples
+
+
+def run_pipeline(dataset_path: str | Path) -> None:
+    """Run full conversion pipeline for training."""
+    dataset_path = Path(dataset_path)
+    records = load_dataset(dataset_path)
+    base = dataset_path.with_suffix("")
+
+    pairs = convert_to_conversation_pairs(records)
+    save_json(pairs, base.with_name(base.name + "_pairs.json"))
+
+    emb = convert_to_embeddings(records)
+    save_json(emb, base.with_name(base.name + "_embeddings.json"))
+
+    triples = convert_to_triples(records)
+    save_json(triples, base.with_name(base.name + "_triples.json"))


### PR DESCRIPTION
## Summary
- create `training` package with a conversion pipeline
- allow running this pipeline from the `scrape` command
- show ML framework integration examples in the README
- test CLI `--train` option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854948379ec8320b0e6e470d458ecee