### PR TITLE
Add Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+EXPOSE 8000
+CMD ["uvicorn", "api_app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -288,3 +288,20 @@ emb = json.load(open('datasets_wikipedia_pro/wikipedia_qa_embeddings.json'))
 emb_tensor = tf.constant([e['embedding'] for e in emb])
 print(emb_tensor.shape)
 ```
+
+## Docker
+
+Para executar a API e o worker em contêineres, primeiro construa a imagem base:
+
+```bash
+docker build -t scraper-api .
+```
+
+Em seguida utilize o `docker-compose.yml` para subir os serviços (API, worker e opcionalmente RabbitMQ):
+
+```bash
+docker-compose up
+```
+
+As imagens podem ser publicadas em um registro e implantadas em plataformas como Kubernetes ou AWS ECS para execução em escala.
+

--- a/api_app.py
+++ b/api_app.py
@@ -148,3 +148,9 @@ async def graphql_endpoint(request: Request):
     body = await request.json()
     result = schema.execute(body.get("query"), variable_values=body.get("variables"))
     return JSONResponse(result.data)
+
+
+@app.get("/health")
+async def health_check():
+    """Basic health check endpoint used by containers and load balancers."""
+    return {"status": "ok"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - QUEUE_URL=amqp://guest:guest@rabbitmq:5672/
+    depends_on:
+      - rabbitmq
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+    environment:
+      - QUEUE_URL=amqp://guest:guest@rabbitmq:5672/
+    depends_on:
+      - rabbitmq
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"


### PR DESCRIPTION
## Summary
- expose basic /health endpoint for the API
- add Dockerfile running uvicorn
- provide docker-compose.yml with API, worker and RabbitMQ
- document Docker usage and deployment notes

## Testing
- `pip install typer numpy beautifulsoup4 pyarrow requests simhash prometheus_client python-dateutil`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685541b18ab88320b1d939aeff8301e9