### PR TITLE
Add proxy selection and concurrency control

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ O módulo `scraper_wiki.py` define o dicionário `BASE_URLS` com os domínios
 principais para cada idioma. A função `get_base_url(lang)` consulta esse mapa e
 retorna `"https://{lang}.wikipedia.org"` quando o idioma não está definido.
 
+### Proxies e User-Agents
+
+Defina `Config.PROXIES` com uma lista de proxies rotativos e adicione strings
+em `Config.USER_AGENTS` para alternar automaticamente o cabeçalho
+``User-Agent`` a cada requisição.
+
 ### Armazenamento
 
 Escolha onde salvar os datasets com `--storage-backend` ou variável `STORAGE_BACKEND`.


### PR DESCRIPTION
## Summary
- allow configuring proxy rotation and concurrency via `fetch_with_retry`
- expose `fetch_all` helper for concurrent fetching
- refresh `WikipediaAdvanced.fetch_page_async` to use the new async path
- document proxy and User-Agent rotation
- test proxy usage and semaphore limiting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68571f157ca4832083732cf589054a35