### PR TITLE
Add infobox and table parsing plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ O pacote `utils.text` oferece funções auxiliares:
 - `normalize_person` simplifica infoboxes de pessoas;
 - `extract_entities` usa spaCy para listar entidades nomeadas.
 
+### Sistema de Plugins
+
+Os plugins permitem estender o scraper com novos analisadores. Em
+`plugins/` foram adicionados `infobox_parser` e `table_parser`, que
+extraem respectivamente infoboxes e tabelas das páginas da Wikipédia.
+Use `--plugin` ou o campo `plugin` na API para escolher qual utilizar.
+
 ## Limpeza e NLP
 
 Estas funções podem ser utilizadas isoladamente ou combinadas com o

--- a/api_app.py
+++ b/api_app.py
@@ -64,7 +64,7 @@ class ScrapeParams(BaseModel):
     lang: Optional[List[str]] | Optional[str] = None
     category: Optional[List[str]] | Optional[str] = None
     format: str = "all"
-    plugin: str = "wikipedia"
+    plugin: str = "wikipedia"  # e.g. "infobox_parser" or "table_parser"
 
 @app.post("/scrape")
 async def scrape(params: ScrapeParams):

--- a/cli.py
+++ b/cli.py
@@ -46,7 +46,11 @@ def scrape(
     category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
     fmt: str = typer.Option("all", "--format", help="Formato de saída"),
     rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
-    plugin: str = typer.Option("wikipedia", "--plugin", help="Plugin de scraping"),
+    plugin: str = typer.Option(
+        "wikipedia",
+        "--plugin",
+        help="Plugin de scraping (wikipedia, infobox_parser, table_parser)",
+    ),
     train: bool = typer.Option(False, "--train", help="Executa conversões para treinamento"),
 ):
     """Executa o scraper imediatamente."""

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,13 +1,23 @@
-"""Plugin utilities."""
+"""Plugin utilities and registry."""
 import importlib
 from typing import List
 from core.builder import DatasetBuilder
 from .base import Plugin
 
+# Mapping of available plugin names to module paths
+AVAILABLE_PLUGINS = {
+    "wikipedia": "wikipedia",
+    "wikidata": "wikidata",
+    "stackoverflow": "stackoverflow",
+    "infobox_parser": "infobox_parser",
+    "table_parser": "table_parser",
+}
+
 
 def load_plugin(name: str) -> Plugin:
-    """Load a plugin by its module name."""
-    module = importlib.import_module(f"plugins.{name}")
+    """Load a plugin by its registry name."""
+    module_name = AVAILABLE_PLUGINS.get(name, name)
+    module = importlib.import_module(f"plugins.{module_name}")
     plugin_cls = getattr(module, "Plugin")
     return plugin_cls()
 
@@ -24,3 +34,5 @@ def run_plugin(plugin: Plugin, langs: List[str], categories: List[str], fmt: str
                     builder.dataset.append(result)
     builder.save_dataset(fmt)
     return builder.dataset
+
+__all__ = ["load_plugin", "run_plugin", "AVAILABLE_PLUGINS"]

--- a/plugins/infobox_parser.py
+++ b/plugins/infobox_parser.py
@@ -1,0 +1,35 @@
+"""Plugin to extract infobox data from Wikipedia pages."""
+from typing import List, Dict
+
+from bs4 import BeautifulSoup
+
+from core import WikipediaAdvanced
+from scraper_wiki import fetch_html_content
+
+from .base import Plugin
+
+
+class Plugin(Plugin):  # type: ignore[misc]
+    """Extract infobox information."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        wiki = WikipediaAdvanced(lang)
+        return wiki.get_category_members(category)
+
+    def parse_item(self, item: Dict) -> Dict:
+        html = fetch_html_content(item["title"], item.get("lang", "en"))
+        if not html:
+            return {}
+        soup = BeautifulSoup(html, "html.parser")
+        box = soup.find("table", class_=lambda c: c and "infobox" in c)
+        if not box:
+            return {}
+        data: Dict[str, str] = {}
+        for row in box.find_all("tr"):
+            header = row.find("th")
+            value = row.find("td")
+            if header and value:
+                key = header.get_text(strip=True)
+                val = value.get_text(strip=True)
+                data[key] = val
+        return {"title": item["title"], "language": item.get("lang", "en"), "infobox": data}

--- a/plugins/table_parser.py
+++ b/plugins/table_parser.py
@@ -1,0 +1,35 @@
+"""Plugin to extract table data from Wikipedia pages."""
+from typing import List, Dict
+
+from bs4 import BeautifulSoup
+
+from core import WikipediaAdvanced
+from scraper_wiki import fetch_html_content
+
+from .base import Plugin
+
+
+class Plugin(Plugin):  # type: ignore[misc]
+    """Parse all HTML tables on a page."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        wiki = WikipediaAdvanced(lang)
+        return wiki.get_category_members(category)
+
+    def parse_item(self, item: Dict) -> Dict:
+        html = fetch_html_content(item["title"], item.get("lang", "en"))
+        if not html:
+            return {}
+        soup = BeautifulSoup(html, "html.parser")
+        tables: List[List[List[str]]] = []
+        for table in soup.find_all("table"):
+            rows: List[List[str]] = []
+            for tr in table.find_all("tr"):
+                cells = [c.get_text(strip=True) for c in tr.find_all(["th", "td"])]
+                if cells:
+                    rows.append(cells)
+            if rows:
+                tables.append(rows)
+        if not tables:
+            return {}
+        return {"title": item["title"], "language": item.get("lang", "en"), "tables": tables}

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -1506,7 +1506,12 @@ def main(langs: Optional[List[str]] = None,
     try:
         from plugins import load_plugin
 
-        for plugin_name in ["stackoverflow", "wikidata"]:
+        for plugin_name in [
+            "stackoverflow",
+            "wikidata",
+            "infobox_parser",
+            "table_parser",
+        ]:
             try:
                 plugin = load_plugin(plugin_name)
             except Exception as e:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import scraper_wiki as sw
+import core
+
+class DummyWiki:
+    def __init__(self, lang: str) -> None:
+        self.lang = lang
+    def get_category_members(self, category: str):
+        return [{"title": "Page", "lang": self.lang, "category": category}]
+
+
+def test_infobox_parser(monkeypatch):
+    monkeypatch.setattr(core, "WikipediaAdvanced", DummyWiki)
+    html = '<table class="infobox"><tr><th>Name</th><td>Python</td></tr></table>'
+    monkeypatch.setattr(sw, "fetch_html_content", lambda title, lang: html)
+    mod = importlib.reload(importlib.import_module("plugins.infobox_parser"))
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "Prog")
+    assert items == [{"title": "Page", "lang": "en", "category": "Prog"}]
+    parsed = plugin.parse_item(items[0])
+    assert parsed == {"title": "Page", "language": "en", "infobox": {"Name": "Python"}}
+
+
+def test_table_parser(monkeypatch):
+    monkeypatch.setattr(core, "WikipediaAdvanced", DummyWiki)
+    html = '<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>'
+    monkeypatch.setattr(sw, "fetch_html_content", lambda title, lang: html)
+    mod = importlib.reload(importlib.import_module("plugins.table_parser"))
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "Prog")
+    assert items[0]["title"] == "Page"
+    parsed = plugin.parse_item(items[0])
+    assert parsed == {
+        "title": "Page",
+        "language": "en",
+        "tables": [[["A", "B"], ["1", "2"]]],
+    }
+


### PR DESCRIPTION
## Summary
- add plugins for parsing infoboxes and tables
- expose new plugins in plugin registry
- allow selecting them via CLI and API
- integrate plugins when building dataset
- document plugin system
- test new plugins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b4e43a58832092c1b3da8dff76d8