### PR TITLE
Enable async scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Controle o número de threads e processos utilizados pelo scraper com as opçõe
 `--max-threads` e `--max-processes`. Esses valores também podem ser definidos
 pelas variáveis de ambiente `MAX_THREADS` e `MAX_PROCESSES`.
 
+Para acelerar a coleta também é possível ativar o modo assíncrono com `--async`,
+que realiza múltiplas requisições HTTP em paralelo respeitando o limite definido
+por `MAX_CONCURRENT_REQUESTS`.
+
 ### URLs base personalizadas
 
 O módulo `scraper_wiki.py` define o dicionário `BASE_URLS` com os domínios

--- a/cli.py
+++ b/cli.py
@@ -46,6 +46,7 @@ def scrape(
     category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
     fmt: str = typer.Option("all", "--format", help="Formato de saída"),
     rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
+    async_mode: bool = typer.Option(False, "--async", help="Usa scraping assíncrono", is_flag=True),
     plugin: str = typer.Option(
         "wikipedia",
         "--plugin",
@@ -56,7 +57,11 @@ def scrape(
     """Executa o scraper imediatamente."""
     cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
     if plugin == "wikipedia":
-        scraper_wiki.main(lang, cats, fmt, rate_limit_delay)
+        if async_mode:
+            import asyncio
+            asyncio.run(scraper_wiki.main_async(lang, cats, fmt, rate_limit_delay))
+        else:
+            scraper_wiki.main(lang, cats, fmt, rate_limit_delay)
         dataset_file = Path(scraper_wiki.Config.OUTPUT_DIR) / "wikipedia_qa.json"
         if dataset_file.exists():
             data = json.loads(dataset_file.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add Config.MAX_CONCURRENT_REQUESTS setting
- implement WikipediaAdvanced.get_category_members_async
- support async dataset build via new `main_async`
- expose `--async` flag in CLI
- document async mode in README
- test async path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854c419483c8320975edcf99c6fb5f2