### PR TITLE
Add GitHub scraper plugin

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,4 +1,5 @@
 """Plugin utilities and registry."""
+
 import importlib
 from typing import List
 from core.builder import DatasetBuilder
@@ -11,6 +12,7 @@ AVAILABLE_PLUGINS = {
     "stackoverflow": "stackoverflow",
     "infobox_parser": "infobox_parser",
     "table_parser": "table_parser",
+    "github_scraper": "github_scraper",
 }
 
 
@@ -22,7 +24,9 @@ def load_plugin(name: str) -> Plugin:
     return plugin_cls()
 
 
-def run_plugin(plugin: Plugin, langs: List[str], categories: List[str], fmt: str = "all") -> List[dict]:
+def run_plugin(
+    plugin: Plugin, langs: List[str], categories: List[str], fmt: str = "all"
+) -> List[dict]:
     """Execute scraping using a plugin."""
     builder = DatasetBuilder()
     for lang in langs:
@@ -34,5 +38,6 @@ def run_plugin(plugin: Plugin, langs: List[str], categories: List[str], fmt: str
                     builder.dataset.append(result)
     builder.save_dataset(fmt)
     return builder.dataset
+
 
 __all__ = ["load_plugin", "run_plugin", "AVAILABLE_PLUGINS"]

--- a/plugins/github_scraper.py
+++ b/plugins/github_scraper.py
@@ -1,0 +1,56 @@
+"""Utilities for scraping GitHub repositories."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Tuple
+
+import requests
+
+
+class GitHubScraper:
+    """Minimal interface for the GitHub API."""
+
+    def __init__(self, token: str | None = None, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://api.github.com"
+        self.token = token
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        return headers
+
+    def _parse_repo(self, repo_url: str) -> Tuple[str, str]:
+        parts = repo_url.rstrip("/").split("/")[-2:]
+        if len(parts) != 2:
+            raise ValueError("Invalid GitHub repository URL")
+        return parts[0], parts[1]
+
+    def get_repo_code(self, repo_url: str) -> str:
+        """Return repository README text using the GitHub API."""
+        owner, repo = self._parse_repo(repo_url)
+        url = f"{self.api_url}/repos/{owner}/{repo}/readme"
+        resp = requests.get(url, headers={"Accept": "application/vnd.github.v3.raw"})
+        resp.raise_for_status()
+        return resp.text
+
+    def get_issues(self, repo_url: str, state: str = "open") -> List[Dict]:
+        """Return issues for the repository."""
+        owner, repo = self._parse_repo(repo_url)
+        url = f"{self.api_url}/repos/{owner}/{repo}/issues"
+        params = {"state": state}
+        resp = requests.get(url, headers=self._headers(), params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_commits(self, repo_url: str) -> List[Dict]:
+        """Return commit metadata for the repository."""
+        owner, repo = self._parse_repo(repo_url)
+        url = f"{self.api_url}/repos/{owner}/{repo}/commits"
+        resp = requests.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
+
+
+class Plugin(GitHubScraper):
+    """Alias for plugin registry compatibility."""

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_github_scraper(monkeypatch):
+    import importlib
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    github_scraper = importlib.import_module("plugins.github_scraper")
+    import requests
+
+    class DummyResp:
+        def __init__(self, data=None, text=""):
+            self._data = data
+            self._text = text
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+        @property
+        def text(self):
+            return self._text
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/readme"):
+            return DummyResp(text="README")
+        if url.endswith("/issues"):
+            return DummyResp(data=[{"title": "issue"}])
+        if url.endswith("/commits"):
+            return DummyResp(data=[{"sha": "abc"}])
+        return DummyResp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    scraper = github_scraper.GitHubScraper()
+    readme = scraper.get_repo_code("https://github.com/user/repo")
+    assert readme == "README"
+    issues = scraper.get_issues("https://github.com/user/repo")
+    assert issues == [{"title": "issue"}]
+    commits = scraper.get_commits("https://github.com/user/repo")
+    assert commits == [{"sha": "abc"}]


### PR DESCRIPTION
## Summary
- add GitHubScraper plugin for fetching repo code, issues and commits
- register plugin in plugin registry
- test GitHubScraper basic usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685852b7c2cc832082d540a86770fb14