### PR TITLE
Add Wikipedia revision history option

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -59,6 +59,8 @@ def scrape(
         help="Profundidade de navegação para páginas iniciais",
     ),
     rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
+    revisions: bool = typer.Option(False, "--revisions", help="Inclui histórico de revisões", is_flag=True),
+    rev_limit: int = typer.Option(5, "--rev-limit", help="Número máximo de revisões"),
     async_mode: bool = typer.Option(False, "--async", help="Usa scraping assíncrono", is_flag=True),
     plugin: str = typer.Option(
         "wikipedia",
@@ -86,6 +88,8 @@ def scrape(
                     rate_limit_delay,
                     start_pages=start_page,
                     depth=depth,
+                    revisions=revisions,
+                    rev_limit=rev_limit,
                 )
             )
         else:
@@ -96,6 +100,8 @@ def scrape(
                 rate_limit_delay,
                 start_pages=start_page,
                 depth=depth,
+                revisions=revisions,
+                rev_limit=rev_limit,
                 client=client,
             )
         dataset_file = Path(scraper_wiki.Config.OUTPUT_DIR) / "wikipedia_qa.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,6 +276,7 @@ def test_scrape_start_page_option(monkeypatch):
         start_pages=None,
         depth=1,
         client=None,
+        **kwargs,
     ):
         called["args"] = {
             "lang": lang,
@@ -301,3 +302,26 @@ def test_scrape_start_page_option(monkeypatch):
         "start": ["Python"],
         "depth": 2,
     }
+
+
+def test_scrape_revisions_option(monkeypatch):
+    captured = {}
+
+    def fake_main(
+        lang,
+        category,
+        fmt,
+        rate_limit_delay=None,
+        start_pages=None,
+        depth=1,
+        revisions=False,
+        rev_limit=5,
+        client=None,
+    ):
+        captured["rev"] = (revisions, rev_limit)
+
+    monkeypatch.setattr(cli.scraper_wiki, "main", fake_main)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["scrape", "--revisions", "--rev-limit", "3"])
+    assert result.exit_code == 0
+    assert captured["rev"] == (True, 3)


### PR DESCRIPTION
## Summary
- implement revision history fetching via Wikipedia API
- include revision metadata in DatasetBuilder when enabled
- add CLI flags `--revisions` and `--rev-limit`
- expose revision API via `WikipediaAdvanced`
- add unit tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685739b82af483209f80c70f2d9c47d2