### PR TITLE
Add simple Click CLI for HTML fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Também é possível enfileirar execuções futuras:
 python cli.py queue --lang en --category "Algorithms"
 ```
 
+### Obter HTML de uma única página
+
+Use o script `click_cli.py` para baixar o HTML bruto de uma página específica da Wikipédia. O formato de saída é definido pela extensão do arquivo informada (`.json` ou `.csv`).
+
+```bash
+python click_cli.py --url https://en.wikipedia.org/wiki/Python_(programming_language) --output page.json
+```
+
 ### Normalização de categorias e busca automática
 
 Os nomes de categoria passam por um processo de normalização que remove

--- a/click_cli.py
+++ b/click_cli.py
@@ -1,0 +1,44 @@
+import asyncio
+import json
+import csv
+from pathlib import Path
+from urllib.parse import urlparse, unquote
+
+import click
+
+import scraper_wiki
+
+
+def _parse_wiki_url(url: str) -> tuple[str, str]:
+    """Return (title, lang) extracted from a Wikipedia URL."""
+    parsed = urlparse(url)
+    lang = parsed.hostname.split('.')[0]
+    title = parsed.path.split('/wiki/')[-1]
+    return unquote(title), lang
+
+
+@click.command()
+@click.option('--url', required=True, help='URL completo da página da Wikipédia')
+@click.option('--output', required=True, type=click.Path(), help='Arquivo de saída (.json ou .csv)')
+def main(url: str, output: str) -> None:
+    """Baixa o HTML de uma página da Wikipédia e salva em JSON ou CSV."""
+    title, lang = _parse_wiki_url(url)
+    html = asyncio.run(scraper_wiki.fetch_html_content_async(title, lang))
+
+    path = Path(output)
+    if path.suffix.lower() == '.json':
+        data = {'url': url, 'html': html}
+        path.write_text(json.dumps(data, ensure_ascii=False), encoding='utf-8')
+    elif path.suffix.lower() == '.csv':
+        with path.open('w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow(['url', 'html'])
+            writer.writerow([url, html])
+    else:
+        click.echo('Formato não suportado. Use extensão .json ou .csv.', err=True)
+        raise SystemExit(1)
+    click.echo(f'Arquivo salvo em {path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `click_cli.py` to download raw HTML from a Wikipedia page
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a1103d908320b54ca1f6a41be32f