### PR TITLE
Implement relation extraction and integrate into dataset

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -53,6 +53,7 @@ import dq
 import metrics
 import storage_sqlite
 from utils.text import clean_text
+from utils.relation import extract_relations
 
 # ============================
 # 🔧 Configurações Avançadas
@@ -1357,6 +1358,9 @@ class DatasetBuilder:
         
         # Gera respostas completas
         answers = self._generate_answers(content, summary, lang)
+
+        # Relações semânticas básicas
+        relations = extract_relations(content, lang)
         
         # Cria embeddings para busca semântica
         content_embedding = self.embedding_model.encode(content, show_progress_bar=False)
@@ -1379,6 +1383,7 @@ class DatasetBuilder:
             'summary_embedding': summary_embedding.tolist(),
             'questions': questions,
             'answers': answers,
+            'relations': relations,
             'created_at': datetime.utcnow().isoformat(),
             'metadata': {
                 'length': len(content),
@@ -1720,6 +1725,12 @@ class DatasetBuilder:
             if not item.get('answers'):
                 logger.warning(
                     f"Registro {item.get('id', 'desconhecido')} sem respostas"
+                )
+                valid = False
+
+            if 'relations' not in item:
+                logger.warning(
+                    f"Registro {item.get('id', 'desconhecido')} sem relações"
                 )
                 valid = False
 

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -500,6 +500,7 @@ def test_save_dataset_json_csv(tmp_path, monkeypatch):
         'summary_embedding': [0.1, 0.2],
         'questions': ['q'],
         'answers': ['a'],
+        'relations': [],
         'created_at': 'now',
         'metadata': {}
     }]
@@ -526,6 +527,7 @@ def test_save_dataset_jsonl(tmp_path, monkeypatch):
         'summary_embedding': [0.1, 0.2],
         'questions': ['q'],
         'answers': ['a'],
+        'relations': [],
         'created_at': 'now',
         'metadata': {}
     }]

--- a/tests/test_utils_relations.py
+++ b/tests/test_utils_relations.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Dummy NLP components
+class DummyToken:
+    def __init__(self, text, dep, i=0, lemma=None):
+        self.text = text
+        self.dep_ = dep
+        self.i = i
+        self.lemma_ = lemma or text
+        self.children = []
+
+class DummyEnt:
+    def __init__(self, text, start, end):
+        self.text = text
+        self.start = start
+        self.end = end
+        self.label_ = "PERSON"
+
+class DummySent(list):
+    pass
+
+class DummyDoc:
+    def __init__(self):
+        sub = DummyToken("Guido", "nsubj", i=0)
+        root = DummyToken("created", "ROOT", i=1, lemma="create")
+        obj = DummyToken("Python", "dobj", i=2)
+        root.children = [sub, obj]
+        self.tokens = [sub, root, obj]
+        self.sents = [DummySent(self.tokens)]
+        self.ents = [DummyEnt("Guido", 0, 1), DummyEnt("Python", 2, 3)]
+
+    def __iter__(self):
+        return iter(self.tokens)
+
+class DummyNLP:
+    def __call__(self, text):
+        return DummyDoc()
+
+class DummyProc:
+    @classmethod
+    def get_instance(cls, lang):
+        return DummyNLP()
+
+
+def test_extract_relations_simple(monkeypatch):
+    monkeypatch.setitem(sys.modules, "sentence_transformers", SimpleNamespace(SentenceTransformer=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: DummyNLP()))
+    monkeypatch.setitem(sys.modules, "scraper_wiki", SimpleNamespace(NLPProcessor=DummyProc))
+
+    relations_mod = importlib.reload(importlib.import_module("utils.relation"))
+    rels = relations_mod.extract_relations("Guido created Python", "en")
+    assert rels == [{"subject": "Guido", "relation": "create", "object": "Python"}]

--- a/utils/relation.py
+++ b/utils/relation.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Simple relation extraction utilities."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+
+
+def _token_to_ent_text(token, ents):
+    """Return entity text covering the token if present."""
+    for ent in ents:
+        if ent.start <= token.i < ent.end:
+            return ent.text
+    return token.text
+
+
+def extract_relations(text: str, lang: str = "en") -> List[Dict[str, str]]:
+    """Extract basic subject-verb-object relations using spaCy."""
+    try:
+        from scraper_wiki import NLPProcessor
+        nlp = NLPProcessor.get_instance(lang)
+        doc = nlp(text)
+    except Exception:
+        return []
+
+    relations: List[Dict[str, str]] = []
+    for sent in doc.sents:
+        root = next((t for t in sent if t.dep_ == "ROOT"), None)
+        if not root:
+            continue
+        subj = next((c for c in root.children if c.dep_ in {"nsubj", "nsubjpass"}), None)
+        obj = next((c for c in root.children if c.dep_ in {"dobj", "attr", "pobj", "obj"}), None)
+        if subj and obj:
+            relations.append({
+                "subject": _token_to_ent_text(subj, doc.ents),
+                "relation": root.lemma_,
+                "object": _token_to_ent_text(obj, doc.ents),
+            })
+    return relations


### PR DESCRIPTION
## Summary
- add new utils.relation module with `extract_relations`
- integrate relation extraction in `DatasetBuilder.generate_qa_pairs`
- ensure save_dataset validates presence of `relations`
- update tests to account for `relations`
- add unit test for relation extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855f05628b08320a471a39654217140