### PR TITLE
Add stemming and translation support

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 import scraper_wiki
+from utils.text import translate_text
 
 
 def _parse_wiki_url(url: str) -> tuple[str, str]:
@@ -42,7 +43,12 @@ def _parse_wiki_url(url: str) -> tuple[str, str]:
     show_default=True,
     help="Diretório para salvar o resultado",
 )
-def main(url: str | None, urls_file: str | None, output_format: str, out_dir: str) -> None:
+@click.option(
+    "--translate",
+    "translate_to",
+    help="Traduz o texto para o idioma especificado",
+)
+def main(url: str | None, urls_file: str | None, output_format: str, out_dir: str, translate_to: str | None) -> None:
     """Baixa o HTML de páginas da Wikipédia e salva em formatos variados."""
     if not url and not urls_file:
         raise click.UsageError("Informe --url ou --file")
@@ -57,6 +63,8 @@ def main(url: str | None, urls_file: str | None, output_format: str, out_dir: st
     for u in urls:
         title, lang = _parse_wiki_url(u)
         html = asyncio.run(scraper_wiki.fetch_html_content_async(title, lang))
+        if translate_to:
+            html = translate_text(html, translate_to)
         records.append({"url": u, "html": html})
 
     out_dir_path = Path(out_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ networkx>=3.5
 simhash>=2.1.2
 tensorflow>=2.16.0  # optional
 transformers>=4.40.0
+googletrans==4.0.0rc1

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -654,8 +654,9 @@ def advanced_clean_text(
     lang: str = 'en',
     remove_stopwords: bool = False,
     split: bool = False,
+    stem: bool = False,
 ) -> str | list[str]:
-    """Clean wiki text and optionally split sentences."""
+    """Clean wiki text with optional stopword removal, stemming and sentence splitting."""
     try:
         text = clean_wiki_text(text)
 
@@ -677,23 +678,44 @@ def advanced_clean_text(
         for section in sections_to_remove:
             text = re.sub(fr'==\s*{section}\s*==.*', '', text, flags=re.IGNORECASE | re.DOTALL)
 
-        if remove_stopwords:
+        if remove_stopwords or stem:
             removed = False
             try:
                 nlp = NLPProcessor.get_instance(lang)
                 doc = nlp(text)
-                text = ' '.join(t.text for t in doc if not getattr(t, 'is_stop', False))
+                tokens = []
+                for t in doc:
+                    if remove_stopwords and getattr(t, 'is_stop', False):
+                        continue
+                    tokens.append(t.lemma_ if stem else t.text)
+                text = ' '.join(tokens)
                 removed = True
             except Exception as e:
-                logger.error(f"Erro ao remover stopwords com spaCy: {e}")
+                logger.error(f"Erro ao processar texto com spaCy: {e}")
             if not removed:
                 try:
                     import nltk
                     from nltk.corpus import stopwords
-                    stop_words = set(stopwords.words(lang))
-                    text = ' '.join(w for w in text.split() if w.lower() not in stop_words)
+                    from nltk.stem import SnowballStemmer, PorterStemmer
+                    stop_words = set()
+                    if remove_stopwords:
+                        stop_words = set(stopwords.words(lang))
+                    if stem:
+                        try:
+                            stemmer = SnowballStemmer(lang)
+                        except Exception:
+                            stemmer = PorterStemmer()
+                    tokens = []
+                    for w in text.split():
+                        if remove_stopwords and w.lower() in stop_words:
+                            continue
+                        if stem:
+                            tokens.append(stemmer.stem(w))
+                        else:
+                            tokens.append(w)
+                    text = ' '.join(tokens)
                 except Exception as e:
-                    logger.error(f"Erro ao remover stopwords com NLTK: {e}")
+                    logger.error(f"Erro ao processar texto com NLTK: {e}")
 
         text = text.strip()
         if split:

--- a/tests/test_utils_text.py
+++ b/tests/test_utils_text.py
@@ -24,11 +24,13 @@ class DummyNLP:
         return DummyDoc()
 
 
-# Load utils.text with spaCy mocked so that importing does not require the real package
+# Load utils.text with spaCy and googletrans mocked so that importing does not require the real packages
 sys.modules["spacy"] = SimpleNamespace(load=lambda *a, **k: DummyNLP())
+sys.modules["googletrans"] = SimpleNamespace(Translator=lambda: SimpleNamespace(translate=lambda text, dest: SimpleNamespace(text=f"{text}-{dest}")))
 text_mod = importlib.import_module("utils.text")
-# After importing, replace spacy with a no-op to avoid accidental use
+# After importing, replace spacy and googletrans with no-op modules to avoid accidental use
 sys.modules["spacy"] = SimpleNamespace(load=lambda *a, **k: None)
+sys.modules["googletrans"] = SimpleNamespace(Translator=lambda: SimpleNamespace(translate=lambda text, dest: SimpleNamespace(text=f"{text}-{dest}")))
 
 
 def test_clean_text_removes_refs_and_spaces():
@@ -74,4 +76,27 @@ def test_clean_text_handles_wikilinks_and_sup():
 def test_clean_text_normalizes_nfkc():
     raw = "ＡＢＣ"
     assert text_mod.clean_text(raw) == "ABC"
+
+
+def test_translate_text_returns_translated():
+    out = text_mod.translate_text("hello", "es")
+    assert out == "hello-es"
+
+
+def test_advanced_clean_text_with_stemming(monkeypatch):
+    class DummyTok:
+        def __init__(self, text):
+            self.text = text
+            self.lemma_ = text.lower() + "_lemma"
+            self.is_stop = False
+
+    class DummyStemNLP:
+        def __call__(self, text):
+            return [DummyTok(t) for t in text.split()]
+
+    import scraper_wiki as sw
+
+    monkeypatch.setattr(sw.NLPProcessor, "get_instance", classmethod(lambda cls, lang: DummyStemNLP()))
+    cleaned = sw.advanced_clean_text("RUNS Running", "en", stem=True)
+    assert cleaned == "runs_lemma running_lemma"
 

--- a/utils/text.py
+++ b/utils/text.py
@@ -76,3 +76,17 @@ def normalize_infobox(infobox: Dict[str, str]) -> Dict[str, str]:
 def extract_entities(text: str) -> list[dict]:
     doc = nlp(text)
     return [{"text": ent.text, "type": ent.label_} for ent in doc.ents]
+
+
+def translate_text(text: str, target_lang: str) -> str:
+    """Translate ``text`` into ``target_lang`` using googletrans.
+
+    If translation fails, the original text is returned unchanged.
+    """
+    try:
+        from googletrans import Translator
+
+        translator = Translator()
+        return translator.translate(text, dest=target_lang).text
+    except Exception:
+        return text


### PR DESCRIPTION
## Summary
- enable optional stemming or lemmatization in `advanced_clean_text`
- add `translate_text` helper using googletrans
- hook up translation to `main.py` via new `--translate` option
- update tests for new features
- update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578dc003288320a9c19d898fd6d357