### PR TITLE
Add JSONL output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Utilize o script `cli.py` para interagir com o scraper. Para executar uma coleta
 ```bash
 python cli.py scrape --lang pt --category "Programação" --format json
 ```
+Para gerar um arquivo no formato JSON Lines basta usar `--format jsonl`:
+
+```bash
+python cli.py scrape --lang pt --category "Programação" --format jsonl
+```
 
 É possível repetir `--lang` e `--category` para processar múltiplos valores. Para monitorar o progresso use:
 
@@ -34,7 +39,7 @@ python cli.py queue --lang en --category "Algorithms"
 ### Obter HTML de uma ou mais páginas
 
 O script `main.py` fornece uma interface avançada baseada em **Click**. Ele
-permite escolher o formato de saída (`json`, `csv` ou `parquet`) e também ler
+permite escolher o formato de saída (`json`, `jsonl`, `csv` ou `parquet`) e também ler
 uma lista de URLs de um arquivo para processamento em lote.
 
 ```bash

--- a/storage.py
+++ b/storage.py
@@ -19,6 +19,11 @@ class LocalStorage(StorageBackend):
             json_file = os.path.join(self.output_dir, 'wikipedia_qa.json')
             with open(json_file, 'w', encoding='utf-8') as f:
                 json.dump(data, f, ensure_ascii=False, indent=4)
+        if fmt in ['all', 'jsonl']:
+            jsonl_file = os.path.join(self.output_dir, 'wikipedia_qa.jsonl')
+            with open(jsonl_file, 'w', encoding='utf-8') as f:
+                for row in data:
+                    f.write(json.dumps(row, ensure_ascii=False) + '\n')
         if fmt in ['all', 'csv']:
             csv_file = os.path.join(self.output_dir, 'wikipedia_qa.csv')
             with open(csv_file, 'w', newline='', encoding='utf-8') as f:
@@ -57,6 +62,13 @@ class S3Storage(StorageBackend):
         if fmt in ['all', 'json']:
             body = json.dumps(data, ensure_ascii=False, indent=4).encode('utf-8')
             self.s3.put_object(Bucket=self.bucket, Key=self._key('wikipedia_qa.json'), Body=body)
+        if fmt in ['all', 'jsonl']:
+            lines = '\n'.join(json.dumps(row, ensure_ascii=False) for row in data)
+            self.s3.put_object(
+                Bucket=self.bucket,
+                Key=self._key('wikipedia_qa.jsonl'),
+                Body=lines.encode('utf-8'),
+            )
         if fmt in ['all', 'csv']:
             import io
             buffer = io.StringIO()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,21 @@ def test_queue_command(tmp_path, monkeypatch):
     assert "en" in queue_content and "Programming" in queue_content and "json" in queue_content
 
 
+def test_queue_command_jsonl(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli, "QUEUE_FILE", tmp_path / "queue.jsonl")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["queue", "--lang", "en", "--category", "Programming", "--format", "jsonl"],
+    )
+
+    assert result.exit_code == 0
+    queue_content = (tmp_path / "queue.jsonl").read_text().strip()
+    assert queue_content
+    assert "jsonl" in queue_content
+
+
 def test_scrape_command(monkeypatch):
     called = {}
 

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -379,6 +379,35 @@ def test_save_dataset_json_csv(tmp_path, monkeypatch):
     assert (tmp_path/'wikipedia_qa.csv').exists()
 
 
+def test_save_dataset_jsonl(tmp_path, monkeypatch):
+    builder = sw.DatasetBuilder()
+    monkeypatch.setattr(sw.Config, 'MIN_TEXT_LENGTH', 5)
+    builder.dataset = [{
+        'id': '1',
+        'title': 't',
+        'language': 'en',
+        'category': 'c',
+        'topic': 'ai',
+        'subtopic': 'nlp',
+        'keywords': [],
+        'content': 'c'*20,
+        'summary': 's'*20,
+        'content_embedding': [0.1, 0.2],
+        'summary_embedding': [0.1, 0.2],
+        'questions': ['q'],
+        'answers': ['a'],
+        'created_at': 'now',
+        'metadata': {}
+    }]
+    builder.save_dataset('jsonl', output_dir=tmp_path)
+    jsonl_file = tmp_path / 'wikipedia_qa.jsonl'
+    assert jsonl_file.exists()
+    content = jsonl_file.read_text(encoding='utf-8').strip().splitlines()
+    assert len(content) == 1
+    record = json.loads(content[0])
+    assert record['id'] == '1'
+
+
 def test_normalize_category_alias():
     assert sw.normalize_category('programacao') == 'Programação'
 


### PR DESCRIPTION
## Summary
- support `jsonl` format in local and S3 backends
- update dataset builder tests for jsonl output
- extend CLI queue tests for new format
- document JSON Lines usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c6d41f208320ac97a1cc35c60893