### PR TITLE
Add Sphinx docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Scraper-Wiki
 Scraper para criacao de datasets para fine tuning e treinamento de modelos de inteligencia artificial
 
+A documentação da API está disponível em [docs/_build/index.html](docs/_build/index.html).
+
 ## Instalação
 
 Use o arquivo `requirements.txt` para instalar as dependências:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Building the Documentation
+
+Install `sphinx` and then run:
+
+```bash
+sphinx-build -b html docs docs/_build
+```
+
+The HTML files will be created under `docs/_build`. Open `index.html` in your browser to view the API docs.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+project = "Scraper-Wiki"
+extensions = ["sphinx.ext.autodoc"]
+autodoc_mock_imports = [
+    "sentence_transformers",
+    "datasets",
+    "spacy",
+    "unidecode",
+    "tqdm",
+    "html2text",
+    "wikipediaapi",
+    "aiohttp",
+    "backoff",
+    "sklearn",
+    "sumy",
+    "streamlit",
+    "psutil",
+    "prometheus_client",
+    "tensorflow",
+    "transformers",
+    "googletrans",
+]
+exclude_patterns = ["_build"]
+html_theme = "alabaster"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,7 @@
+Scraper-Wiki Documentation
+==========================
+
+.. toctree::
+   :maxdepth: 2
+
+   modules

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,17 @@
+API Reference
+=============
+
+.. automodule:: scraper_wiki
+   :members:
+
+.. automodule:: core.scraping
+   :members:
+
+.. automodule:: utils.text
+   :members:
+
+.. automodule:: plugins.wikipedia
+   :members:
+
+.. automodule:: training.pipeline
+   :members:


### PR DESCRIPTION
## Summary
- add a Sphinx configuration under `docs/`
- document how to build docs
- link generated docs from `README.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858444b3f74832098332663c16cdb76