### PR TITLE
Add QA and text dataset export options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Para gravar em TFRecord basta definir `--format tfrecord`:
 ```bash
 python cli.py scrape --lang pt --category "Programação" --format tfrecord
 ```
+Para gerar pares pergunta/resposta use `--format qa`:
+
+```bash
+python cli.py scrape --lang pt --category "Programação" --format qa
+```
+Para salvar um corpus de texto simples utilize `--format text`:
+
+```bash
+python cli.py scrape --lang pt --category "Programação" --format text
+```
 
 É possível repetir `--lang` e `--category` para processar múltiplos valores. Para monitorar o progresso use:
 

--- a/cli.py
+++ b/cli.py
@@ -44,7 +44,11 @@ QUEUE_FILE = Path("jobs_queue.jsonl")
 def scrape(
     lang: list[str] = typer.Option(None, "--lang", help="Idioma a processar", show_default=False),
     category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
-    fmt: str = typer.Option("all", "--format", help="Formato de saída"),
+    fmt: str = typer.Option(
+        "all",
+        "--format",
+        help="Formato de saída (json, jsonl, csv, parquet, tfrecord, qa, text)",
+    ),
     rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
     async_mode: bool = typer.Option(False, "--async", help="Usa scraping assíncrono", is_flag=True),
     plugin: str = typer.Option(
@@ -96,7 +100,11 @@ def monitor():
 def queue(
     lang: list[str] = typer.Option(None, "--lang", help="Idioma a processar", show_default=False),
     category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
-    fmt: str = typer.Option("all", "--format", help="Formato de saída"),
+    fmt: str = typer.Option(
+        "all",
+        "--format",
+        help="Formato de saída (json, jsonl, csv, parquet, tfrecord, qa, text)",
+    ),
 ):
     """Enfileira um job de scraping."""
     cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -573,6 +573,39 @@ def test_save_dataset_jsonl(tmp_path, monkeypatch):
     assert record['id'] == '1'
 
 
+def test_save_dataset_qa_and_text(tmp_path, monkeypatch):
+    builder = sw.DatasetBuilder()
+    monkeypatch.setattr(sw.Config, 'MIN_TEXT_LENGTH', 5)
+    builder.dataset = [{
+        'id': '1',
+        'title': 'T',
+        'language': 'en',
+        'category': 'c',
+        'topic': 'ai',
+        'subtopic': 'nlp',
+        'keywords': [],
+        'content': 'sample content '*2,
+        'summary': 'summary text',
+        'content_embedding': [0.1],
+        'summary_embedding': [0.1],
+        'questions': [{'text': 'q1'}],
+        'answers': [{'text': 'a1'}],
+        'relations': [],
+        'created_at': 'now',
+        'metadata': {}
+    }]
+
+    builder.save_dataset('qa', output_dir=tmp_path)
+    qa_file = tmp_path / 'qa_pairs.json'
+    assert qa_file.exists()
+    data = json.loads(qa_file.read_text(encoding='utf-8'))
+    assert data == [{'question': 'q1', 'answer': 'a1'}]
+
+    builder.save_dataset('text', output_dir=tmp_path)
+    txt_dir = tmp_path / 'text_corpus'
+    assert (txt_dir / '1.txt').exists()
+
+
 def test_normalize_category_alias():
     assert sw.normalize_category('programacao') == 'Programação'
 

--- a/training/formats.py
+++ b/training/formats.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+from utils.text import clean_text
+
+
+def save_qa_dataset(records: List[Dict], path: Path) -> None:
+    """Save question/answer pairs in a simple JSON list."""
+    pairs = []
+    for rec in records:
+        qs = rec.get("questions", [])
+        ans = rec.get("answers", [])
+        for q, a in zip(qs, ans):
+            q_text = q.get("text") if isinstance(q, dict) else q
+            a_text = a.get("text") if isinstance(a, dict) else a
+            pairs.append({"question": q_text, "answer": a_text})
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(pairs, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def save_text_corpus(records: List[Dict], directory: Path) -> None:
+    """Write one cleaned ``.txt`` file per record."""
+    directory.mkdir(parents=True, exist_ok=True)
+    for rec in records:
+        text = clean_text(rec.get("content", ""))
+        name = rec.get("id") or rec.get("title", "record")
+        file_path = directory / f"{name}.txt"
+        file_path.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Summary
- add training format helpers for QA pairs and text corpus
- support `qa` and `text` formats via CLI and DatasetBuilder
- document the new formats
- test QA/text dataset generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685725cd178883208d4d8e34dfa4b85e