### PR TITLE
Add regex relation extraction and graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,19 @@ for raw in dataset.take(1):
     print(raw.numpy())
 ```
 
+### Gerar grafo de conhecimento
+
+```python
+from utils.relation import relations_to_graph
+from scraper_wiki import DatasetBuilder
+import networkx as nx
+
+builder = DatasetBuilder()
+data = builder.generate_qa_pairs('Title', 'Ada worked at IBM.', 'Ada summary', 'en', 'History')
+G = relations_to_graph(data['relations'])
+nx.write_graphml(G, 'relations.graphml')
+```
+
 ## Docker
 
 Para executar a API e o worker em contêineres, primeiro construa a imagem base:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ psutil>=7.0.0
 typer>=0.16.0
 pika>=1.3.2
 prometheus-client>=0.20.0
+networkx>=3.5
 simhash>=2.1.2
 tensorflow>=2.16.0  # optional

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -53,7 +53,7 @@ import dq
 import metrics
 import storage_sqlite
 from utils.text import clean_text
-from utils.relation import extract_relations
+from utils.relation import extract_relations, extract_relations_regex
 from utils.cleaner import clean_wiki_text, split_sentences
 
 # ============================
@@ -1376,6 +1376,8 @@ class DatasetBuilder:
 
         # Relações semânticas básicas
         relations = extract_relations(content, lang)
+        relations_regex = extract_relations_regex(content)
+        relations.extend(r for r in relations_regex if r not in relations)
         
         # Cria embeddings para busca semântica
         content_embedding = self.embedding_model.encode(content, show_progress_bar=False)

--- a/tests/test_utils_relations.py
+++ b/tests/test_utils_relations.py
@@ -71,3 +71,24 @@ def test_token_to_ent_text_fallback():
     token = DummyToken('Word', 'nsubj', i=0)
     ent = DummyEnt('Other', 1, 2)
     assert rel._token_to_ent_text(token, [ent]) == 'Word'
+
+
+def test_extract_relations_regex_basic(monkeypatch):
+    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None))
+    import utils.relation as rel
+    text = 'Ada worked at IBM. Bob studied at MIT.'
+    res = rel.extract_relations_regex(text)
+    assert {'subject': 'Ada', 'relation': 'worked at', 'object': 'IBM'} in res
+    assert {'subject': 'Bob', 'relation': 'studied at', 'object': 'MIT'} in res
+
+
+def test_relations_to_graph_builds_edges(monkeypatch):
+    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None))
+    import utils.relation as rel
+    relations = [
+        {'subject': 'Ada', 'relation': 'worked at', 'object': 'IBM'},
+        {'subject': 'Bob', 'relation': 'studied at', 'object': 'MIT'},
+    ]
+    g = rel.relations_to_graph(relations)
+    assert g.has_edge('Ada', 'IBM')
+    assert g['Ada']['IBM']['relation'] == 'worked at'

--- a/utils/relation.py
+++ b/utils/relation.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 from typing import List, Dict
+import re
+import networkx as nx
 
 
 
@@ -38,3 +40,25 @@ def extract_relations(text: str, lang: str = "en") -> List[Dict[str, str]]:
                 "object": _token_to_ent_text(obj, doc.ents),
             })
     return relations
+
+
+def extract_relations_regex(text: str) -> List[Dict[str, str]]:
+    """Extract simple relations based on a regex pattern."""
+    pattern = re.compile(r"([A-Z][a-zA-Z]*) (worked at|studied at|discovered) ([A-Z][a-zA-Z]*)")
+    relations: List[Dict[str, str]] = []
+    for match in pattern.finditer(text):
+        subject, relation, obj = match.groups()
+        relations.append({"subject": subject, "relation": relation, "object": obj})
+    return relations
+
+
+def relations_to_graph(relations: List[Dict[str, str]]) -> nx.DiGraph:
+    """Convert a list of relations to a directed NetworkX graph."""
+    graph = nx.DiGraph()
+    for rel in relations:
+        subj = rel.get("subject")
+        obj = rel.get("object")
+        graph.add_node(subj)
+        graph.add_node(obj)
+        graph.add_edge(subj, obj, relation=rel.get("relation"))
+    return graph


### PR DESCRIPTION
## Summary
- add regex-based relation extraction in utils
- expose relation graph creation with networkx
- use new extraction in DatasetBuilder
- document graph export in README
- require networkx
- test new relation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571ca04c34832093076438f5aeba71