### PR TITLE
Add image URL support and update build metadata

### DIFF
--- a/dq.py
+++ b/dq.py
@@ -132,7 +132,12 @@ def complete_missing_fields(records: List[Dict], extra: List[Dict]) -> List[Dict
         if not more:
             continue
         for k, v in more.items():
-            if k not in rec or rec[k] in (None, "", []):
+            if k == "metadata" and isinstance(v, dict):
+                rec_meta = rec.setdefault("metadata", {})
+                for mk, mv in v.items():
+                    if mk not in rec_meta or rec_meta[mk] in (None, "", []):
+                        rec_meta[mk] = mv
+            elif k not in rec or rec[k] in (None, "", []):
                 rec[k] = v
     return records
 

--- a/plugins/wikidata.py
+++ b/plugins/wikidata.py
@@ -46,6 +46,21 @@ class Plugin(Plugin):  # type: ignore[misc]
         data = resp.json().get("entities", {}).get(qid, {})
         labels = data.get("labels", {})
         descriptions = data.get("descriptions", {})
+        claims = data.get("claims", {})
+        image_name = None
+        if isinstance(claims, dict) and "P18" in claims:
+            image_claim = claims.get("P18", [{}])[0]
+            image_name = (
+                image_claim.get("mainsnak", {})
+                .get("datavalue", {})
+                .get("value")
+            )
+        image_url = (
+            f"https://commons.wikimedia.org/wiki/Special:FilePath/{image_name}"
+            if image_name
+            else None
+        )
+
         lang = item.get("lang", "en")
         return {
             "title": labels.get(lang, {}).get("value", item.get("label", "")),
@@ -53,5 +68,6 @@ class Plugin(Plugin):  # type: ignore[misc]
             "category": item.get("category", ""),
             "description": descriptions.get(lang, {}).get("value", item.get("description", "")),
             "wikidata_id": qid,
+            "image_url": image_url,
         }
 

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -1349,7 +1349,15 @@ class DatasetBuilder:
         """Asynchronous wrapper for :meth:`process_page`."""
         return await asyncio.to_thread(self.process_page, page_info, proc_executor)
     
-    def generate_qa_pairs(self, title: str, content: str, summary: str, lang: str, category: str) -> dict:
+    def generate_qa_pairs(
+        self,
+        title: str,
+        content: str,
+        summary: str,
+        lang: str,
+        category: str,
+        extra_metadata: dict | None = None,
+    ) -> dict:
         # Extrai keywords para gerar perguntas variadas
         keywords = extract_keywords(content, lang)
         
@@ -1391,6 +1399,11 @@ class DatasetBuilder:
                 'source_url': f"{get_base_url(lang)}/wiki/{title.replace(' ', '_')}"
             }
         }
+        if extra_metadata:
+            if 'wikidata_id' in extra_metadata:
+                record['wikidata_id'] = extra_metadata['wikidata_id']
+            if 'image_url' in extra_metadata:
+                record['image_url'] = extra_metadata['image_url']
         try:
             storage_sqlite.save_to_db({'id': record['id'], 'metadata': record.get('metadata', {})})
         except Exception as e:

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -18,3 +18,15 @@ def test_deduplicate_by_simhash_removes_near_duplicates():
     assert removed == 1
     assert len(unique) == 2
 
+
+def test_complete_missing_fields_adds_new_keys():
+    records = [
+        {"title": "Python", "language": "en"},
+    ]
+    extra = [
+        {"title": "Python", "language": "en", "wikidata_id": "Q1", "image_url": "img"}
+    ]
+    res = dq.complete_missing_fields(records, extra)
+    assert res[0]["wikidata_id"] == "Q1"
+    assert res[0]["image_url"] == "img"
+

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -143,6 +143,11 @@ def test_wikidata_plugin(monkeypatch):
             "Q1": {
                 "labels": {"en": {"value": "Item"}},
                 "descriptions": {"en": {"value": "Desc"}},
+                "claims": {
+                    "P18": [
+                        {"mainsnak": {"datavalue": {"value": "Pic.jpg"}}}
+                    ]
+                },
             }
         }
     }
@@ -166,5 +171,6 @@ def test_wikidata_plugin(monkeypatch):
         "category": "python",
         "description": "Desc",
         "wikidata_id": "Q1",
+        "image_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Pic.jpg",
     }
 


### PR DESCRIPTION
## Summary
- include `image_url` in Wikidata plugin output
- allow passing extra metadata to `generate_qa_pairs`
- merge metadata dictionaries in `complete_missing_fields`
- update related unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567c25860c8320b4de7ca770145fff