### PR TITLE
Add extra tests

### DIFF
--- a/tests/test_utils_relations.py
+++ b/tests/test_utils_relations.py
@@ -56,3 +56,59 @@ def test_extract_relations_simple(monkeypatch):
     relations_mod = importlib.reload(importlib.import_module("utils.relation"))
     rels = relations_mod.extract_relations("Guido created Python", "en")
     assert rels == [{"subject": "Guido", "relation": "create", "object": "Python"}]
+
+
+def test_extract_relations_no_match(monkeypatch):
+    class EmptyDoc:
+        def __init__(self):
+            root = DummyToken('is', 'ROOT', i=0, lemma='be')
+            self.tokens = [root]
+            self.sents = [DummySent([root])]
+            self.ents = []
+        def __iter__(self):
+            return iter(self.tokens)
+
+    class EmptyNLP:
+        def __call__(self, text):
+            return EmptyDoc()
+
+    monkeypatch.setitem(sys.modules, "sentence_transformers", SimpleNamespace(SentenceTransformer=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: EmptyNLP()))
+    monkeypatch.setitem(sys.modules, "scraper_wiki", SimpleNamespace(NLPProcessor=DummyProc))
+
+    relations_mod = importlib.reload(importlib.import_module("utils.relation"))
+    rels = relations_mod.extract_relations("Just words", "en")
+    assert rels == []
+
+
+def test_extract_relations_multiple(monkeypatch):
+    class MultiDoc:
+        def __init__(self):
+            s1_sub = DummyToken('Guido', 'nsubj', i=0)
+            s1_root = DummyToken('created', 'ROOT', i=1, lemma='create')
+            s1_obj = DummyToken('Python', 'dobj', i=2)
+            s1_root.children = [s1_sub, s1_obj]
+            s2_sub = DummyToken('Python', 'nsubj', i=3)
+            s2_root = DummyToken('powers', 'ROOT', i=4, lemma='power')
+            s2_obj = DummyToken('programs', 'dobj', i=5)
+            s2_root.children = [s2_sub, s2_obj]
+            self.tokens = [s1_sub, s1_root, s1_obj, s2_sub, s2_root, s2_obj]
+            self.sents = [DummySent(self.tokens[:3]), DummySent(self.tokens[3:])]
+            self.ents = [DummyEnt('Guido', 0, 1), DummyEnt('Python', 2, 3)]
+        def __iter__(self):
+            return iter(self.tokens)
+
+    class MultiNLP:
+        def __call__(self, text):
+            return MultiDoc()
+
+    monkeypatch.setitem(sys.modules, "sentence_transformers", SimpleNamespace(SentenceTransformer=lambda *a, **k: None))
+    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: MultiNLP()))
+    monkeypatch.setitem(sys.modules, "scraper_wiki", SimpleNamespace(NLPProcessor=DummyProc))
+
+    relations_mod = importlib.reload(importlib.import_module("utils.relation"))
+    rels = relations_mod.extract_relations("Two sentences", "en")
+    assert rels == [
+        {"subject": "Guido", "relation": "create", "object": "Python"},
+        {"subject": "Python", "relation": "power", "object": "programs"},
+    ]


### PR DESCRIPTION
## Summary
- extend BFS page crawler tests for visited handling
- cover additional cleaning logic in `advanced_clean_text`
- verify TFRecord generation through DatasetBuilder
- add relation extraction edge cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68568b3d0e90832085df16e3f8f9e8fc