### PR TITLE
Add tests for text utility functions

### DIFF
--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -1,43 +1,56 @@
 import importlib
 import sys
 from types import SimpleNamespace
-
-# ensure repo root on path
 from pathlib import Path
+
+# Ensure repository root is on sys.path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+
 class DummyEnt:
-    def __init__(self, text, label):
+    def __init__(self, text: str, label: str) -> None:
         self.text = text
         self.label_ = label
 
+
 class DummyDoc:
-    def __init__(self):
-        self.ents = [DummyEnt('Python', 'ORG'), DummyEnt('Guido', 'PERSON')]
+    def __init__(self) -> None:
+        self.ents = [DummyEnt("Python", "ORG"), DummyEnt("Guido", "PERSON")]
+
 
 class DummyNLP:
-    def __call__(self, text):
+    def __call__(self, text: str):
         return DummyDoc()
 
-sys.modules['spacy'] = SimpleNamespace(load=lambda *a, **k: DummyNLP())
-text_mod = importlib.import_module('utils.text')
-sys.modules['spacy'] = SimpleNamespace(load=lambda *a, **k: None)
+
+# Load utils.text with spaCy mocked so that importing does not require the real package
+sys.modules["spacy"] = SimpleNamespace(load=lambda *a, **k: DummyNLP())
+text_mod = importlib.import_module("utils.text")
+# After importing, replace spacy with a no-op to avoid accidental use
+sys.modules["spacy"] = SimpleNamespace(load=lambda *a, **k: None)
 
 
-def test_clean_text_basic():
-    assert text_mod.clean_text('A [1]\nB  C') == 'A B C'
+def test_clean_text_removes_refs_and_spaces():
+    raw = "Example [1] text  with\n  extra spaces [23]"
+    assert text_mod.clean_text(raw) == "Example text with extra spaces"
 
 
-def test_normalize_person():
-    data = {'name': 'Guido', 'birth_date': '1956', 'occupation': 'Programmer|BDFL'}
+def test_normalize_person_extracts_fields():
+    data = {"name": "Guido", "birth_date": "1956", "occupation": "Programmer|BDFL"}
     result = text_mod.normalize_person(data)
-    assert result['name'] == 'Guido'
-    assert result['occupation'] == ['Programmer', 'BDFL']
+    assert result == {
+        "name": "Guido",
+        "birth_date": "1956",
+        "occupation": ["Programmer", "BDFL"],
+    }
 
 
-def test_extract_entities(monkeypatch):
-    monkeypatch.setattr(text_mod, 'nlp', DummyNLP())
-    ents = text_mod.extract_entities('Any text')
-    assert {'text': 'Python', 'type': 'ORG'} in ents
-    assert {'text': 'Guido', 'type': 'PERSON'} in ents
+def test_extract_entities_returns_entities(monkeypatch):
+    monkeypatch.setattr(text_mod, "nlp", DummyNLP())
+    ents = text_mod.extract_entities("Any text")
+    assert ents == [
+        {"text": "Python", "type": "ORG"},
+        {"text": "Guido", "type": "PERSON"},
+    ]
+


### PR DESCRIPTION
## Summary
- add coverage for cleaning text, normalizing a person and extracting entities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854acda7194832089401728cdfca3b1