### PR TITLE
Add code processing utilities

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -57,6 +57,11 @@ import storage_sqlite
 from utils.text import clean_text, extract_entities
 from utils.relation import extract_relations, extract_relations_regex
 from utils.cleaner import clean_wiki_text, split_sentences
+from utils.code import (
+    normalize_indentation,
+    remove_comments,
+    detect_programming_language,
+)
 
 
 # ============================
@@ -1687,6 +1692,10 @@ class DatasetBuilder:
         category: str,
         extra_metadata: dict | None = None,
     ) -> dict:
+        code_lang = detect_programming_language(content)
+        if code_lang != "unknown":
+            content = normalize_indentation(remove_comments(content, code_lang))
+
         # Extrai keywords para gerar perguntas variadas
         keywords = extract_keywords(content, lang)
 
@@ -1734,6 +1743,8 @@ class DatasetBuilder:
                 "source_url": f"{get_base_url(lang)}/wiki/{title.replace(' ', '_')}",
             },
         }
+        if code_lang != "unknown":
+            record["metadata"]["code_language"] = code_lang
         if extra_metadata:
             if "wikidata_id" in extra_metadata:
                 record["wikidata_id"] = extra_metadata["wikidata_id"]

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+sw = importlib.import_module("scraper_wiki")
+
+
+def test_generate_qa_pairs_processes_code(monkeypatch):
+    builder = sw.DatasetBuilder()
+    monkeypatch.setattr(builder, "_generate_questions", lambda *a, **k: [])
+    monkeypatch.setattr(builder, "_generate_answers", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
+    import numpy as np
+
+    monkeypatch.setattr(
+        builder.embedding_model, "encode", lambda *a, **k: np.array([0.0])
+    )
+    code = "def foo():\n    pass  # comment"
+    result = builder.generate_qa_pairs("T", code, "S", "en", "c")
+    assert result["content"] == "def foo():\n    pass"
+    assert result["metadata"].get("code_language") == "python"

--- a/tests/test_utils_code.py
+++ b/tests/test_utils_code.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+code_mod = importlib.import_module("utils.code")
+
+
+def test_normalize_indentation():
+    raw = "    def f():\n        pass\n"
+    assert code_mod.normalize_indentation(raw) == "def f():\n    pass"
+
+
+def test_remove_comments_python():
+    raw = "def f():\n    # c\n    return 1"
+    assert code_mod.remove_comments(raw, "python") == "def f():\n    return 1"
+
+
+def test_detect_programming_language():
+    assert code_mod.detect_programming_language("def f():\n    pass") == "python"
+    assert code_mod.detect_programming_language("console.log('x');") == "javascript"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,11 @@ from .text import (
 )
 from .relation import extract_relations
 from .cleaner import clean_wiki_text, split_sentences
+from .code import (
+    normalize_indentation,
+    remove_comments,
+    detect_programming_language,
+)
 
 __all__ = [
     "clean_text",
@@ -17,4 +22,7 @@ __all__ = [
     "extract_relations",
     "clean_wiki_text",
     "split_sentences",
+    "normalize_indentation",
+    "remove_comments",
+    "detect_programming_language",
 ]

--- a/utils/code.py
+++ b/utils/code.py
@@ -1,0 +1,46 @@
+import re
+import textwrap
+
+
+def normalize_indentation(code: str) -> str:
+    """Return ``code`` with common indentation removed."""
+    dedented = textwrap.dedent(code)
+    lines = [line.rstrip() for line in dedented.splitlines()]
+    return "\n".join(lines).strip()
+
+
+def remove_comments(code: str, language: str) -> str:
+    """Return ``code`` without comments for ``language``."""
+    patterns = []
+    lang = language.lower()
+    if lang in {"python", "py"}:
+        patterns = [r"#.*", r'""".*?"""', r"'''(.|\n)*?'''"]
+    elif lang in {"javascript", "js", "java", "c", "cpp", "go", "php", "rust"}:
+        patterns = [r"//.*", r"/\*.*?\*/"]
+    else:
+        patterns = [r"#.*", r"//.*", r"/\*.*?\*/"]
+    text = code
+    for pat in patterns:
+        text = re.sub(pat, "", text, flags=re.DOTALL)
+    lines = [line for line in text.splitlines() if line.strip()]
+    return "\n".join(lines)
+
+
+def detect_programming_language(code: str) -> str:
+    """Guess the programming language of ``code`` using simple heuristics."""
+    heuristics = {
+        "python": ["def ", "import ", "print("],
+        "javascript": ["function ", "console.log", "var ", "let ", "const "],
+        "java": ["public class", "System.out.println"],
+        "c": ["#include", "printf("],
+        "cpp": ["std::", "#include <iostream"],
+        "php": ["<?php", "echo "],
+        "ruby": ["end", "puts "],
+        "go": ["package main", "fmt."],
+        "rust": ["fn ", "::"],
+    }
+    lowered = code.lower()
+    for lang, keys in heuristics.items():
+        if any(k.lower() in lowered for k in keys):
+            return lang
+    return "unknown"


### PR DESCRIPTION
## Summary
- implement utilities for code text handling
- expose new code helpers in `utils`
- integrate code cleaning in `DatasetBuilder.generate_qa_pairs`
- test utilities and dataset builder changes

## Testing
- `pytest tests/test_utils_code.py tests/test_datasetbuilder_code.py -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685857125db08320bdbdb129c9ca3619