### PR TITLE
Add entity extraction during page processing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5,8 +5,6 @@ import typer
 
 import scraper_wiki
 import dashboard
-from utils.text import clean_text, extract_entities
-from concurrent.futures import ThreadPoolExecutor
 
 app = typer.Typer(help="Scraper Wiki command line interface")
 
@@ -101,16 +99,9 @@ def scrape(
                 client=client,
             )
         dataset_file = Path(scraper_wiki.Config.OUTPUT_DIR) / "wikipedia_qa.json"
-        if dataset_file.exists():
-            data = json.loads(dataset_file.read_text(encoding="utf-8"))
-            with ThreadPoolExecutor(max_workers=scraper_wiki.Config.MAX_THREADS) as ex:
-                ents = list(ex.map(lambda r: extract_entities(clean_text(r.get("content", ""))), data))
-            for rec, ent in zip(data, ents):
-                rec["entities"] = ent
-            dataset_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
-            if train:
-                from training import pipeline
-                pipeline.run_pipeline(dataset_file)
+        if dataset_file.exists() and train:
+            from training import pipeline
+            pipeline.run_pipeline(dataset_file)
     else:
         from plugins import load_plugin, run_plugin
 

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -422,6 +422,7 @@ def test_process_page_uses_clean_text(monkeypatch):
     monkeypatch.setattr(sw.Config, 'REMOVE_STOPWORDS', True)
     monkeypatch.setattr(sw, 'summarize_text', lambda *a, **k: '')
     monkeypatch.setattr(sw.DatasetBuilder, 'generate_qa_pairs', lambda *a, **k: {})
+    monkeypatch.setattr(sw, 'extract_entities', lambda text: [])
     monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
         scrape_success=SimpleNamespace(inc=lambda: None),
         scrape_error=SimpleNamespace(inc=lambda: None),
@@ -433,7 +434,7 @@ def test_process_page_uses_clean_text(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({'title': 'T', 'lang': 'en'})
 
-    assert res == {}
+    assert res == {'entities': []}
     assert called['clean'] == 'raw text'
     assert called['adv'] == ('cleaned', 'en', True)
 
@@ -461,6 +462,7 @@ def test_process_page_increments_counter(monkeypatch):
     monkeypatch.setattr(sw, 'advanced_clean_text', lambda t, lang, remove_stopwords=False: t)
     monkeypatch.setattr(sw, 'summarize_text', lambda *a, **k: '')
     monkeypatch.setattr(sw.DatasetBuilder, 'generate_qa_pairs', lambda *a, **k: {'ok': True})
+    monkeypatch.setattr(sw, 'extract_entities', lambda text: [])
     monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
         scrape_success=SimpleNamespace(inc=lambda: None),
         scrape_error=SimpleNamespace(inc=lambda: None),
@@ -472,7 +474,7 @@ def test_process_page_increments_counter(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({'title': 'T', 'lang': 'en'})
 
-    assert res == {'ok': True}
+    assert res == {'ok': True, 'entities': []}
     assert counts['pages'] == 1
 
 
@@ -501,6 +503,7 @@ def test_process_page_records_histogram(monkeypatch):
     monkeypatch.setattr(sw, 'advanced_clean_text', lambda t, lang, remove_stopwords=False: t)
     monkeypatch.setattr(sw, 'summarize_text', lambda *a, **k: '')
     monkeypatch.setattr(sw.DatasetBuilder, 'generate_qa_pairs', lambda *a, **k: {'ok': True})
+    monkeypatch.setattr(sw, 'extract_entities', lambda text: [])
     monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
         scrape_success=SimpleNamespace(inc=lambda: None),
         scrape_error=SimpleNamespace(inc=lambda: None),
@@ -512,7 +515,7 @@ def test_process_page_records_histogram(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({'title': 'T', 'lang': 'en'})
 
-    assert res == {'ok': True}
+    assert res == {'ok': True, 'entities': []}
     assert observed['count'] == 1
 
 


### PR DESCRIPTION
## Summary
- store named entities when processing a page
- remove CLI post-processing for entities
- update tests to expect entities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685733c178b483209573440a51fb7d94