### PR TITLE
Add batch-capable CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,17 @@ Também é possível enfileirar execuções futuras:
 python cli.py queue --lang en --category "Algorithms"
 ```
 
-### Obter HTML de uma única página
+### Obter HTML de uma ou mais páginas
 
-Use o script `click_cli.py` para baixar o HTML bruto de uma página específica da Wikipédia. O formato de saída é definido pela extensão do arquivo informada (`.json` ou `.csv`).
+O script `main.py` fornece uma interface avançada baseada em **Click**. Ele
+permite escolher o formato de saída (`json`, `csv` ou `parquet`) e também ler
+uma lista de URLs de um arquivo para processamento em lote.
 
 ```bash
-python click_cli.py --url https://en.wikipedia.org/wiki/Python_(programming_language) --output page.json
+python main.py --url "https://en.wikipedia.org/wiki/Python" --output csv
+
+# Para modo batch
+python main.py --file urls.txt --output parquet
 ```
 
 ### Normalização de categorias e busca automática

--- a/main.py
+++ b/main.py
@@ -1,0 +1,81 @@
+import asyncio
+import csv
+import json
+from pathlib import Path
+from urllib.parse import urlparse, unquote
+
+import click
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import scraper_wiki
+
+
+def _parse_wiki_url(url: str) -> tuple[str, str]:
+    """Return (title, lang) extracted from a Wikipedia URL."""
+    parsed = urlparse(url)
+    lang = parsed.hostname.split('.')[0]
+    title = parsed.path.split('/wiki/')[-1]
+    return unquote(title), lang
+
+
+@click.command()
+@click.option("--url", help="URL de uma página da Wikipédia")
+@click.option(
+    "--file",
+    "urls_file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Arquivo com URLs, um por linha",
+)
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["json", "csv", "parquet"], case_sensitive=False),
+    default="json",
+    show_default=True,
+    help="Formato de saída",
+)
+@click.option(
+    "--out-dir",
+    type=click.Path(file_okay=False),
+    default=".",
+    show_default=True,
+    help="Diretório para salvar o resultado",
+)
+def main(url: str | None, urls_file: str | None, output_format: str, out_dir: str) -> None:
+    """Baixa o HTML de páginas da Wikipédia e salva em formatos variados."""
+    if not url and not urls_file:
+        raise click.UsageError("Informe --url ou --file")
+
+    urls = []
+    if url:
+        urls.append(url)
+    if urls_file:
+        urls.extend([u.strip() for u in Path(urls_file).read_text().splitlines() if u.strip()])
+
+    records = []
+    for u in urls:
+        title, lang = _parse_wiki_url(u)
+        html = asyncio.run(scraper_wiki.fetch_html_content_async(title, lang))
+        records.append({"url": u, "html": html})
+
+    out_dir_path = Path(out_dir)
+    out_dir_path.mkdir(parents=True, exist_ok=True)
+
+    out_path = out_dir_path / f"output.{output_format.lower()}"
+    if output_format.lower() == "json":
+        out_path.write_text(json.dumps(records, ensure_ascii=False), encoding="utf-8")
+    elif output_format.lower() == "csv":
+        with out_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=["url", "html"])
+            writer.writeheader()
+            writer.writerows(records)
+    else:  # parquet
+        table = pa.Table.from_pylist(records)
+        pq.write_table(table, out_path)
+
+    click.echo(f"Arquivo salvo em {out_path} ({len(records)} página(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,111 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy dependencies
+sys.modules.setdefault('sentence_transformers', SimpleNamespace(SentenceTransformer=object))
+sys.modules.setdefault('datasets', SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None))
+sys.modules.setdefault('spacy', SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault('unidecode', SimpleNamespace(unidecode=lambda x: x))
+sys.modules.setdefault('tqdm', SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault('html2text', SimpleNamespace())
+wiki_mod = ModuleType('wikipediaapi')
+wiki_mod.WikipediaException = Exception
+wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
+wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
+wiki_mod.WikipediaPage = object
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
+sys.modules.setdefault('wikipediaapi', wiki_mod)
+aiohttp_stub = SimpleNamespace(
+    ClientSession=object,
+    ClientTimeout=lambda *a, **k: None,
+    ClientError=Exception,
+    ClientResponseError=Exception,
+)
+sys.modules.setdefault('aiohttp', aiohttp_stub)
+sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
+
+sk_mod = ModuleType('sklearn')
+sk_mod.cluster = SimpleNamespace(KMeans=object)
+sk_mod.feature_extraction = SimpleNamespace(text=SimpleNamespace(TfidfVectorizer=object))
+sys.modules.setdefault('sklearn', sk_mod)
+sys.modules.setdefault('sklearn.cluster', sk_mod.cluster)
+sys.modules.setdefault('sklearn.feature_extraction', sk_mod.feature_extraction)
+sys.modules.setdefault('sklearn.feature_extraction.text', sk_mod.feature_extraction.text)
+
+sumy_mod = ModuleType('sumy')
+parsers_mod = ModuleType('sumy.parsers')
+plaintext_mod = ModuleType('sumy.parsers.plaintext')
+plaintext_mod.PlaintextParser = object
+parsers_mod.plaintext = plaintext_mod
+nlp_mod = ModuleType('sumy.nlp')
+tokenizers_mod = ModuleType('sumy.nlp.tokenizers')
+tokenizers_mod.Tokenizer = object
+nlp_mod.tokenizers = tokenizers_mod
+summarizers_mod = ModuleType('sumy.summarizers')
+lsa_mod = ModuleType('sumy.summarizers.lsa')
+lsa_mod.LsaSummarizer = object
+summarizers_mod.lsa = lsa_mod
+sumy_mod.parsers = parsers_mod
+sumy_mod.nlp = nlp_mod
+sumy_mod.summarizers = summarizers_mod
+sys.modules.setdefault('sumy', sumy_mod)
+sys.modules.setdefault('sumy.parsers', parsers_mod)
+sys.modules.setdefault('sumy.parsers.plaintext', plaintext_mod)
+sys.modules.setdefault('sumy.nlp', nlp_mod)
+sys.modules.setdefault('sumy.nlp.tokenizers', tokenizers_mod)
+sys.modules.setdefault('sumy.summarizers', summarizers_mod)
+sys.modules.setdefault('sumy.summarizers.lsa', lsa_mod)
+sys.modules.setdefault('streamlit', SimpleNamespace())
+sys.modules.setdefault('psutil', SimpleNamespace(cpu_percent=lambda interval=1: 0, virtual_memory=lambda: SimpleNamespace(percent=0)))
+
+import main
+from click.testing import CliRunner
+
+
+def test_single_url_csv(tmp_path, monkeypatch):
+    async def fake_fetch(title, lang):
+        return f"<html>{title}-{lang}</html>"
+
+    monkeypatch.setattr(main.scraper_wiki, "fetch_html_content_async", fake_fetch)
+    out_dir = tmp_path
+    runner = CliRunner()
+    result = runner.invoke(main.main, [
+        "--url", "https://en.wikipedia.org/wiki/Python",
+        "--output", "csv",
+        "--out-dir", str(out_dir),
+    ])
+    assert result.exit_code == 0
+    out_file = out_dir / "output.csv"
+    assert out_file.exists()
+    content = out_file.read_text(encoding="utf-8")
+    assert "https://en.wikipedia.org/wiki/Python" in content
+
+
+def test_batch_file_json(tmp_path, monkeypatch):
+    urls_file = tmp_path / "urls.txt"
+    urls_file.write_text(
+        "https://en.wikipedia.org/wiki/Python\nhttps://pt.wikipedia.org/wiki/Programacao"
+    )
+
+    async def fake_fetch(title, lang):
+        return f"<html>{title}-{lang}</html>"
+
+    monkeypatch.setattr(main.scraper_wiki, "fetch_html_content_async", fake_fetch)
+
+    runner = CliRunner()
+    result = runner.invoke(main.main, [
+        "--file", str(urls_file),
+        "--output", "json",
+        "--out-dir", str(tmp_path),
+    ])
+    assert result.exit_code == 0
+    out_file = tmp_path / "output.json"
+    assert out_file.exists()
+    data = json.loads(out_file.read_text(encoding="utf-8"))
+    assert len(data) == 2
+


### PR DESCRIPTION
## Summary
- implement `main.py` with Click
- add batch mode and support for json/csv/parquet
- document advanced CLI usage in README
- test the new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854bbf206a4832081d3fad061218d4f