### PR TITLE
Add HTML extraction helpers and tests

### DIFF
--- a/plugins/infobox_parser.py
+++ b/plugins/infobox_parser.py
@@ -4,7 +4,7 @@ from typing import List, Dict
 from bs4 import BeautifulSoup
 
 from core import WikipediaAdvanced
-from scraper_wiki import fetch_html_content
+from scraper_wiki import fetch_html_content, extract_infobox
 
 from .base import Plugin
 
@@ -20,16 +20,11 @@ class Plugin(Plugin):  # type: ignore[misc]
         html = fetch_html_content(item["title"], item.get("lang", "en"))
         if not html:
             return {}
-        soup = BeautifulSoup(html, "html.parser")
-        box = soup.find("table", class_=lambda c: c and "infobox" in c)
-        if not box:
+        data = extract_infobox(html)
+        if not data:
             return {}
-        data: Dict[str, str] = {}
-        for row in box.find_all("tr"):
-            header = row.find("th")
-            value = row.find("td")
-            if header and value:
-                key = header.get_text(strip=True)
-                val = value.get_text(strip=True)
-                data[key] = val
-        return {"title": item["title"], "language": item.get("lang", "en"), "infobox": data}
+        return {
+            "title": item["title"],
+            "language": item.get("lang", "en"),
+            "infobox": data,
+        }

--- a/plugins/table_parser.py
+++ b/plugins/table_parser.py
@@ -4,7 +4,7 @@ from typing import List, Dict
 from bs4 import BeautifulSoup
 
 from core import WikipediaAdvanced
-from scraper_wiki import fetch_html_content
+from scraper_wiki import fetch_html_content, extract_tables
 
 from .base import Plugin
 
@@ -20,16 +20,11 @@ class Plugin(Plugin):  # type: ignore[misc]
         html = fetch_html_content(item["title"], item.get("lang", "en"))
         if not html:
             return {}
-        soup = BeautifulSoup(html, "html.parser")
-        tables: List[List[List[str]]] = []
-        for table in soup.find_all("table"):
-            rows: List[List[str]] = []
-            for tr in table.find_all("tr"):
-                cells = [c.get_text(strip=True) for c in tr.find_all(["th", "td"])]
-                if cells:
-                    rows.append(cells)
-            if rows:
-                tables.append(rows)
+        tables = extract_tables(html)
         if not tables:
             return {}
-        return {"title": item["title"], "language": item.get("lang", "en"), "tables": tables}
+        return {
+            "title": item["title"],
+            "language": item.get("lang", "en"),
+            "tables": tables,
+        }

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -691,6 +691,46 @@ def extract_links(html: str, base_url: str) -> List[str]:
         return []
 
 
+def extract_infobox(html: str) -> Dict[str, str]:
+    """Return a dictionary with key/value pairs from the first infobox table."""
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+        box = soup.find("table", class_=lambda c: c and "infobox" in c)
+        if not box:
+            return {}
+        data: Dict[str, str] = {}
+        for row in box.find_all("tr"):
+            header = row.find("th")
+            value = row.find("td")
+            if header and value:
+                key = header.get_text(strip=True)
+                val = value.get_text(strip=True)
+                data[key] = val
+        return data
+    except Exception as e:
+        logger.error(f"Erro ao extrair infobox: {e}")
+        return {}
+
+
+def extract_tables(html: str) -> List[List[List[str]]]:
+    """Return all HTML tables as lists of rows and cells."""
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+        tables: List[List[List[str]]] = []
+        for table in soup.find_all("table"):
+            rows: List[List[str]] = []
+            for tr in table.find_all("tr"):
+                cells = [c.get_text(strip=True) for c in tr.find_all(["th", "td"])]
+                if cells:
+                    rows.append(cells)
+            if rows:
+                tables.append(rows)
+        return tables
+    except Exception as e:
+        logger.error(f"Erro ao extrair tabelas: {e}")
+        return []
+
+
 async def fetch_with_retry(
     url: str,
     *,

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import scraper_wiki as sw
+
+
+def test_extract_infobox():
+    html = "<table class='infobox'><tr><th>Name</th><td>Python</td></tr></table>"
+    result = sw.extract_infobox(html)
+    assert result == {"Name": "Python"}
+
+
+def test_extract_infobox_malformed():
+    html = "<table class='infobox'><tr><th>Name</th><td>Python<tr><th>Released</th><td>1991"  # missing closing tags
+    result = sw.extract_infobox(html)
+    assert "Name" in result
+
+
+def test_extract_tables():
+    html = "<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>"
+    tables = sw.extract_tables(html)
+    assert tables == [[['A', 'B'], ['1', '2']]]
+
+
+def test_extract_tables_malformed():
+    html = "<table><tr><th>A<th>B<tr><td>1<td>2"  # unclosed tags
+    tables = sw.extract_tables(html)
+    assert tables != []


### PR DESCRIPTION
## Summary
- add `extract_infobox` and `extract_tables` helpers
- refactor infobox and table parsers to use the helpers
- test extraction functions including malformed HTML cases

## Testing
- `pip install -r requirements.txt` *(fails: operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6854bfb523f083209057256984f98958