### PR TITLE
Update text cleaning utilities

### DIFF
--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -65,3 +65,13 @@ def test_normalize_infobox_converts_dates(monkeypatch):
     out = text_mod.normalize_infobox(info)
     assert out == {"title": "Page", "date": "2020-01-01", "other": "x"}
 
+
+def test_clean_text_handles_wikilinks_and_sup():
+    raw = "Hello [[Link|World]]<sup>1</sup> [[Page]]"
+    assert text_mod.clean_text(raw) == "Hello World Page"
+
+
+def test_clean_text_normalizes_nfkc():
+    raw = "ＡＢＣ"
+    assert text_mod.clean_text(raw) == "ABC"
+

--- a/utils/text.py
+++ b/utils/text.py
@@ -1,7 +1,9 @@
 import re
+import unicodedata
 from datetime import datetime
 from typing import Dict
 
+from bs4 import BeautifulSoup
 import spacy
 
 try:
@@ -13,6 +15,19 @@ nlp = spacy.load("en_core_web_sm")
 
 
 def clean_text(text: str) -> str:
+    # Remove <sup> tags and their content
+    soup = BeautifulSoup(text, "html.parser")
+    for sup in soup.find_all("sup"):
+        sup.decompose()
+    text = soup.get_text()
+
+    # Replace wiki style links [[Page|text]] -> text and [[Page]] -> Page
+    text = re.sub(r"\[\[([^|\]]+)\|([^\]]+)\]\]", r"\2", text)
+    text = re.sub(r"\[\[([^|\]]+)\]\]", r"\1", text)
+
+    # Normalize unicode characters
+    text = unicodedata.normalize("NFKC", text)
+
     text = re.sub(r"\[\d+\]", "", text)
     text = re.sub(r"\s+", " ", text)
     return text.strip()


### PR DESCRIPTION
## Summary
- strip `<sup>` tags from text and collapse wiki links in `clean_text`
- normalize Unicode characters with NFKC
- test wiki link and `<sup>` removal logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e9def7c883208c14ae1c8abccb9d