### PR TITLE
Implement SQLite infobox storage

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -51,6 +51,7 @@ import sqlite3
 import storage
 import dq
 import metrics
+import storage_sqlite
 
 # ============================
 # 🔧 Configurações Avançadas
@@ -1069,8 +1070,8 @@ class DatasetBuilder:
         
         # Classificação avançada de tópicos
         topic, subtopic = self._classify_topic(title, content, lang)
-        
-        return {
+
+        record = {
             'id': hashlib.md5(f"{title}_{lang}".encode('utf-8')).hexdigest(),
             'title': title,
             'language': lang,
@@ -1091,6 +1092,11 @@ class DatasetBuilder:
                 'source_url': f"https://{lang}.wikipedia.org/wiki/{title.replace(' ', '_')}"
             }
         }
+        try:
+            storage_sqlite.save_to_db({'id': record['id'], 'metadata': record.get('metadata', {})})
+        except Exception as e:
+            logger.error(f"Erro ao salvar no SQLite: {e}")
+        return record
     
     def _generate_questions(self, title: str, content: str, lang: str, keywords: List[str]) -> List[dict]:
         questions = []

--- a/storage_sqlite.py
+++ b/storage_sqlite.py
@@ -1,0 +1,22 @@
+import os
+import json
+import sqlite3
+
+
+def save_to_db(data: dict, table: str = "infoboxes", db_path: str = "infoboxes.sqlite") -> None:
+    """Save a dictionary as a JSON blob in the given SQLite table."""
+    dir_name = os.path.dirname(db_path)
+    if dir_name:
+        os.makedirs(dir_name, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {table} (id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT)"
+        )
+        conn.execute(
+            f"INSERT INTO {table} (data) VALUES (?)",
+            (json.dumps(data, ensure_ascii=False),),
+        )
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -1,0 +1,14 @@
+import json
+import sqlite3
+from storage_sqlite import save_to_db
+
+
+def test_save_to_db_creates_table_and_inserts(tmp_path):
+    db_file = tmp_path / "test.sqlite"
+    data = {"a": 1}
+    save_to_db(data, table="info", db_path=str(db_file))
+    conn = sqlite3.connect(db_file)
+    row = conn.execute("SELECT data FROM info").fetchone()
+    conn.close()
+    assert row is not None
+    assert json.loads(row[0]) == data


### PR DESCRIPTION
## Summary
- add `save_to_db` helper for sqlite JSON blobs
- store page metadata from `DatasetBuilder` in SQLite
- test sqlite helper creating a temporary DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a757157883208a51eb9a0e110937