### PR TITLE
Add StackOverflow and Wikidata plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ Os plugins permitem estender o scraper com novos analisadores. Em
 extraem respectivamente infoboxes e tabelas das páginas da Wikipédia.
 Use `--plugin` ou o campo `plugin` na API para escolher qual utilizar.
 
+Exemplo executando o plugin do StackOverflow:
+
+```python
+from plugins import load_plugin, run_plugin
+
+plg = load_plugin("stackoverflow")
+records = run_plugin(plg, ["en"], ["python"])
+```
+
+E para consultar itens da Wikidata:
+
+```python
+plg = load_plugin("wikidata")
+records = run_plugin(plg, ["en"], ["Artificial intelligence"])
+```
+
 ## Limpeza e NLP
 
 Estas funções podem ser utilizadas isoladamente ou combinadas com o

--- a/plugins/stackoverflow.py
+++ b/plugins/stackoverflow.py
@@ -1,13 +1,51 @@
-"""Example StackOverflow plugin."""
+"""StackOverflow scraping plugin."""
+
+from typing import List, Dict
+
+import html2text
+import requests
+
+from scraper_wiki import Config, advanced_clean_text
 from .base import Plugin
 
 
 class Plugin(Plugin):  # type: ignore[misc]
-    def fetch_items(self, lang: str, category: str):
-        # Placeholder implementation
-        return []
+    """Fetch questions from StackOverflow by tag."""
 
-    def parse_item(self, item: dict):
-        # Placeholder implementation
-        return {}
+    def __init__(self, api_key: str | None = None, endpoint: str | None = None) -> None:
+        self.api_key = api_key or Config.STACKOVERFLOW_API_KEY
+        self.endpoint = endpoint or Config.STACKOVERFLOW_API_ENDPOINT.rstrip("/")
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        params = {
+            "site": "stackoverflow",
+            "tagged": category,
+            "pagesize": 10,
+            "order": "desc",
+            "sort": "votes",
+            "filter": "withbody",
+        }
+        if self.api_key:
+            params["key"] = self.api_key
+        resp = requests.get(f"{self.endpoint}/questions", params=params, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        items = data.get("items", [])
+        for it in items:
+            it["lang"] = lang
+            it["category"] = category
+        return items
+
+    def parse_item(self, item: Dict) -> Dict:
+        body = item.get("body", "")
+        text = html2text.html2text(body) if hasattr(html2text, "html2text") else body
+        clean = advanced_clean_text(text, item.get("lang", "en"))
+        return {
+            "title": item.get("title", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "score": item.get("score", 0),
+            "link": item.get("link", ""),
+            "content": clean,
+        }
 

--- a/plugins/wikidata.py
+++ b/plugins/wikidata.py
@@ -1,13 +1,57 @@
-"""Example Wikidata plugin."""
+"""Wikidata scraping plugin."""
+
+from typing import List, Dict
+
+import requests
+
+from scraper_wiki import Config
 from .base import Plugin
 
 
 class Plugin(Plugin):  # type: ignore[misc]
-    def fetch_items(self, lang: str, category: str):
-        # Placeholder implementation
-        return []
+    """Query Wikidata items related to a category."""
 
-    def parse_item(self, item: dict):
-        # Placeholder implementation
-        return {}
+    def __init__(self, endpoint: str | None = None) -> None:
+        self.endpoint = endpoint or Config.WIKIDATA_API_ENDPOINT
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        params = {
+            "action": "wbsearchentities",
+            "search": category,
+            "language": lang,
+            "format": "json",
+            "limit": 10,
+        }
+        resp = requests.get(self.endpoint, params=params, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        items = data.get("search", [])
+        for it in items:
+            it["lang"] = lang
+            it["category"] = category
+        return items
+
+    def parse_item(self, item: Dict) -> Dict:
+        qid = item.get("id")
+        if not qid:
+            return {}
+        params = {
+            "action": "wbgetentities",
+            "ids": qid,
+            "languages": item.get("lang", "en"),
+            "format": "json",
+        }
+        resp = requests.get(self.endpoint, params=params, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json().get("entities", {}).get(qid, {})
+        labels = data.get("labels", {})
+        descriptions = data.get("descriptions", {})
+        lang = item.get("lang", "en")
+        return {
+            "title": labels.get(lang, {}).get("value", item.get("label", "")),
+            "language": lang,
+            "category": item.get("category", ""),
+            "description": descriptions.get(lang, {}).get("value", item.get("description", "")),
+            "wikidata_id": qid,
+        }
 

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -139,6 +139,15 @@ class Config:
     STORAGE_BACKEND = os.environ.get("STORAGE_BACKEND", "local")
     LOG_SERVICE_URL = os.environ.get("LOG_SERVICE_URL")
     LOG_SERVICE_TYPE = os.environ.get("LOG_SERVICE_TYPE", "loki")
+
+    # API endpoints and keys for optional plugins
+    STACKOVERFLOW_API_KEY = os.environ.get("STACKOVERFLOW_API_KEY")
+    STACKOVERFLOW_API_ENDPOINT = os.environ.get(
+        "STACKOVERFLOW_API_ENDPOINT", "https://api.stackexchange.com/2.3"
+    )
+    WIKIDATA_API_ENDPOINT = os.environ.get(
+        "WIKIDATA_API_ENDPOINT", "https://www.wikidata.org/w/api.php"
+    )
     
     @classmethod
     def get_random_user_agent(cls):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,10 +1,56 @@
 import importlib
 import sys
 from pathlib import Path
+from types import SimpleNamespace, ModuleType
 
 # Ensure repository root is on sys.path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+# Stub heavy dependencies to avoid installing them
+sys.modules.setdefault('sentence_transformers', SimpleNamespace(SentenceTransformer=object))
+sys.modules.setdefault('datasets', SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None))
+sys.modules.setdefault('spacy', SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault('tqdm', SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault('html2text', SimpleNamespace(html2text=lambda x: x))
+sk_mod = SimpleNamespace(
+    cluster=SimpleNamespace(KMeans=object),
+    feature_extraction=SimpleNamespace(text=SimpleNamespace(TfidfVectorizer=object))
+)
+sys.modules.setdefault('sklearn', sk_mod)
+sys.modules.setdefault('sklearn.cluster', sk_mod.cluster)
+sys.modules.setdefault('sklearn.feature_extraction', sk_mod.feature_extraction)
+sys.modules.setdefault('sklearn.feature_extraction.text', sk_mod.feature_extraction.text)
+sumy_mod = SimpleNamespace(
+    parsers=SimpleNamespace(plaintext=SimpleNamespace(PlaintextParser=object)),
+    nlp=SimpleNamespace(tokenizers=SimpleNamespace(Tokenizer=object)),
+    summarizers=SimpleNamespace(lsa=SimpleNamespace(LsaSummarizer=object))
+)
+sys.modules.setdefault('sumy', sumy_mod)
+sys.modules.setdefault('sumy.parsers', sumy_mod.parsers)
+sys.modules.setdefault('sumy.parsers.plaintext', sumy_mod.parsers.plaintext)
+sys.modules.setdefault('sumy.nlp', sumy_mod.nlp)
+sys.modules.setdefault('sumy.nlp.tokenizers', sumy_mod.nlp.tokenizers)
+sys.modules.setdefault('sumy.summarizers', sumy_mod.summarizers)
+sys.modules.setdefault('sumy.summarizers.lsa', sumy_mod.summarizers.lsa)
+sys.modules.setdefault('streamlit', SimpleNamespace())
+sys.modules.setdefault('psutil', SimpleNamespace(cpu_percent=lambda interval=1: 0, virtual_memory=lambda: SimpleNamespace(percent=0)))
+sys.modules.setdefault('prometheus_client', SimpleNamespace(Counter=lambda *a, **k: object, start_http_server=lambda *a, **k: None))
+wiki_mod = ModuleType('wikipediaapi')
+wiki_mod.WikipediaException = Exception
+wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
+wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
+wiki_mod.WikipediaPage = object
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
+sys.modules.setdefault('wikipediaapi', wiki_mod)
+aiohttp_stub = SimpleNamespace(
+    ClientSession=object,
+    ClientTimeout=lambda *a, **k: None,
+    ClientError=Exception,
+    ClientResponseError=Exception,
+)
+sys.modules.setdefault('aiohttp', aiohttp_stub)
+sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
 
 import scraper_wiki as sw
 import core
@@ -41,5 +87,84 @@ def test_table_parser(monkeypatch):
         "title": "Page",
         "language": "en",
         "tables": [[["A", "B"], ["1", "2"]]],
+    }
+
+
+def test_stackoverflow_plugin(monkeypatch):
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return self._data
+
+    resp = {
+        "items": [{
+            "title": "Q1",
+            "body": "<p>code</p>",
+            "score": 5,
+            "link": "url",
+        }]
+    }
+
+    def fake_get(url, params=None, timeout=None):
+        return DummyResp(resp)
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.reload(importlib.import_module("plugins.stackoverflow"))
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "python")
+    assert items[0]["category"] == "python"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["title"] == "Q1"
+    assert parsed["language"] == "en"
+    assert parsed["category"] == "python"
+    assert parsed["score"] == 5
+    assert parsed["link"] == "url"
+
+
+def test_wikidata_plugin(monkeypatch):
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return self._data
+
+    search_resp = {
+        "search": [{"id": "Q1", "label": "Item", "description": "Desc"}]
+    }
+    entity_resp = {
+        "entities": {
+            "Q1": {
+                "labels": {"en": {"value": "Item"}},
+                "descriptions": {"en": {"value": "Desc"}},
+            }
+        }
+    }
+
+    def fake_get(url, params=None, timeout=None):
+        if params.get("action") == "wbsearchentities":
+            return DummyResp(search_resp)
+        return DummyResp(entity_resp)
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.reload(importlib.import_module("plugins.wikidata"))
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "python")
+    assert items[0]["category"] == "python"
+    parsed = plugin.parse_item(items[0])
+    assert parsed == {
+        "title": "Item",
+        "language": "en",
+        "category": "python",
+        "description": "Desc",
+        "wikidata_id": "Q1",
     }
 


### PR DESCRIPTION
## Summary
- implement new plugins for StackOverflow and Wikidata
- expose plugin API settings in `Config`
- document plugin usage examples
- mock heavy libs in plugin tests and add tests for new plugins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cdb397a48320bd3c3b18e17edb74