### PR TITLE
Add pretrained utilities and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,20 @@ with torch.no_grad():
 print(tokenizer.decode(output[0], skip_special_tokens=True))
 ```
 
+Utilize também os utilitários em `training.pretrained_utils`:
+
+```python
+from pathlib import Path
+from training.pretrained_utils import prepare_bert_inputs, extract_image_dataset
+
+# Tokenizar textos com BERT
+inputs = prepare_bert_inputs(["exemplo de texto"])
+
+# Gerar dataset de imagens para Stable Diffusion
+records = [{"image_url": "http://site/img.jpg", "caption": "Uma foto"}]
+extract_image_dataset(records, Path('sd_data'))
+```
+
 ### Carregando embeddings com TensorFlow
 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ prometheus-client>=0.20.0
 networkx>=3.5
 simhash>=2.1.2
 tensorflow>=2.16.0  # optional
+transformers>=4.40.0

--- a/tests/test_pretrained_utils.py
+++ b/tests/test_pretrained_utils.py
@@ -1,0 +1,49 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub torch and transformers before import
+class DummyTensor:
+    def __init__(self, data):
+        self.data = data
+
+sys.modules['torch'] = SimpleNamespace(Tensor=DummyTensor)
+
+class DummyTokenizer:
+    def __call__(self, texts, padding=True, truncation=True, return_tensors='pt'):
+        return {'input_ids': DummyTensor(texts)}
+
+sys.modules['transformers'] = SimpleNamespace(
+    BertTokenizer=SimpleNamespace(from_pretrained=lambda name: DummyTokenizer())
+)
+
+pretrained_utils = importlib.import_module('training.pretrained_utils')
+
+
+def test_prepare_bert_inputs():
+    res = pretrained_utils.prepare_bert_inputs(['a', 'b'])
+    assert isinstance(res['input_ids'], DummyTensor)
+    assert res['input_ids'].data == ['a', 'b']
+
+
+def test_extract_image_dataset(tmp_path, monkeypatch):
+    recs = [{'image_url': 'http://x/img.jpg', 'caption': 'cap'}]
+
+    def fake_get(url, timeout=10):
+        class Resp:
+            content = b'img'
+            def raise_for_status(self):
+                pass
+        assert url == 'http://x/img.jpg'
+        return Resp()
+
+    monkeypatch.setattr(pretrained_utils.requests, 'get', fake_get)
+
+    pretrained_utils.extract_image_dataset(recs, tmp_path)
+    assert (tmp_path / '00000.jpg').exists()
+    text = (tmp_path / 'captions.txt').read_text(encoding='utf-8')
+    assert 'cap' in text

--- a/training/pretrained_utils.py
+++ b/training/pretrained_utils.py
@@ -1,0 +1,77 @@
+"""Utilities for working with pretrained models.
+
+This module provides helper functions to prepare inputs for BERT models and to
+build simple image datasets compatible with Stable Diffusion training.
+
+Example
+-------
+>>> from training.pretrained_utils import prepare_bert_inputs
+>>> inputs = prepare_bert_inputs(["Hello World"])  # doctest: +SKIP
+>>> inputs["input_ids"].shape[0] == 1
+True
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+import torch
+from transformers import BertTokenizer
+
+
+def prepare_bert_inputs(texts: List[str]) -> Dict[str, torch.Tensor]:
+    """Tokenize ``texts`` with ``BertTokenizer`` and return tensors.
+
+    Parameters
+    ----------
+    texts : list[str]
+        Sentences or documents to encode.
+
+    Returns
+    -------
+    Dict[str, torch.Tensor]
+        Tokenized inputs ready for ``torch`` models.
+
+    Example
+    -------
+    >>> from training.pretrained_utils import prepare_bert_inputs
+    >>> res = prepare_bert_inputs(["example text"])  # doctest: +SKIP
+    >>> list(res.keys())
+    ['input_ids', 'token_type_ids', 'attention_mask']
+    """
+
+    tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+    return tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
+
+
+def extract_image_dataset(records: List[dict], out_dir: Path) -> None:
+    """Download image URLs and captions for Stable Diffusion.
+
+    Each record should contain ``image_url`` and ``caption`` or ``title`` fields.
+    Images are saved inside ``out_dir`` using zero-padded names and a
+    ``captions.txt`` file maps filenames to captions.
+
+    Example
+    -------
+    >>> recs = [{"image_url": "http://example.com/pic.jpg", "caption": "A cat"}]
+    >>> extract_image_dataset(recs, Path('data'))  # doctest: +SKIP
+    """
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    captions = out_dir / "captions.txt"
+    with captions.open("w", encoding="utf-8") as cf:
+        for idx, rec in enumerate(records):
+            url = rec.get("image_url")
+            if not url:
+                continue
+            caption = rec.get("caption") or rec.get("title", "")
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            ext = Path(url).suffix or ".jpg"
+            name = f"{idx:05d}{ext}"
+            with open(out_dir / name, "wb") as img_f:
+                img_f.write(resp.content)
+            cf.write(f"{name}\t{caption}\n")


### PR DESCRIPTION
## Summary
- implement `prepare_bert_inputs` and `extract_image_dataset`
- document usage of new utilities
- add tests for the utilities
- include `transformers` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685729f4888c8320b3f92ad487bffaf5