### PR TITLE
Add GitHub issue commit pairing

### DIFF
--- a/plugins/github_scraper.py
+++ b/plugins/github_scraper.py
@@ -51,6 +51,34 @@ class GitHubScraper:
         resp.raise_for_status()
         return resp.json()
 
+    def get_issue_commit_pairs(
+        self, repo_url: str, state: str = "closed"
+    ) -> List[Tuple[Dict, Dict]]:
+        """Return pairs of issues and commits that reference them."""
+        issues = self.get_issues(repo_url, state=state)
+        commits = self.get_commits(repo_url)
+        pairs: List[Tuple[Dict, Dict]] = []
+        for issue in issues:
+            number = issue.get("number")
+            if not number:
+                continue
+            token = f"#{number}"
+            for commit in commits:
+                message = commit.get("commit", {}).get("message", "")
+                if token in message:
+                    pairs.append((issue, commit))
+                    break
+        return pairs
+
+    def build_problem_solution_records(self, repo_url: str) -> List[Dict]:
+        """Return dataset records combining issues and closing commits."""
+        records = []
+        for issue, commit in self.get_issue_commit_pairs(repo_url):
+            problem = f"{issue.get('title', '')}\n\n{issue.get('body', '')}"
+            solution = commit.get("commit", {}).get("message", "")
+            records.append({"problem": problem, "solution": solution})
+        return records
+
 
 class Plugin(GitHubScraper):
     """Alias for plugin registry compatibility."""

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -50,3 +50,53 @@ def test_github_scraper(monkeypatch):
     assert issues == [{"title": "issue"}]
     commits = scraper.get_commits("https://github.com/user/repo")
     assert commits == [{"sha": "abc"}]
+
+
+def test_issue_commit_pairs(monkeypatch):
+    import importlib
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    github_scraper = importlib.import_module("plugins.github_scraper")
+    import requests
+
+    class DummyResp:
+        def __init__(self, data=None):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/issues"):
+            return DummyResp(
+                data=[
+                    {"number": 1, "title": "Bug", "body": "Fix bug"},
+                    {"number": 2, "title": "Feature", "body": "Add feature"},
+                ]
+            )
+        if url.endswith("/commits"):
+            return DummyResp(
+                data=[
+                    {"commit": {"message": "Fix bug\n\nCloses #1"}},
+                    {"commit": {"message": "Add feature #2"}},
+                ]
+            )
+        return DummyResp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    scraper = github_scraper.GitHubScraper()
+    pairs = scraper.get_issue_commit_pairs("https://github.com/user/repo")
+    assert len(pairs) == 2
+    records = scraper.build_problem_solution_records("https://github.com/user/repo")
+    assert records == [
+        {"problem": "Bug\n\nFix bug", "solution": "Fix bug\n\nCloses #1"},
+        {"problem": "Feature\n\nAdd feature", "solution": "Add feature #2"},
+    ]

--- a/utils/code.py
+++ b/utils/code.py
@@ -14,14 +14,17 @@ def remove_comments(code: str, language: str) -> str:
     patterns = []
     lang = language.lower()
     if lang in {"python", "py"}:
-        patterns = [r"#.*", r'""".*?"""', r"'''(.|\n)*?'''"]
+        patterns = [r"#.*$", r'""".*?"""', r"'''(.|\n)*?'''"]
     elif lang in {"javascript", "js", "java", "c", "cpp", "go", "php", "rust"}:
         patterns = [r"//.*", r"/\*.*?\*/"]
     else:
         patterns = [r"#.*", r"//.*", r"/\*.*?\*/"]
     text = code
     for pat in patterns:
-        text = re.sub(pat, "", text, flags=re.DOTALL)
+        flags = re.DOTALL
+        if pat == r"#.*$":
+            flags = re.MULTILINE
+        text = re.sub(pat, "", text, flags=flags)
     lines = [line for line in text.splitlines() if line.strip()]
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- enhance `GitHubScraper` with issue/commit pairing and record building
- ensure comment stripping in `utils.code.remove_comments` keeps lines
- test GitHub issue/commit extraction

## Testing
- `pip install -q -r /tmp/req.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585a2dca688320bcd97fb6f28815de