### PR TITLE
Add simhash deduplication step

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,18 @@ contém o exemplo `cluster.yaml` para configuração de múltiplos nós com Dask
 Ray. Em ambientes Kubernetes, basta criar um `Deployment` apontando para essa
 imagem e montar o arquivo de configuração se necessário.
 
+## Controle de Qualidade
+
+Antes de salvar os dados, o `DatasetBuilder` aplica três etapas de deduplicação
+e validação:
+
+1. `deduplicate_by_hash` remove entradas idênticas pelo hash do conteúdo;
+2. `deduplicate_by_embedding` descarta registros muito semelhantes pelos embeddings;
+3. `deduplicate_by_simhash` detecta textos quase idênticos usando Simhash.
+
+Em seguida, os registros passam por verificações de integridade dos campos e dos
+embeddings para garantir consistência.
+
 ## Integração com frameworks de ML
 
 Os arquivos gerados em `training/` permitem treinar modelos de NLP de forma simples. A seguir alguns exemplos.

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ psutil>=7.0.0
 typer>=0.16.0
 pika>=1.3.2
 prometheus-client>=0.20.0
+simhash>=2.1.2

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -1529,6 +1529,13 @@ class DatasetBuilder:
             logger.warning("Nenhum dado para salvar")
             return
 
+        # Remove near-duplicates based on Simhash
+        try:
+            self.dataset, rem_sim = dq.deduplicate_by_simhash(self.dataset)
+            self.duplicates_removed += rem_sim
+        except Exception as e:  # pragma: no cover - library issues
+            logger.error(f"Erro na deduplicação Simhash: {e}")
+
         # Validação dos registros antes de salvar
         validated_data = []
         for item in self.dataset:

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+# Ensure repo root on path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import dq
+
+
+def test_deduplicate_by_simhash_removes_near_duplicates():
+    records = [
+        {"content": "Python is great for testing algorithms"},
+        {"content": "Python is great for testing algorithm"},
+        {"content": "Completely different text"},
+    ]
+    unique, removed = dq.deduplicate_by_simhash(records, distance=3)
+    assert removed == 1
+    assert len(unique) == 2
+


### PR DESCRIPTION
## Summary
- introduce `deduplicate_by_simhash` in `dq.py`
- run Simhash deduplication inside `DatasetBuilder.save_dataset`
- document quality control with Simhash in README
- add simhash to requirements
- test near-duplicate removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d1686f888320afe11dc98aecbb7d