### PR TITLE
Add NER training notebook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,3 +340,17 @@ docker-compose up
 
 As imagens podem ser publicadas em um registro e implantadas em plataformas como Kubernetes ou AWS ECS para execução em escala.
 
+
+## Notebooks de Exemplo
+
+Os notebooks ficam em `examples/` e demonstram como utilizar os dados
+para treinamento de modelos. Para executá-los, instale as dependências e
+abra o Jupyter:
+
+```bash
+pip install -r requirements.txt jupyter
+jupyter notebook examples/ner_training.ipynb
+```
+
+O arquivo `ner_training.ipynb` carrega o dataset via Hugging Face e realiza
+um treinamento rápido de NER com Transformers.

--- a/examples/ner_training.ipynb
+++ b/examples/ner_training.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Exemplo de Treinamento NER"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Este notebook mostra como carregar o dataset via Hugging Face e treinar um modelo simples de reconhecimento de entidades." 
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "!pip install -q transformers datasets"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from datasets import load_dataset\nfrom transformers import (AutoTokenizer, AutoModelForTokenClassification, DataCollatorForTokenClassification, TrainingArguments, Trainer)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "dataset = load_dataset('conll2003')\nlabel_list = dataset['train'].features['ner_tags'].feature.names"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "tokenizer = AutoTokenizer.from_pretrained('bert-base-cased')"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def tokenize_and_align(example):\n    tokenized = tokenizer(example['tokens'], truncation=True, is_split_into_words=True)\n    word_ids = tokenized.word_ids()\n    labels = []\n    prev_word_id = None\n    for word_id in word_ids:\n        if word_id is None:\n            labels.append(-100)\n        elif word_id != prev_word_id:\n            labels.append(example['ner_tags'][word_id])\n        else:\n            labels.append(example['ner_tags'][word_id] if tokenizer.is_fast else -100)\n        prev_word_id = word_id\n    tokenized['labels'] = labels\n    return tokenized"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "tokenized_datasets = dataset.map(tokenize_and_align, batched=False)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "model = AutoModelForTokenClassification.from_pretrained('bert-base-cased', num_labels=len(label_list))\ndata_collator = DataCollatorForTokenClassification(tokenizer)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "training_args = TrainingArguments(\n    output_dir='./models/ner',\n    per_device_train_batch_size=8,\n    per_device_eval_batch_size=8,\n    num_train_epochs=1,\n    evaluation_strategy='epoch',\n    logging_steps=10,\n    learning_rate=5e-5,\n    weight_decay=0.01,\n    save_strategy='no'\n)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "trainer = Trainer(\n    model=model,\n    args=training_args,\n    train_dataset=tokenized_datasets['train'].select(range(200)),\n    eval_dataset=tokenized_datasets['validation'].select(range(200)),\n    tokenizer=tokenizer,\n    data_collator=data_collator,\n)\ntrainer.train()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "metrics = trainer.evaluate()\nmetrics"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `examples/ner_training.ipynb` with a short Hugging Face workflow
- document how to run the notebooks in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857122557848320b1d4b574ba757bff