### PR TITLE
Add utilities for infobox normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ O pacote `utils.text` oferece funções auxiliares:
 - `clean_text` remove referências numéricas e espaços extras;
 - `normalize_person` simplifica infoboxes de pessoas;
 - `extract_entities` usa spaCy para listar entidades nomeadas.
+- `parse_date` converte datas para o formato ISO 8601;
+- `normalize_infobox` padroniza chaves e valores de infoboxes.
 
 ### Sistema de Plugins
 
@@ -125,7 +127,13 @@ Estas funções podem ser utilizadas isoladamente ou combinadas com o
 informações estruturadas.
 
 ```python
-from utils.text import clean_text, normalize_person, extract_entities
+from utils.text import (
+    clean_text,
+    normalize_person,
+    normalize_infobox,
+    parse_date,
+    extract_entities,
+)
 from scraper_wiki import DatasetBuilder
 
 # Processando uma página manualmente
@@ -136,6 +144,8 @@ record = builder.process_page({"title": "Guido van Rossum", "lang": "en"})
 cleaned = clean_text(record["content"])
 entities = extract_entities(cleaned)
 person = normalize_person({"name": record["title"], "occupation": "Programmer|BDFL"})
+normalized = normalize_infobox({"title": record["title"], "date": "Jan 1, 1990"})
+iso_date = parse_date("1 January 1990")
 ```
 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ sentence-transformers>=4.1.0
 scikit-learn>=1.7.0
 sumy>=0.11.0
 pyarrow>=20.0.0
+python-dateutil>=2.9.0
 fastapi>=0.115.13
 uvicorn>=0.34.3
 

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -54,3 +54,14 @@ def test_extract_entities_returns_entities(monkeypatch):
         {"text": "Guido", "type": "PERSON"},
     ]
 
+
+def test_parse_date_iso():
+    assert text_mod.parse_date("January 1, 2020") == "2020-01-01"
+
+
+def test_normalize_infobox_converts_dates(monkeypatch):
+    monkeypatch.setattr(text_mod, "parse_date", lambda v: "2020-01-01")
+    info = {"title": "Page", "date": "1 Jan 2020", "other": "x"}
+    out = text_mod.normalize_infobox(info)
+    assert out == {"title": "Page", "date": "2020-01-01", "other": "x"}
+


### PR DESCRIPTION
## Summary
- add `parse_date` and `normalize_infobox` utilities
- document the new helpers in README
- require `python-dateutil`
- test infobox normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854be5cbe908320825b2bcca3d63fbb