### PR TITLE
Refactor HTTP fetching with aiohttp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ unidecode>=1.4.0
 datasets>=3.6.0
 beautifulsoup4>=4.13.4
 requests>=2.32.4
+aiohttp>=3.9
 html2text>=2025.4.15
 backoff>=2.2.1
 numpy>=2.3.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,13 @@ wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
 wiki_mod.WikipediaPage = object
 wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
 sys.modules.setdefault('wikipediaapi', wiki_mod)
-sys.modules.setdefault('aiohttp', SimpleNamespace(ClientSession=object))
+aiohttp_stub = SimpleNamespace(
+    ClientSession=object,
+    ClientTimeout=lambda *a, **k: None,
+    ClientError=Exception,
+    ClientResponseError=Exception,
+)
+sys.modules.setdefault('aiohttp', aiohttp_stub)
 sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
 
 sklearn_mod = ModuleType('sklearn')


### PR DESCRIPTION
## Summary
- add `aiohttp>=3.9` dependency
- implement async helper `fetch_with_retry` using `aiohttp` with 10s timeout
- rewrite `fetch_html_content` and `search_category` around new async helper
- simplify `fetch_html_content_async`
- adjust tests for new async behaviour and stub `aiohttp`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549d7a19848320983455d0fde44b28