### PR TITLE
Add image extraction helper

### DIFF
--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -434,7 +434,7 @@ def test_process_page_uses_clean_text(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({'title': 'T', 'lang': 'en'})
 
-    assert res == {'entities': []}
+    assert res == {'entities': [], 'images': []}
     assert called['clean'] == 'raw text'
     assert called['adv'] == ('cleaned', 'en', True)
 
@@ -474,7 +474,7 @@ def test_process_page_increments_counter(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({'title': 'T', 'lang': 'en'})
 
-    assert res == {'ok': True, 'entities': []}
+    assert res == {'ok': True, 'entities': [], 'images': []}
     assert counts['pages'] == 1
 
 
@@ -515,7 +515,7 @@ def test_process_page_records_histogram(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({'title': 'T', 'lang': 'en'})
 
-    assert res == {'ok': True, 'entities': []}
+    assert res == {'ok': True, 'entities': [], 'images': []}
     assert observed['count'] == 1
 
 

--- a/tests/test_utils_images.py
+++ b/tests/test_utils_images.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import scraper_wiki as sw
+
+
+def test_extract_images_basic():
+    html = (
+        "<div class='thumb'>"
+        "<img src='//upload.wikimedia.org/img.jpg'/>"
+        "<div class='thumbcaption'>Cap</div>"
+        "</div>"
+    )
+    res = sw.extract_images(html)
+    assert res == [{"image_url": "https://upload.wikimedia.org/img.jpg", "caption": "Cap"}]
+
+
+def test_extract_images_no_caption():
+    html = "<figure><img src='pic.png'/></figure>"
+    res = sw.extract_images(html)
+    assert res == [{"image_url": "pic.png", "caption": ""}]


### PR DESCRIPTION
## Summary
- support extracting images from HTML
- include image data when processing pages
- add unit tests for image extraction and update tests for DatasetBuilder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685735d0c9408320a7b76e22284281c5