### PR TITLE
Add stopword removal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ O pacote `utils.text` oferece funções auxiliares:
 - `extract_entities` usa spaCy para listar entidades nomeadas.
 - `parse_date` converte datas para o formato ISO 8601;
 - `normalize_infobox` padroniza chaves e valores de infoboxes.
+- `advanced_clean_text` elimina HTML e pode remover stopwords quando
+  `Config.REMOVE_STOPWORDS` (ou variável `REMOVE_STOPWORDS=1`) está ativado.
 
 ### Sistema de Plugins
 


### PR DESCRIPTION
## Summary
- make stopword removal optional via `Config.REMOVE_STOPWORDS`
- support removing stopwords in `advanced_clean_text`
- pass stopword flag in `DatasetBuilder.process_page`
- test stopword removal and updated call sites
- document the new feature and environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c83a2e388320b5f6a120fa957b40