### PR TITLE
Add tests for image, revision, checkpoint functions

### DIFF
--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -1523,3 +1523,44 @@ def test_resume_from_checkpoint(tmp_path, monkeypatch):
     assert titles == {"Done", "A", "B"}
     saved = json.loads(pages_path.read_text(encoding="utf-8"))
     assert saved == []
+
+
+def test_get_revision_history_from_cache(monkeypatch):
+    fake_cache = {"revisions_en_Title_5": [{"timestamp": "t", "user": "u"}]}
+    monkeypatch.setattr(sw, "cache", SimpleNamespace(
+        get=lambda k: fake_cache.get(k),
+        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+        stats=lambda: {},
+    ))
+    monkeypatch.setattr(sw.requests, "get", lambda *a, **k: (_ for _ in ()).throw(AssertionError("network called")))
+    res = sw.get_revision_history("Title", "en", 5)
+    assert res == [{"timestamp": "t", "user": "u"}]
+
+
+def test_wikipedia_advanced_revision_history(monkeypatch):
+    captured = {}
+
+    def fake_get_rev(title, lang, limit):
+        captured["args"] = (title, lang, limit)
+        return ["ok"]
+
+    monkeypatch.setattr(sw, "get_revision_history", fake_get_rev)
+    wiki = sw.WikipediaAdvanced("pt")
+    res = wiki.get_revision_history("Page", 3)
+    assert res == ["ok"]
+    assert captured["args"] == ("Page", "pt", 3)
+
+
+def test_dataset_builder_initializes_from_checkpoints(tmp_path, monkeypatch):
+    monkeypatch.setattr(sw.Config, "LOG_DIR", str(tmp_path))
+
+    data = [{"title": "D"}]
+    pages = [{"title": "P", "lang": "en"}]
+    (Path(tmp_path) / "checkpoint_data.json").write_text(json.dumps(data), encoding="utf-8")
+    (Path(tmp_path) / "checkpoint_pages.json").write_text(json.dumps(pages), encoding="utf-8")
+
+    builder = sw.DatasetBuilder()
+
+    assert builder.dataset == data
+    assert builder.pending_pages == pages
+    assert (Path(tmp_path) / "progress.json").exists()

--- a/tests/test_utils_images.py
+++ b/tests/test_utils_images.py
@@ -22,3 +22,18 @@ def test_extract_images_no_caption():
     html = "<figure><img src='pic.png'/></figure>"
     res = sw.extract_images(html)
     assert res == [{"image_url": "pic.png", "caption": ""}]
+
+
+def test_extract_images_multiple():
+    html = (
+        "<div class='thumb'>"
+        "<img src='img1.png'/>"
+        "<div class='thumbcaption'>One</div>"
+        "</div>"
+        "<figure><img src='//example.com/img2.jpg'/><figcaption>Two</figcaption></figure>"
+    )
+    res = sw.extract_images(html)
+    assert res == [
+        {"image_url": "img1.png", "caption": "One"},
+        {"image_url": "https://example.com/img2.jpg", "caption": "Two"},
+    ]


### PR DESCRIPTION
## Summary
- expand image extraction tests
- test revision history caching and wrapper
- check DatasetBuilder checkpoint loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685830c53b848320b2ccf23e9ce213a1