### PR TITLE
Add dataset metadata info

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,15 @@ e validação:
 Em seguida, os registros passam por verificações de integridade dos campos e dos
 embeddings para garantir consistência.
 
+### Arquivo `dataset_info.json`
+
+O método `save_dataset` gera também o arquivo `dataset_info.json` com
+informações básicas sobre o conjunto criado:
+
+- `source`: origem dos registros, por exemplo `"wikipedia"`;
+- `collection_date`: data da coleta no formato `AAAA-MM-DD`;
+- `license`: licença aplicável, padrão `"CC BY-SA 4.0"`.
+
 ## Integração com frameworks de ML
 
 Os arquivos gerados em `training/` permitem treinar modelos de NLP de forma simples. A seguir alguns exemplos.

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -2052,6 +2052,22 @@ class DatasetBuilder:
             except Exception as e:
                 logger.error(f"Erro ao salvar dataset HuggingFace: {e}")
 
+        # Write metadata about the dataset
+        try:
+            sources = {
+                item.get("metadata", {}).get("source", "unknown")
+                for item in sorted_data
+            }
+            info = {
+                "source": list(sources)[0] if len(sources) == 1 else sorted(sources),
+                "collection_date": datetime.utcnow().date().isoformat(),
+                "license": "CC BY-SA 4.0",
+            }
+            with open(os.path.join(output_dir, "dataset_info.json"), "w", encoding="utf-8") as f:
+                json.dump(info, f, ensure_ascii=False, indent=2)
+        except Exception as e:  # pragma: no cover - unexpected I/O errors
+            logger.error(f"Erro ao salvar dataset_info.json: {e}")
+
 # ============================
 # 🚦 Pipeline de Execução Principal
 # ============================

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -549,6 +549,10 @@ def test_save_dataset_json_csv(tmp_path, monkeypatch):
     }]
     builder.save_dataset('json', output_dir=tmp_path)
     assert (tmp_path/'wikipedia_qa.json').exists()
+    info_file = tmp_path / 'dataset_info.json'
+    assert info_file.exists()
+    info = json.loads(info_file.read_text(encoding='utf-8'))
+    assert set(['source', 'collection_date', 'license']).issubset(info)
     builder.save_dataset('csv', output_dir=tmp_path)
     assert (tmp_path/'wikipedia_qa.csv').exists()
 


### PR DESCRIPTION
## Summary
- generate dataset_info.json with basic metadata
- test creation of dataset_info.json
- document dataset_info.json fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685828852ac0832092144fa85872c506