### PR TITLE
Add async worker and Redis queue backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Controle o número de threads e processos utilizados pelo scraper com as opçõe
 `--max-threads` e `--max-processes`. Esses valores também podem ser definidos
 pelas variáveis de ambiente `MAX_THREADS` e `MAX_PROCESSES`.
 
+Para limitar o número de tarefas executadas em paralelo pelo worker assíncrono
+defina `WORKER_CONCURRENCY` (padrão `5`). O número máximo de requisições HTTP
+em andamento continua controlado por `MAX_CONCURRENT_REQUESTS`.
+
 Para acelerar a coleta também é possível ativar o modo assíncrono com `--async`,
 que realiza múltiplas requisições HTTP em paralelo respeitando o limite definido
 por `MAX_CONCURRENT_REQUESTS`.
@@ -289,9 +293,13 @@ Esses valores podem ser consultados por Prometheus e visualizados em dashboards 
 
 ## Filas e Workers
 
-O módulo `task_queue.py` abstrai o uso de backends como RabbitMQ. Execute `worker.py`
-em contêiner separado para processar as tarefas enviadas por
-`DatasetBuilder.build_from_pages(use_queue=True)`.
+O módulo `task_queue.py` abstrai o uso de backends de fila. Utilize `QUEUE_URL`
+para apontar para instâncias `redis://` ou `amqp://` (RabbitMQ). Execute
+`worker.py` ou `worker.py --async` em contêiner separado para processar as
+tarefas enviadas por `DatasetBuilder.build_from_pages(use_queue=True)`.
+
+O nível de paralelismo do worker assíncrono é controlado por
+`WORKER_CONCURRENCY`.
 
 Um `Dockerfile.worker` está disponível para criar a imagem do worker e a pasta
 contém o exemplo `cluster.yaml` para configuração de múltiplos nós com Dask ou

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ streamlit>=1.46.0
 psutil>=7.0.0
 typer>=0.16.0
 pika>=1.3.2
+redis>=5.0.0
 prometheus-client>=0.20.0
 networkx>=3.5
 simhash>=2.1.2

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -105,6 +105,7 @@ class Config:
     MAX_THREADS = int(os.environ.get("MAX_THREADS", multiprocessing.cpu_count() * 2))
     MAX_PROCESSES = int(os.environ.get("MAX_PROCESSES", multiprocessing.cpu_count()))
     MAX_CONCURRENT_REQUESTS = int(os.environ.get("MAX_CONCURRENT_REQUESTS", "5"))
+    WORKER_CONCURRENCY = int(os.environ.get("WORKER_CONCURRENCY", "5"))
     RETRIES = 5
     TIMEOUT = 10
     RATE_LIMIT_DELAY = float(os.environ.get("RATE_LIMIT_DELAY", 0.5))

--- a/task_queue.py
+++ b/task_queue.py
@@ -4,16 +4,24 @@ from queue import Queue as _Queue
 
 try:
     import pika
-except Exception:
+except Exception:  # pragma: no cover - optional dependency
     pika = None
+
+try:
+    import redis
+except Exception:  # pragma: no cover - optional dependency
+    redis = None
+
 
 class BaseQueue:
     """Abstract queue backend."""
+
     def publish(self, queue: str, message: dict):
         raise NotImplementedError
 
     def consume(self, queue: str):
         raise NotImplementedError
+
 
 class InMemoryQueue(BaseQueue):
     def __init__(self):
@@ -32,6 +40,7 @@ class InMemoryQueue(BaseQueue):
             yield json.loads(msg)
             q.task_done()
 
+
 class RabbitMQQueue(BaseQueue):
     def __init__(self, url: str):
         if pika is None:
@@ -42,7 +51,7 @@ class RabbitMQQueue(BaseQueue):
     def publish(self, queue: str, message: dict):
         self.channel.queue_declare(queue=queue, durable=True)
         body = json.dumps(message).encode()
-        self.channel.basic_publish(exchange='', routing_key=queue, body=body)
+        self.channel.basic_publish(exchange="", routing_key=queue, body=body)
 
     def consume(self, queue: str):
         self.channel.queue_declare(queue=queue, durable=True)
@@ -51,15 +60,40 @@ class RabbitMQQueue(BaseQueue):
                 self.channel.basic_ack(method.delivery_tag)
                 yield json.loads(body.decode())
 
+
+class RedisQueue(BaseQueue):
+    """Queue backend using Redis lists."""
+
+    def __init__(self, url: str):
+        if redis is None:
+            raise RuntimeError("redis not installed")
+        self.client = redis.from_url(url)
+
+    def publish(self, queue: str, message: dict):
+        self.client.rpush(queue, json.dumps(message))
+
+    def consume(self, queue: str):
+        while True:
+            item = self.client.blpop(queue, timeout=1)
+            if item:
+                yield json.loads(item[1])
+
+
 _BACKEND = None
+
 
 def get_backend() -> BaseQueue:
     global _BACKEND
     if _BACKEND is not None:
         return _BACKEND
-    url = os.environ.get('QUEUE_URL')
-    if url and pika:
-        _BACKEND = RabbitMQQueue(url)
+    url = os.environ.get("QUEUE_URL")
+    if url:
+        if url.startswith("redis") and redis:
+            _BACKEND = RedisQueue(url)
+        elif pika:
+            _BACKEND = RabbitMQQueue(url)
+        else:
+            raise RuntimeError("No supported queue backend available")
     else:
         _BACKEND = InMemoryQueue()
     return _BACKEND

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -10,61 +10,77 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 # Stub heavy dependencies to avoid installation
-sys.modules['sentence_transformers'] = SimpleNamespace(SentenceTransformer=object)
-sys.modules.setdefault('datasets', SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None))
-sys.modules.setdefault('spacy', SimpleNamespace(load=lambda *a, **k: None))
-sys.modules.setdefault('unidecode', SimpleNamespace(unidecode=lambda x: x))
-sys.modules.setdefault('tqdm', SimpleNamespace(tqdm=lambda x, **k: x))
-sys.modules.setdefault('html2text', SimpleNamespace())
-wiki_mod = ModuleType('wikipediaapi')
+sys.modules["sentence_transformers"] = SimpleNamespace(SentenceTransformer=object)
+sys.modules.setdefault(
+    "datasets",
+    SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None),
+)
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault("unidecode", SimpleNamespace(unidecode=lambda x: x))
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault("html2text", SimpleNamespace())
+wiki_mod = ModuleType("wikipediaapi")
 wiki_mod.WikipediaException = Exception
 wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
 wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
 wiki_mod.WikipediaPage = object
-wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
-sys.modules.setdefault('wikipediaapi', wiki_mod)
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(
+    page=lambda *a, **k: SimpleNamespace(exists=lambda: False),
+    api=SimpleNamespace(article_url=lambda x: ""),
+)
+sys.modules.setdefault("wikipediaapi", wiki_mod)
 aiohttp_stub = SimpleNamespace(
     ClientSession=object,
     ClientTimeout=lambda *a, **k: None,
     ClientError=Exception,
     ClientResponseError=Exception,
 )
-sys.modules.setdefault('aiohttp', aiohttp_stub)
-sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
-sklearn_mod = ModuleType('sklearn')
+sys.modules.setdefault("aiohttp", aiohttp_stub)
+sys.modules.setdefault(
+    "backoff",
+    SimpleNamespace(
+        on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None
+    ),
+)
+sklearn_mod = ModuleType("sklearn")
 sklearn_mod.cluster = SimpleNamespace(KMeans=object)
-sklearn_mod.feature_extraction = SimpleNamespace(text=SimpleNamespace(TfidfVectorizer=object))
-sys.modules.setdefault('sklearn', sklearn_mod)
-sys.modules.setdefault('sklearn.cluster', sklearn_mod.cluster)
-sys.modules.setdefault('sklearn.feature_extraction', sklearn_mod.feature_extraction)
-sys.modules.setdefault('sklearn.feature_extraction.text', sklearn_mod.feature_extraction.text)
-sumy_mod = ModuleType('sumy')
-parsers_mod = ModuleType('sumy.parsers')
-plaintext_mod = ModuleType('sumy.parsers.plaintext')
+sklearn_mod.feature_extraction = SimpleNamespace(
+    text=SimpleNamespace(TfidfVectorizer=object)
+)
+sys.modules.setdefault("sklearn", sklearn_mod)
+sys.modules.setdefault("sklearn.cluster", sklearn_mod.cluster)
+sys.modules.setdefault("sklearn.feature_extraction", sklearn_mod.feature_extraction)
+sys.modules.setdefault(
+    "sklearn.feature_extraction.text", sklearn_mod.feature_extraction.text
+)
+sumy_mod = ModuleType("sumy")
+parsers_mod = ModuleType("sumy.parsers")
+plaintext_mod = ModuleType("sumy.parsers.plaintext")
 plaintext_mod.PlaintextParser = object
 parsers_mod.plaintext = plaintext_mod
-nlp_mod = ModuleType('sumy.nlp')
-tokenizers_mod = ModuleType('sumy.nlp.tokenizers')
+nlp_mod = ModuleType("sumy.nlp")
+tokenizers_mod = ModuleType("sumy.nlp.tokenizers")
 tokenizers_mod.Tokenizer = object
 nlp_mod.tokenizers = tokenizers_mod
-summarizers_mod = ModuleType('sumy.summarizers')
-lsa_mod = ModuleType('sumy.summarizers.lsa')
+summarizers_mod = ModuleType("sumy.summarizers")
+lsa_mod = ModuleType("sumy.summarizers.lsa")
 lsa_mod.LsaSummarizer = object
 summarizers_mod.lsa = lsa_mod
 sumy_mod.parsers = parsers_mod
 sumy_mod.nlp = nlp_mod
 sumy_mod.summarizers = summarizers_mod
-sys.modules.setdefault('sumy', sumy_mod)
-sys.modules.setdefault('sumy.parsers', parsers_mod)
-sys.modules.setdefault('sumy.parsers.plaintext', plaintext_mod)
-sys.modules.setdefault('sumy.nlp', nlp_mod)
-sys.modules.setdefault('sumy.nlp.tokenizers', tokenizers_mod)
-sys.modules.setdefault('sumy.summarizers', summarizers_mod)
-sys.modules.setdefault('sumy.summarizers.lsa', lsa_mod)
+sys.modules.setdefault("sumy", sumy_mod)
+sys.modules.setdefault("sumy.parsers", parsers_mod)
+sys.modules.setdefault("sumy.parsers.plaintext", plaintext_mod)
+sys.modules.setdefault("sumy.nlp", nlp_mod)
+sys.modules.setdefault("sumy.nlp.tokenizers", tokenizers_mod)
+sys.modules.setdefault("sumy.summarizers", summarizers_mod)
+sys.modules.setdefault("sumy.summarizers.lsa", lsa_mod)
 
 # Provide missing attribute in wikipediaapi
 import wikipediaapi
-if not hasattr(wikipediaapi, 'WikipediaException'):
+
+if not hasattr(wikipediaapi, "WikipediaException"):
     wikipediaapi.WikipediaException = Exception
 
 import scraper_wiki as sw
@@ -79,66 +95,78 @@ def tmp_log_dir(tmp_path, monkeypatch):
 class DummyEmbed:
     def encode(self, *args, **kwargs):
         import numpy as np
+
         return np.zeros((len(args[0]) if args else 1, 3))
 
 
 sw.NLPProcessor.get_embedding_model = classmethod(lambda cls: DummyEmbed())
 
+
 class DummyNLP:
     def __call__(self, text):
         class Doc:
-            noun_chunks = [SimpleNamespace(text='Python')]
+            noun_chunks = [SimpleNamespace(text="Python")]
             ents = []
             sents = []
+
         return Doc()
+
 
 sw.NLPProcessor.get_instance = classmethod(lambda cls, lang: DummyNLP())
 
 
 def test_translate_question_pt():
     qb = sw.DatasetBuilder()
-    question = qb._translate_question('What is Python?', 'pt')
-    assert 'O que é' in question
+    question = qb._translate_question("What is Python?", "pt")
+    assert "O que é" in question
+
 
 def test_translate_question_es():
     qb = sw.DatasetBuilder()
-    question = qb._translate_question('How does Python relate to programacion?', 'es')
-    assert 'Cómo' in question and 'se relaciona con' in question
+    question = qb._translate_question("How does Python relate to programacion?", "es")
+    assert "Cómo" in question and "se relaciona con" in question
+
 
 def test_translate_question_fr():
     qb = sw.DatasetBuilder()
-    question = qb._translate_question('How does Python relate to programmation?', 'fr')
-    assert 'Comment' in question and 'se rapporte à' in question
+    question = qb._translate_question("How does Python relate to programmation?", "fr")
+    assert "Comment" in question and "se rapporte à" in question
+
 
 def test_classify_topic_ai_nlp():
     qb = sw.DatasetBuilder()
-    topic, sub = qb._classify_topic('Deep Learning', 'O processamento de linguagem natural evoluiu', 'pt')
-    assert topic == 'ai'
-    assert sub == 'nlp'
+    topic, sub = qb._classify_topic(
+        "Deep Learning", "O processamento de linguagem natural evoluiu", "pt"
+    )
+    assert topic == "ai"
+    assert sub == "nlp"
 
 
 def test_generate_qa_pairs_accepts_extra_metadata(monkeypatch):
     qb = sw.DatasetBuilder()
-    monkeypatch.setattr(qb, '_generate_questions', lambda *a, **k: [])
-    monkeypatch.setattr(qb, '_generate_answers', lambda *a, **k: [])
-    monkeypatch.setattr(sw, 'extract_relations', lambda *a, **k: [])
+    monkeypatch.setattr(qb, "_generate_questions", lambda *a, **k: [])
+    monkeypatch.setattr(qb, "_generate_answers", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
     import numpy as np
-    monkeypatch.setattr(qb.embedding_model, 'encode', lambda *a, **k: np.array([0.0]))
+
+    monkeypatch.setattr(qb.embedding_model, "encode", lambda *a, **k: np.array([0.0]))
     result = qb.generate_qa_pairs(
-        title='T',
-        content='content',
-        summary='sum',
-        lang='en',
-        category='c',
-        extra_metadata={'wikidata_id': 'Q1', 'image_url': 'img'},
+        title="T",
+        content="content",
+        summary="sum",
+        lang="en",
+        category="c",
+        extra_metadata={"wikidata_id": "Q1", "image_url": "img"},
     )
-    assert result['wikidata_id'] == 'Q1'
-    assert result['image_url'] == 'img'
+    assert result["wikidata_id"] == "Q1"
+    assert result["image_url"] == "img"
+
 
 def test_advanced_clean_text_removes_html():
-    raw = '<div>Example</div>\n[[1]]\n== Referências ==\nTexto'
-    cleaned = sw.advanced_clean_text(raw, 'pt')
-    assert '<div>' not in cleaned and 'Referências' not in cleaned
+    raw = "<div>Example</div>\n[[1]]\n== Referências ==\nTexto"
+    cleaned = sw.advanced_clean_text(raw, "pt")
+    assert "<div>" not in cleaned and "Referências" not in cleaned
+
 
 def test_advanced_clean_text_remove_stopwords(monkeypatch):
     class DummyTok:
@@ -149,18 +177,22 @@ def test_advanced_clean_text_remove_stopwords(monkeypatch):
     class DummyNLPStop:
         def __call__(self, text):
             return [
-                DummyTok(tok, tok.lower() in {'the', 'and'})
-                for tok in text.split()
+                DummyTok(tok, tok.lower() in {"the", "and"}) for tok in text.split()
             ]
 
-    monkeypatch.setattr(sw.NLPProcessor, 'get_instance', classmethod(lambda cls, lang: DummyNLPStop()))
-    cleaned = sw.advanced_clean_text('the quick and brown fox', 'en', remove_stopwords=True)
-    assert cleaned == 'quick brown fox'
+    monkeypatch.setattr(
+        sw.NLPProcessor, "get_instance", classmethod(lambda cls, lang: DummyNLPStop())
+    )
+    cleaned = sw.advanced_clean_text(
+        "the quick and brown fox", "en", remove_stopwords=True
+    )
+    assert cleaned == "quick brown fox"
+
 
 def test_extract_main_content():
     html = '<html><body><div id="mw-content-text">content</div><table></table></body></html>'
     result = sw.extract_main_content(html)
-    assert 'content' in result and 'table' not in result
+    assert "content" in result and "table" not in result
 
 
 def test_extract_links_basic():
@@ -170,11 +202,11 @@ def test_extract_links_basic():
         '<a href="/other/Page3">P3</a>'
         '<a href="/wiki/Page4">P4</a>'
     )
-    base = sw.get_base_url('en')
+    base = sw.get_base_url("en")
     links = sw.extract_links(html, base)
     assert links == [
         f"{sw.get_base_url('en')}/wiki/Page1",
-        'https://example.com/wiki/Page2',
+        "https://example.com/wiki/Page2",
         f"{sw.get_base_url('en')}/wiki/Page4",
     ]
 
@@ -184,22 +216,22 @@ def test_get_links_from_category_page(monkeypatch):
     called = {}
 
     def fake_fetch(title, lang):
-        called['args'] = (title, lang)
+        called["args"] = (title, lang)
         return sample_html
 
-    monkeypatch.setattr(sw, 'fetch_html_content', fake_fetch)
-    wiki = sw.WikipediaAdvanced('en')
-    links = wiki.get_links_from_category_page('Test')
+    monkeypatch.setattr(sw, "fetch_html_content", fake_fetch)
+    wiki = sw.WikipediaAdvanced("en")
+    links = wiki.get_links_from_category_page("Test")
 
-    assert called['args'] == ('Category:Test', 'en')
+    assert called["args"] == ("Category:Test", "en")
     assert links == [f"{sw.get_base_url('en')}/wiki/Page"]
 
 
 def test_crawl_links_basic(monkeypatch):
     mapping = {
-        'Start': ['P1', 'P2'],
-        'P1': ['P3'],
-        'P2': ['P4'],
+        "Start": ["P1", "P2"],
+        "P1": ["P3"],
+        "P2": ["P4"],
     }
 
     def fake_fetch(title, lang):
@@ -208,24 +240,48 @@ def test_crawl_links_basic(monkeypatch):
     def fake_extract(html, base):
         return [f"{base}/wiki/{p}" for p in mapping.get(html, [])]
 
-    monkeypatch.setattr(sw, 'fetch_html_content', fake_fetch)
-    monkeypatch.setattr(sw, 'extract_links', fake_extract)
+    monkeypatch.setattr(sw, "fetch_html_content", fake_fetch)
+    monkeypatch.setattr(sw, "extract_links", fake_extract)
 
-    wiki = sw.WikipediaAdvanced('en')
-    result = wiki.crawl_links('Start', depth=1)
-    base = sw.get_base_url('en')
+    wiki = sw.WikipediaAdvanced("en")
+    result = wiki.crawl_links("Start", depth=1)
+    base = sw.get_base_url("en")
     assert result == [
-        {'title': 'P1', 'url': f'{base}/wiki/P1', 'lang': 'en', 'category': 'Start', 'depth': 0},
-        {'title': 'P2', 'url': f'{base}/wiki/P2', 'lang': 'en', 'category': 'Start', 'depth': 0},
-        {'title': 'P3', 'url': f'{base}/wiki/P3', 'lang': 'en', 'category': 'Start', 'depth': 1},
-        {'title': 'P4', 'url': f'{base}/wiki/P4', 'lang': 'en', 'category': 'Start', 'depth': 1},
+        {
+            "title": "P1",
+            "url": f"{base}/wiki/P1",
+            "lang": "en",
+            "category": "Start",
+            "depth": 0,
+        },
+        {
+            "title": "P2",
+            "url": f"{base}/wiki/P2",
+            "lang": "en",
+            "category": "Start",
+            "depth": 0,
+        },
+        {
+            "title": "P3",
+            "url": f"{base}/wiki/P3",
+            "lang": "en",
+            "category": "Start",
+            "depth": 1,
+        },
+        {
+            "title": "P4",
+            "url": f"{base}/wiki/P4",
+            "lang": "en",
+            "category": "Start",
+            "depth": 1,
+        },
     ]
 
 
 def test_crawl_links_async(monkeypatch):
     mapping = {
-        'Start': ['P1'],
-        'P1': ['P2'],
+        "Start": ["P1"],
+        "P1": ["P2"],
     }
 
     async def fake_fetch_async(title, lang):
@@ -234,21 +290,34 @@ def test_crawl_links_async(monkeypatch):
     def fake_extract(html, base):
         return [f"{base}/wiki/{p}" for p in mapping.get(html, [])]
 
-    monkeypatch.setattr(sw, 'fetch_html_content_async', fake_fetch_async)
-    monkeypatch.setattr(sw, 'extract_links', fake_extract)
+    monkeypatch.setattr(sw, "fetch_html_content_async", fake_fetch_async)
+    monkeypatch.setattr(sw, "extract_links", fake_extract)
 
-    wiki = sw.WikipediaAdvanced('en')
+    wiki = sw.WikipediaAdvanced("en")
     import asyncio as aio
-    result = aio.run(wiki.crawl_links_async('Start', depth=1))
-    base = sw.get_base_url('en')
+
+    result = aio.run(wiki.crawl_links_async("Start", depth=1))
+    base = sw.get_base_url("en")
     assert result == [
-        {'title': 'P1', 'url': f'{base}/wiki/P1', 'lang': 'en', 'category': 'Start', 'depth': 0},
-        {'title': 'P2', 'url': f'{base}/wiki/P2', 'lang': 'en', 'category': 'Start', 'depth': 1},
+        {
+            "title": "P1",
+            "url": f"{base}/wiki/P1",
+            "lang": "en",
+            "category": "Start",
+            "depth": 0,
+        },
+        {
+            "title": "P2",
+            "url": f"{base}/wiki/P2",
+            "lang": "en",
+            "category": "Start",
+            "depth": 1,
+        },
     ]
 
 
 def test_crawl_links_respects_limit(monkeypatch):
-    mapping = {'A': ['B', 'C', 'D']}
+    mapping = {"A": ["B", "C", "D"]}
 
     def fake_fetch(title, lang):
         return title
@@ -256,12 +325,12 @@ def test_crawl_links_respects_limit(monkeypatch):
     def fake_extract(html, base):
         return [f"{base}/wiki/{p}" for p in mapping.get(html, [])]
 
-    monkeypatch.setattr(sw, 'fetch_html_content', fake_fetch)
-    monkeypatch.setattr(sw, 'extract_links', fake_extract)
-    monkeypatch.setattr(sw.Config, 'MAX_PAGES_PER_CATEGORY', 2)
+    monkeypatch.setattr(sw, "fetch_html_content", fake_fetch)
+    monkeypatch.setattr(sw, "extract_links", fake_extract)
+    monkeypatch.setattr(sw.Config, "MAX_PAGES_PER_CATEGORY", 2)
 
-    wiki = sw.WikipediaAdvanced('en')
-    result = wiki.crawl_links('A')
+    wiki = sw.WikipediaAdvanced("en")
+    result = wiki.crawl_links("A")
     assert len(result) == 2
 
 
@@ -277,58 +346,64 @@ def test_nlp_triple_fallback(monkeypatch):
     def fake_load(name, *args, **kwargs):
         calls.append(name)
         if len(calls) < 3:
-            raise OSError('missing')
+            raise OSError("missing")
         return DummyNLP()
 
-    monkeypatch.setattr(sw_reloaded.spacy, 'load', fake_load)
+    monkeypatch.setattr(sw_reloaded.spacy, "load", fake_load)
 
-    nlp = sw_reloaded.NLPProcessor.get_instance('pt')
+    nlp = sw_reloaded.NLPProcessor.get_instance("pt")
     assert isinstance(nlp, DummyNLP)
-    assert calls == ['pt_core_news_lg', 'pt_core_news_sm', 'en_core_web_sm']
+    assert calls == ["pt_core_news_lg", "pt_core_news_sm", "en_core_web_sm"]
 
 
 def test_fetch_html_content_success(monkeypatch):
     class DummyResp:
         def __init__(self):
-            self.text = '<html></html>'
+            self.text = "<html></html>"
+
         def raise_for_status(self):
             pass
 
     async def fake_fetch(url, headers=None, **kw):
-        return 200, '<html></html>'
+        return 200, "<html></html>"
 
     async def fake_sleep(d):
         pass
 
-    monkeypatch.setattr(sw, 'fetch_with_retry', fake_fetch)
-    monkeypatch.setattr(sw.asyncio, 'sleep', fake_sleep)
-    result = sw.fetch_html_content('Any', 'en')
-    assert result == '<html></html>'
+    monkeypatch.setattr(sw, "fetch_with_retry", fake_fetch)
+    monkeypatch.setattr(sw.asyncio, "sleep", fake_sleep)
+    result = sw.fetch_html_content("Any", "en")
+    assert result == "<html></html>"
 
 
 def test_fetch_html_content_error(monkeypatch):
     fake_cache = {}
-    monkeypatch.setattr(sw, 'cache', SimpleNamespace(
-        get=lambda k: fake_cache.get(k),
-        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
-        stats=lambda: {}
-    ))
+    monkeypatch.setattr(
+        sw,
+        "cache",
+        SimpleNamespace(
+            get=lambda k: fake_cache.get(k),
+            set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+            stats=lambda: {},
+        ),
+    )
 
     async def fake_fetch(*a, **k):
-        raise Exception('fail')
+        raise Exception("fail")
 
     async def fake_sleep(d):
         pass
 
-    monkeypatch.setattr(sw, 'fetch_with_retry', fake_fetch)
-    monkeypatch.setattr(sw.asyncio, 'sleep', fake_sleep)
-    result = sw.fetch_html_content('Any', 'en')
-    assert result == ''
+    monkeypatch.setattr(sw, "fetch_with_retry", fake_fetch)
+    monkeypatch.setattr(sw.asyncio, "sleep", fake_sleep)
+    result = sw.fetch_html_content("Any", "en")
+    assert result == ""
 
 
 class DummyFuture:
     def __init__(self, value):
         self._value = value
+
     def result(self):
         return self._value
 
@@ -336,158 +411,181 @@ class DummyFuture:
 class DummyExecutor:
     def __init__(self, *a, **k):
         pass
+
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         pass
+
     def submit(self, fn, *args, **kwargs):
         return DummyFuture(fn(*args, **kwargs))
 
 
 def test_build_from_pages(monkeypatch):
     dummy_data = {
-        'id': '1',
-        'content_embedding': [0.0],
-        'summary_embedding': [0.0],
-        'questions': ['q'],
-        'answers': ['a'],
-        'summary': 'text text text',
-        'wikidata_id': 'Q1',
-        'image_url': 'img',
+        "id": "1",
+        "content_embedding": [0.0],
+        "summary_embedding": [0.0],
+        "questions": ["q"],
+        "answers": ["a"],
+        "summary": "text text text",
+        "wikidata_id": "Q1",
+        "image_url": "img",
     }
+
     def fake_process_page(self, page, proc_executor=None):
         return DummyFuture(dummy_data)
 
-    monkeypatch.setattr(sw.DatasetBuilder, 'process_page', fake_process_page)
-    monkeypatch.setattr(sw, 'ThreadPoolExecutor', DummyExecutor)
-    monkeypatch.setattr(sw, 'ProcessPoolExecutor', DummyExecutor)
-    monkeypatch.setattr(sw, 'as_completed', lambda it: it)
-    monkeypatch.setattr(sw, 'tqdm', lambda it, **k: it)
+    monkeypatch.setattr(sw.DatasetBuilder, "process_page", fake_process_page)
+    monkeypatch.setattr(sw, "ThreadPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(sw, "ProcessPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(sw, "as_completed", lambda it: it)
+    monkeypatch.setattr(sw, "tqdm", lambda it, **k: it)
 
     builder = sw.DatasetBuilder()
-    pages = [{'title': 't', 'lang': 'en'}]
+    pages = [{"title": "t", "lang": "en"}]
     data = builder.build_from_pages(pages)
     assert data == [dummy_data]
-    assert data[0]['wikidata_id'] == 'Q1'
-    assert data[0]['image_url'] == 'img'
+    assert data[0]["wikidata_id"] == "Q1"
+    assert data[0]["image_url"] == "img"
 
 
 def test_build_from_pages_async(monkeypatch):
     dummy_data = {
-        'id': '1',
-        'content_embedding': [0.0],
-        'summary_embedding': [0.0],
-        'questions': ['q'],
-        'answers': ['a'],
-        'summary': 'text text text',
-        'wikidata_id': 'Q1',
-        'image_url': 'img'
+        "id": "1",
+        "content_embedding": [0.0],
+        "summary_embedding": [0.0],
+        "questions": ["q"],
+        "answers": ["a"],
+        "summary": "text text text",
+        "wikidata_id": "Q1",
+        "image_url": "img",
     }
 
     async def fake_process_page_async(self, page, proc_executor=None):
         return DummyFuture(dummy_data)
 
-    monkeypatch.setattr(sw.DatasetBuilder, 'process_page_async', fake_process_page_async)
-    monkeypatch.setattr(sw, 'ProcessPoolExecutor', DummyExecutor)
-    monkeypatch.setattr(sw, 'as_completed', lambda it: it)
-    monkeypatch.setattr(sw, 'tqdm', lambda it, **k: it)
+    monkeypatch.setattr(
+        sw.DatasetBuilder, "process_page_async", fake_process_page_async
+    )
+    monkeypatch.setattr(sw, "ProcessPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(sw, "as_completed", lambda it: it)
+    monkeypatch.setattr(sw, "tqdm", lambda it, **k: it)
 
     builder = sw.DatasetBuilder()
-    pages = [{'title': 't', 'lang': 'en'}]
+    pages = [{"title": "t", "lang": "en"}]
     import asyncio as aio
+
     data = aio.run(builder.build_from_pages_async(pages))
     assert data == [dummy_data]
-    assert data[0]['wikidata_id'] == 'Q1'
-    assert data[0]['image_url'] == 'img'
+    assert data[0]["wikidata_id"] == "Q1"
+    assert data[0]["image_url"] == "img"
 
 
 def test_process_page_uses_clean_text(monkeypatch):
     class DummyPage:
-        text = 'raw text'
+        text = "raw text"
+
         def exists(self):
             return True
 
     class DummyWiki:
         def __init__(self, lang):
             pass
+
         def fetch_page(self, title):
             return DummyPage()
 
     called = {}
 
     def fake_clean(text):
-        called['clean'] = text
-        return 'cleaned'
+        called["clean"] = text
+        return "cleaned"
 
     def fake_adv(text, lang, remove_stopwords=False):
-        called['adv'] = (text, lang, remove_stopwords)
-        return 'x' * 151
+        called["adv"] = (text, lang, remove_stopwords)
+        return "x" * 151
 
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'clean_text', fake_clean)
-    monkeypatch.setattr(sw, 'advanced_clean_text', fake_adv)
-    monkeypatch.setattr(sw.Config, 'REMOVE_STOPWORDS', True)
-    monkeypatch.setattr(sw, 'summarize_text', lambda *a, **k: '')
-    monkeypatch.setattr(sw.DatasetBuilder, 'generate_qa_pairs', lambda *a, **k: {})
-    monkeypatch.setattr(sw, 'extract_entities', lambda text: [])
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_success=SimpleNamespace(inc=lambda: None),
-        scrape_error=SimpleNamespace(inc=lambda: None),
-        pages_scraped_total=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-        page_processing_seconds=SimpleNamespace(observe=lambda v: None),
-    ))
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "clean_text", fake_clean)
+    monkeypatch.setattr(sw, "advanced_clean_text", fake_adv)
+    monkeypatch.setattr(sw.Config, "REMOVE_STOPWORDS", True)
+    monkeypatch.setattr(sw, "summarize_text", lambda *a, **k: "")
+    monkeypatch.setattr(sw.DatasetBuilder, "generate_qa_pairs", lambda *a, **k: {})
+    monkeypatch.setattr(sw, "extract_entities", lambda text: [])
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_success=SimpleNamespace(inc=lambda: None),
+            scrape_error=SimpleNamespace(inc=lambda: None),
+            pages_scraped_total=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            page_processing_seconds=SimpleNamespace(observe=lambda v: None),
+        ),
+    )
 
     builder = sw.DatasetBuilder()
-    res = builder.process_page({'title': 'T', 'lang': 'en'})
+    res = builder.process_page({"title": "T", "lang": "en"})
 
-    assert res == {'entities': [], 'images': []}
-    assert called['clean'] == 'raw text'
-    assert called['adv'] == ('cleaned', 'en', True)
+    assert res == {"entities": [], "images": []}
+    assert called["clean"] == "raw text"
+    assert called["adv"] == ("cleaned", "en", True)
 
 
 def test_process_page_increments_counter(monkeypatch):
     class DummyPage:
-        text = 't' * 200
+        text = "t" * 200
+
         def exists(self):
             return True
 
     class DummyWiki:
         def __init__(self, lang):
             pass
+
         def fetch_page(self, title):
             return DummyPage()
 
-    counts = {'pages': 0}
+    counts = {"pages": 0}
 
     def inc_pages():
-        counts['pages'] += 1
+        counts["pages"] += 1
 
-    monkeypatch.setattr(sw.Config, 'MIN_TEXT_LENGTH', 10)
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'clean_text', lambda t: t)
-    monkeypatch.setattr(sw, 'advanced_clean_text', lambda t, lang, remove_stopwords=False: t)
-    monkeypatch.setattr(sw, 'summarize_text', lambda *a, **k: '')
-    monkeypatch.setattr(sw.DatasetBuilder, 'generate_qa_pairs', lambda *a, **k: {'ok': True})
-    monkeypatch.setattr(sw, 'extract_entities', lambda text: [])
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_success=SimpleNamespace(inc=lambda: None),
-        scrape_error=SimpleNamespace(inc=lambda: None),
-        pages_scraped_total=SimpleNamespace(inc=inc_pages),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-        page_processing_seconds=SimpleNamespace(observe=lambda v: None),
-    ))
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 10)
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "clean_text", lambda t: t)
+    monkeypatch.setattr(
+        sw, "advanced_clean_text", lambda t, lang, remove_stopwords=False: t
+    )
+    monkeypatch.setattr(sw, "summarize_text", lambda *a, **k: "")
+    monkeypatch.setattr(
+        sw.DatasetBuilder, "generate_qa_pairs", lambda *a, **k: {"ok": True}
+    )
+    monkeypatch.setattr(sw, "extract_entities", lambda text: [])
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_success=SimpleNamespace(inc=lambda: None),
+            scrape_error=SimpleNamespace(inc=lambda: None),
+            pages_scraped_total=SimpleNamespace(inc=inc_pages),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            page_processing_seconds=SimpleNamespace(observe=lambda v: None),
+        ),
+    )
 
     builder = sw.DatasetBuilder()
-    res = builder.process_page({'title': 'T', 'lang': 'en'})
+    res = builder.process_page({"title": "T", "lang": "en"})
 
-    assert res == {'ok': True, 'entities': [], 'images': []}
-    assert counts['pages'] == 1
+    assert res == {"ok": True, "entities": [], "images": []}
+    assert counts["pages"] == 1
 
 
 def test_process_page_records_histogram(monkeypatch):
     class DummyPage:
-        text = 't' * 200
+        text = "t" * 200
 
         def exists(self):
             return True
@@ -499,129 +597,143 @@ def test_process_page_records_histogram(monkeypatch):
         def fetch_page(self, title):
             return DummyPage()
 
-    observed = {'count': 0}
+    observed = {"count": 0}
 
     def observe(v):
-        observed['count'] += 1
+        observed["count"] += 1
 
-    monkeypatch.setattr(sw.Config, 'MIN_TEXT_LENGTH', 10)
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'clean_text', lambda t: t)
-    monkeypatch.setattr(sw, 'advanced_clean_text', lambda t, lang, remove_stopwords=False: t)
-    monkeypatch.setattr(sw, 'summarize_text', lambda *a, **k: '')
-    monkeypatch.setattr(sw.DatasetBuilder, 'generate_qa_pairs', lambda *a, **k: {'ok': True})
-    monkeypatch.setattr(sw, 'extract_entities', lambda text: [])
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_success=SimpleNamespace(inc=lambda: None),
-        scrape_error=SimpleNamespace(inc=lambda: None),
-        pages_scraped_total=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-        page_processing_seconds=SimpleNamespace(observe=observe),
-    ))
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 10)
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "clean_text", lambda t: t)
+    monkeypatch.setattr(
+        sw, "advanced_clean_text", lambda t, lang, remove_stopwords=False: t
+    )
+    monkeypatch.setattr(sw, "summarize_text", lambda *a, **k: "")
+    monkeypatch.setattr(
+        sw.DatasetBuilder, "generate_qa_pairs", lambda *a, **k: {"ok": True}
+    )
+    monkeypatch.setattr(sw, "extract_entities", lambda text: [])
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_success=SimpleNamespace(inc=lambda: None),
+            scrape_error=SimpleNamespace(inc=lambda: None),
+            pages_scraped_total=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            page_processing_seconds=SimpleNamespace(observe=observe),
+        ),
+    )
 
     builder = sw.DatasetBuilder()
-    res = builder.process_page({'title': 'T', 'lang': 'en'})
+    res = builder.process_page({"title": "T", "lang": "en"})
 
-    assert res == {'ok': True, 'entities': [], 'images': []}
-    assert observed['count'] == 1
+    assert res == {"ok": True, "entities": [], "images": []}
+    assert observed["count"] == 1
 
 
 def test_save_dataset_json_csv(tmp_path, monkeypatch):
     builder = sw.DatasetBuilder()
-    monkeypatch.setattr(sw.Config, 'MIN_TEXT_LENGTH', 5)
-    builder.dataset = [{
-        'id': '1',
-        'title': 't',
-        'language': 'en',
-        'category': 'c',
-        'topic': 'ai',
-        'subtopic': 'nlp',
-        'keywords': [],
-        'content': 'c'*20,
-        'summary': 's'*20,
-        'content_embedding': [0.1, 0.2],
-        'summary_embedding': [0.1, 0.2],
-        'questions': ['q'],
-        'answers': ['a'],
-        'relations': [],
-        'created_at': 'now',
-        'metadata': {}
-    }]
-    builder.save_dataset('json', output_dir=tmp_path)
-    assert (tmp_path/'wikipedia_qa.json').exists()
-    info_file = tmp_path / 'dataset_info.json'
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 5)
+    builder.dataset = [
+        {
+            "id": "1",
+            "title": "t",
+            "language": "en",
+            "category": "c",
+            "topic": "ai",
+            "subtopic": "nlp",
+            "keywords": [],
+            "content": "c" * 20,
+            "summary": "s" * 20,
+            "content_embedding": [0.1, 0.2],
+            "summary_embedding": [0.1, 0.2],
+            "questions": ["q"],
+            "answers": ["a"],
+            "relations": [],
+            "created_at": "now",
+            "metadata": {},
+        }
+    ]
+    builder.save_dataset("json", output_dir=tmp_path)
+    assert (tmp_path / "wikipedia_qa.json").exists()
+    info_file = tmp_path / "dataset_info.json"
     assert info_file.exists()
-    info = json.loads(info_file.read_text(encoding='utf-8'))
-    assert set(['source', 'collection_date', 'license']).issubset(info)
-    builder.save_dataset('csv', output_dir=tmp_path)
-    assert (tmp_path/'wikipedia_qa.csv').exists()
+    info = json.loads(info_file.read_text(encoding="utf-8"))
+    assert set(["source", "collection_date", "license"]).issubset(info)
+    builder.save_dataset("csv", output_dir=tmp_path)
+    assert (tmp_path / "wikipedia_qa.csv").exists()
 
 
 def test_save_dataset_jsonl(tmp_path, monkeypatch):
     builder = sw.DatasetBuilder()
-    monkeypatch.setattr(sw.Config, 'MIN_TEXT_LENGTH', 5)
-    builder.dataset = [{
-        'id': '1',
-        'title': 't',
-        'language': 'en',
-        'category': 'c',
-        'topic': 'ai',
-        'subtopic': 'nlp',
-        'keywords': [],
-        'content': 'c'*20,
-        'summary': 's'*20,
-        'content_embedding': [0.1, 0.2],
-        'summary_embedding': [0.1, 0.2],
-        'questions': ['q'],
-        'answers': ['a'],
-        'relations': [],
-        'created_at': 'now',
-        'metadata': {}
-    }]
-    builder.save_dataset('jsonl', output_dir=tmp_path)
-    jsonl_file = tmp_path / 'wikipedia_qa.jsonl'
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 5)
+    builder.dataset = [
+        {
+            "id": "1",
+            "title": "t",
+            "language": "en",
+            "category": "c",
+            "topic": "ai",
+            "subtopic": "nlp",
+            "keywords": [],
+            "content": "c" * 20,
+            "summary": "s" * 20,
+            "content_embedding": [0.1, 0.2],
+            "summary_embedding": [0.1, 0.2],
+            "questions": ["q"],
+            "answers": ["a"],
+            "relations": [],
+            "created_at": "now",
+            "metadata": {},
+        }
+    ]
+    builder.save_dataset("jsonl", output_dir=tmp_path)
+    jsonl_file = tmp_path / "wikipedia_qa.jsonl"
     assert jsonl_file.exists()
-    content = jsonl_file.read_text(encoding='utf-8').strip().splitlines()
+    content = jsonl_file.read_text(encoding="utf-8").strip().splitlines()
     assert len(content) == 1
     record = json.loads(content[0])
-    assert record['id'] == '1'
+    assert record["id"] == "1"
 
 
 def test_save_dataset_qa_and_text(tmp_path, monkeypatch):
     builder = sw.DatasetBuilder()
-    monkeypatch.setattr(sw.Config, 'MIN_TEXT_LENGTH', 5)
-    builder.dataset = [{
-        'id': '1',
-        'title': 'T',
-        'language': 'en',
-        'category': 'c',
-        'topic': 'ai',
-        'subtopic': 'nlp',
-        'keywords': [],
-        'content': 'sample content '*2,
-        'summary': 'summary text',
-        'content_embedding': [0.1],
-        'summary_embedding': [0.1],
-        'questions': [{'text': 'q1'}],
-        'answers': [{'text': 'a1'}],
-        'relations': [],
-        'created_at': 'now',
-        'metadata': {}
-    }]
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 5)
+    builder.dataset = [
+        {
+            "id": "1",
+            "title": "T",
+            "language": "en",
+            "category": "c",
+            "topic": "ai",
+            "subtopic": "nlp",
+            "keywords": [],
+            "content": "sample content " * 2,
+            "summary": "summary text",
+            "content_embedding": [0.1],
+            "summary_embedding": [0.1],
+            "questions": [{"text": "q1"}],
+            "answers": [{"text": "a1"}],
+            "relations": [],
+            "created_at": "now",
+            "metadata": {},
+        }
+    ]
 
-    builder.save_dataset('qa', output_dir=tmp_path)
-    qa_file = tmp_path / 'qa_pairs.json'
+    builder.save_dataset("qa", output_dir=tmp_path)
+    qa_file = tmp_path / "qa_pairs.json"
     assert qa_file.exists()
-    data = json.loads(qa_file.read_text(encoding='utf-8'))
-    assert data == [{'question': 'q1', 'answer': 'a1'}]
+    data = json.loads(qa_file.read_text(encoding="utf-8"))
+    assert data == [{"question": "q1", "answer": "a1"}]
 
-    builder.save_dataset('text', output_dir=tmp_path)
-    txt_dir = tmp_path / 'text_corpus'
-    assert (txt_dir / '1.txt').exists()
+    builder.save_dataset("text", output_dir=tmp_path)
+    txt_dir = tmp_path / "text_corpus"
+    assert (txt_dir / "1.txt").exists()
 
 
 def test_normalize_category_alias():
-    assert sw.normalize_category('programacao') == 'Programação'
+    assert sw.normalize_category("programacao") == "Programação"
 
 
 def test_main_uses_normalized_category(monkeypatch):
@@ -638,6 +750,7 @@ def test_main_uses_normalized_category(monkeypatch):
     class DummyBuilder:
         def __init__(self, *a, **k):
             pass
+
         def build_from_pages(self, pages, *a, **k):
             return []
 
@@ -647,226 +760,133 @@ def test_main_uses_normalized_category(monkeypatch):
         def save_dataset(self, format=None):
             pass
 
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'DatasetBuilder', DummyBuilder)
-    monkeypatch.setattr(sw.time, 'sleep', lambda *a, **k: None)
-    sys.modules['plugins'] = SimpleNamespace(
-        load_plugin=lambda name: SimpleNamespace(fetch_items=lambda l, c: [], parse_item=lambda i: None)
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "DatasetBuilder", DummyBuilder)
+    monkeypatch.setattr(sw.time, "sleep", lambda *a, **k: None)
+    sys.modules["plugins"] = SimpleNamespace(
+        load_plugin=lambda name: SimpleNamespace(
+            fetch_items=lambda l, c: [], parse_item=lambda i: None
+        )
     )
 
-    sw.main(langs=['pt'], categories=['programacao'], fmt='json')
+    sw.main(langs=["pt"], categories=["programacao"], fmt="json")
 
-    assert called == ['Programação']
+    assert called == ["Programação"]
+
 
 def test_search_category(monkeypatch):
     called = {}
 
     fake_cache = {}
-    monkeypatch.setattr(sw, 'cache', SimpleNamespace(
-        get=lambda k: fake_cache.get(k),
-        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
-        stats=lambda: {}
-    ))
+    monkeypatch.setattr(
+        sw,
+        "cache",
+        SimpleNamespace(
+            get=lambda k: fake_cache.get(k),
+            set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+            stats=lambda: {},
+        ),
+    )
 
     async def fake_fetch(url, params=None, headers=None):
-        called['params'] = params
+        called["params"] = params
         data = {"query": {"search": [{"title": "Category:Computing"}]}}
         return 200, json.dumps(data)
 
     async def fake_sleep(d):
         pass
 
-    monkeypatch.setattr(sw, 'fetch_with_retry', fake_fetch)
-    monkeypatch.setattr(sw.asyncio, 'sleep', fake_sleep)
-    result = sw.search_category('comp', 'en')
-    assert result == 'Computing'
-    assert called['params']['srnamespace'] == 14
+    monkeypatch.setattr(sw, "fetch_with_retry", fake_fetch)
+    monkeypatch.setattr(sw.asyncio, "sleep", fake_sleep)
+    result = sw.search_category("comp", "en")
+    assert result == "Computing"
+    assert called["params"]["srnamespace"] == 14
 
 
 def test_get_category_members_search(monkeypatch):
-    wiki = sw.WikipediaAdvanced('en')
+    wiki = sw.WikipediaAdvanced("en")
     fetch_calls = []
 
     dummy_member = SimpleNamespace(
-        ns=sw.wikipediaapi.Namespace.MAIN,
-        title='Page',
-        fullurl='url'
+        ns=sw.wikipediaapi.Namespace.MAIN, title="Page", fullurl="url"
     )
     dummy_cat = SimpleNamespace(
-        exists=lambda: True,
-        categorymembers={'p': dummy_member}
+        exists=lambda: True, categorymembers={"p": dummy_member}
     )
 
     def fake_fetch(self, name):
         fetch_calls.append(name)
-        if name == 'Missing':
+        if name == "Missing":
             return None
         return dummy_cat
 
-    monkeypatch.setattr(sw.WikipediaAdvanced, 'fetch_category', fake_fetch, raising=False)
-    monkeypatch.setattr(sw, 'search_category', lambda keyword, lang: 'Found')
+    monkeypatch.setattr(
+        sw.WikipediaAdvanced, "fetch_category", fake_fetch, raising=False
+    )
+    monkeypatch.setattr(sw, "search_category", lambda keyword, lang: "Found")
 
-    members = wiki.get_category_members('Missing')
-    assert members == [{
-        'title': 'Page',
-        'url': 'url',
-        'lang': 'en',
-        'category': 'Found',
-        'depth': 0
-    }]
-    assert fetch_calls == ['Missing', 'Found']
+    members = wiki.get_category_members("Missing")
+    assert members == [
+        {"title": "Page", "url": "url", "lang": "en", "category": "Found", "depth": 0}
+    ]
+    assert fetch_calls == ["Missing", "Found"]
 
 
 def test_get_category_members_async(monkeypatch):
-    wiki = sw.WikipediaAdvanced('en')
+    wiki = sw.WikipediaAdvanced("en")
     dummy_member = SimpleNamespace(
-        ns=sw.wikipediaapi.Namespace.MAIN,
-        title='Page',
-        fullurl='url'
+        ns=sw.wikipediaapi.Namespace.MAIN, title="Page", fullurl="url"
     )
     dummy_cat = SimpleNamespace(
-        exists=lambda: True,
-        categorymembers={'p': dummy_member}
+        exists=lambda: True, categorymembers={"p": dummy_member}
     )
 
     def fake_fetch(self, name):
         return dummy_cat
 
-    monkeypatch.setattr(sw.WikipediaAdvanced, 'fetch_category', fake_fetch, raising=False)
+    monkeypatch.setattr(
+        sw.WikipediaAdvanced, "fetch_category", fake_fetch, raising=False
+    )
     import asyncio as aio
-    members = aio.run(wiki.get_category_members_async('Any'))
-    assert members == [{
-        'title': 'Page',
-        'url': 'url',
-        'lang': 'en',
-        'category': 'Any',
-        'depth': 0
-    }]
+
+    members = aio.run(wiki.get_category_members_async("Any"))
+    assert members == [
+        {"title": "Page", "url": "url", "lang": "en", "category": "Any", "depth": 0}
+    ]
 
 
 def test_main_collects_pages_unaccented(monkeypatch):
     fake_cache = {}
-    monkeypatch.setattr(sw, 'cache', SimpleNamespace(
-        get=lambda k: fake_cache.get(k),
-        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
-        stats=lambda: {}
-    ))
+    monkeypatch.setattr(
+        sw,
+        "cache",
+        SimpleNamespace(
+            get=lambda k: fake_cache.get(k),
+            set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+            stats=lambda: {},
+        ),
+    )
     original_norm = sw.normalize_category
+
     def fake_norm(name):
-        if name == 'ciencia da computacao':
-            return 'Ciência da computação'
+        if name == "ciencia da computacao":
+            return "Ciência da computação"
         return original_norm(name)
-    monkeypatch.setattr(sw, 'normalize_category', fake_norm)
+
+    monkeypatch.setattr(sw, "normalize_category", fake_norm)
 
     class DummyWiki:
         def __init__(self, lang):
             self.lang = lang
 
         def get_category_members(self, category_name):
-            return [{
-                'title': 'Page',
-                'url': 'url',
-                'lang': self.lang,
-                'category': category_name,
-                'depth': 0
-            }]
-
-    class DummyBuilder:
-        def __init__(self, *a, **k):
-            self.pages = []
-
-        def build_from_pages(self, pages, *a, **k):
-            self.pages.extend(pages)
-            return []
-
-        def enhance_with_clustering(self):
-            pass
-
-        def save_dataset(self, format=None):
-            pass
-
-    builder = DummyBuilder()
-
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'DatasetBuilder', lambda *a, **k: builder)
-    monkeypatch.setattr(sw.time, 'sleep', lambda *a, **k: None)
-    monkeypatch.setattr(sw.metrics, 'start_metrics_server', lambda *a, **k: None)
-    sys.modules['plugins'] = SimpleNamespace(load_plugin=lambda name: SimpleNamespace(fetch_items=lambda l, c: [], parse_item=lambda i: None))
-    sys.modules['plugins'] = SimpleNamespace(load_plugin=lambda name: SimpleNamespace(fetch_items=lambda l, c: [], parse_item=lambda i: None))
-    sys.modules['plugins'] = SimpleNamespace(load_plugin=lambda name: SimpleNamespace(fetch_items=lambda l, c: [], parse_item=lambda i: None))
-    sys.modules['plugins'] = SimpleNamespace(load_plugin=lambda name: SimpleNamespace(fetch_items=lambda l, c: [], parse_item=lambda i: None))
-
-    sw.main(langs=['pt'], categories=['ciencia da computacao'], fmt='json')
-
-    assert len(builder.pages) == 1
-    assert builder.pages[0]['category'] == 'Ciência da computação'
-
-
-def test_main_collects_pages_alias(monkeypatch):
-    fake_cache = {}
-    monkeypatch.setattr(sw, 'cache', SimpleNamespace(
-        get=lambda k: fake_cache.get(k),
-        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
-        stats=lambda: {}
-    ))
-    from unidecode import unidecode as real_unidecode
-    monkeypatch.setattr(sw, 'unidecode', real_unidecode)
-    class DummyWiki:
-        def __init__(self, lang):
-            self.lang = lang
-
-        def get_category_members(self, category_name):
-            return [{
-                'title': 'AliasPage',
-                'url': 'url',
-                'lang': self.lang,
-                'category': category_name,
-                'depth': 0
-            }]
-
-    class DummyBuilder:
-        def __init__(self, *a, **k):
-            self.pages = []
-
-        def build_from_pages(self, pages, *a, **k):
-            self.pages.extend(pages)
-            return []
-
-        def enhance_with_clustering(self):
-            pass
-
-        def save_dataset(self, format=None):
-            pass
-
-    builder = DummyBuilder()
-
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'DatasetBuilder', lambda *a, **k: builder)
-    monkeypatch.setattr(sw.time, 'sleep', lambda *a, **k: None)
-    monkeypatch.setattr(sw.metrics, 'start_metrics_server', lambda *a, **k: None)
-
-    sw.main(langs=['pt'], categories=['programacao'], fmt='json')
-
-    assert len(builder.pages) == 1
-    assert builder.pages[0]['category'] == 'Programação'
-
-
-def test_main_crawls_start_pages(monkeypatch):
-    class DummyWiki:
-        def __init__(self, lang):
-            self.lang = lang
-
-        def get_category_members(self, category_name):
-            return []
-
-        def crawl_links(self, start_page, depth):
             return [
                 {
-                    'title': 'P',
-                    'url': 'url',
-                    'lang': self.lang,
-                    'category': start_page,
-                    'depth': 0,
+                    "title": "Page",
+                    "url": "url",
+                    "lang": self.lang,
+                    "category": category_name,
+                    "depth": 0,
                 }
             ]
 
@@ -886,15 +906,138 @@ def test_main_crawls_start_pages(monkeypatch):
 
     builder = DummyBuilder()
 
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'DatasetBuilder', lambda *a, **k: builder)
-    monkeypatch.setattr(sw.time, 'sleep', lambda *a, **k: None)
-    monkeypatch.setattr(sw.metrics, 'start_metrics_server', lambda *a, **k: None)
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "DatasetBuilder", lambda *a, **k: builder)
+    monkeypatch.setattr(sw.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(sw.metrics, "start_metrics_server", lambda *a, **k: None)
+    sys.modules["plugins"] = SimpleNamespace(
+        load_plugin=lambda name: SimpleNamespace(
+            fetch_items=lambda l, c: [], parse_item=lambda i: None
+        )
+    )
+    sys.modules["plugins"] = SimpleNamespace(
+        load_plugin=lambda name: SimpleNamespace(
+            fetch_items=lambda l, c: [], parse_item=lambda i: None
+        )
+    )
+    sys.modules["plugins"] = SimpleNamespace(
+        load_plugin=lambda name: SimpleNamespace(
+            fetch_items=lambda l, c: [], parse_item=lambda i: None
+        )
+    )
+    sys.modules["plugins"] = SimpleNamespace(
+        load_plugin=lambda name: SimpleNamespace(
+            fetch_items=lambda l, c: [], parse_item=lambda i: None
+        )
+    )
 
-    sw.main(langs=['en'], start_pages=['Start'], depth=2)
+    sw.main(langs=["pt"], categories=["ciencia da computacao"], fmt="json")
 
     assert len(builder.pages) == 1
-    assert builder.pages[0]['category'] == 'Start'
+    assert builder.pages[0]["category"] == "Ciência da computação"
+
+
+def test_main_collects_pages_alias(monkeypatch):
+    fake_cache = {}
+    monkeypatch.setattr(
+        sw,
+        "cache",
+        SimpleNamespace(
+            get=lambda k: fake_cache.get(k),
+            set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+            stats=lambda: {},
+        ),
+    )
+    from unidecode import unidecode as real_unidecode
+
+    monkeypatch.setattr(sw, "unidecode", real_unidecode)
+
+    class DummyWiki:
+        def __init__(self, lang):
+            self.lang = lang
+
+        def get_category_members(self, category_name):
+            return [
+                {
+                    "title": "AliasPage",
+                    "url": "url",
+                    "lang": self.lang,
+                    "category": category_name,
+                    "depth": 0,
+                }
+            ]
+
+    class DummyBuilder:
+        def __init__(self, *a, **k):
+            self.pages = []
+
+        def build_from_pages(self, pages, *a, **k):
+            self.pages.extend(pages)
+            return []
+
+        def enhance_with_clustering(self):
+            pass
+
+        def save_dataset(self, format=None):
+            pass
+
+    builder = DummyBuilder()
+
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "DatasetBuilder", lambda *a, **k: builder)
+    monkeypatch.setattr(sw.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(sw.metrics, "start_metrics_server", lambda *a, **k: None)
+
+    sw.main(langs=["pt"], categories=["programacao"], fmt="json")
+
+    assert len(builder.pages) == 1
+    assert builder.pages[0]["category"] == "Programação"
+
+
+def test_main_crawls_start_pages(monkeypatch):
+    class DummyWiki:
+        def __init__(self, lang):
+            self.lang = lang
+
+        def get_category_members(self, category_name):
+            return []
+
+        def crawl_links(self, start_page, depth):
+            return [
+                {
+                    "title": "P",
+                    "url": "url",
+                    "lang": self.lang,
+                    "category": start_page,
+                    "depth": 0,
+                }
+            ]
+
+    class DummyBuilder:
+        def __init__(self, *a, **k):
+            self.pages = []
+
+        def build_from_pages(self, pages, *a, **k):
+            self.pages.extend(pages)
+            return []
+
+        def enhance_with_clustering(self):
+            pass
+
+        def save_dataset(self, format=None):
+            pass
+
+    builder = DummyBuilder()
+
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "DatasetBuilder", lambda *a, **k: builder)
+    monkeypatch.setattr(sw.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(sw.metrics, "start_metrics_server", lambda *a, **k: None)
+
+    sw.main(langs=["en"], start_pages=["Start"], depth=2)
+
+    assert len(builder.pages) == 1
+    assert builder.pages[0]["category"] == "Start"
 
 
 def test_main_async_crawls_start_pages(monkeypatch):
@@ -908,11 +1051,11 @@ def test_main_async_crawls_start_pages(monkeypatch):
         async def crawl_links_async(self, start_page, depth):
             return [
                 {
-                    'title': 'P',
-                    'url': 'url',
-                    'lang': self.lang,
-                    'category': start_page,
-                    'depth': 0,
+                    "title": "P",
+                    "url": "url",
+                    "lang": self.lang,
+                    "category": start_page,
+                    "depth": 0,
                 }
             ]
 
@@ -936,41 +1079,43 @@ def test_main_async_crawls_start_pages(monkeypatch):
 
     builder = DummyBuilder()
 
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'DatasetBuilder', lambda *a, **k: builder)
-    monkeypatch.setattr(sw.time, 'sleep', lambda *a, **k: None)
-    monkeypatch.setattr(sw.metrics, 'start_metrics_server', lambda *a, **k: None)
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "DatasetBuilder", lambda *a, **k: builder)
+    monkeypatch.setattr(sw.time, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(sw.metrics, "start_metrics_server", lambda *a, **k: None)
 
     import asyncio as aio
-    aio.run(sw.main_async(langs=['en'], start_pages=['Start'], depth=2))
+
+    aio.run(sw.main_async(langs=["en"], start_pages=["Start"], depth=2))
 
     assert len(builder.pages) == 1
-    assert builder.pages[0]['category'] == 'Start'
+    assert builder.pages[0]["category"] == "Start"
 
 
 def test_get_category_members_search_requests(monkeypatch):
-    wiki = sw.WikipediaAdvanced('en')
+    wiki = sw.WikipediaAdvanced("en")
     fetch_calls = []
     fake_cache = {}
-    monkeypatch.setattr(sw, 'cache', SimpleNamespace(
-        get=lambda k: fake_cache.get(k),
-        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
-        stats=lambda: {}
-    ))
+    monkeypatch.setattr(
+        sw,
+        "cache",
+        SimpleNamespace(
+            get=lambda k: fake_cache.get(k),
+            set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+            stats=lambda: {},
+        ),
+    )
 
     dummy_member = SimpleNamespace(
-        ns=sw.wikipediaapi.Namespace.MAIN,
-        title='Page',
-        fullurl='url'
+        ns=sw.wikipediaapi.Namespace.MAIN, title="Page", fullurl="url"
     )
     dummy_cat = SimpleNamespace(
-        exists=lambda: True,
-        categorymembers={'p': dummy_member}
+        exists=lambda: True, categorymembers={"p": dummy_member}
     )
 
     def fake_fetch_category(self, name):
         fetch_calls.append(name)
-        if name == 'Found':
+        if name == "Found":
             return dummy_cat
         return None
 
@@ -978,23 +1123,22 @@ def test_get_category_members_search_requests(monkeypatch):
         data = {"query": {"search": [{"title": "Category:Found"}]}}
         return 200, json.dumps(data)
 
-    monkeypatch.setattr(sw.WikipediaAdvanced, 'fetch_category', fake_fetch_category, raising=False)
-    monkeypatch.setattr(sw, 'fetch_with_retry', fake_fetch_http)
+    monkeypatch.setattr(
+        sw.WikipediaAdvanced, "fetch_category", fake_fetch_category, raising=False
+    )
+    monkeypatch.setattr(sw, "fetch_with_retry", fake_fetch_http)
 
-    members = wiki.get_category_members('Missing')
-    assert members == [{
-        'title': 'Page',
-        'url': 'url',
-        'lang': 'en',
-        'category': 'Found',
-        'depth': 0
-    }]
-    assert fetch_calls == ['Missing', 'Found']
+    members = wiki.get_category_members("Missing")
+    assert members == [
+        {"title": "Page", "url": "url", "lang": "en", "category": "Found", "depth": 0}
+    ]
+    assert fetch_calls == ["Missing", "Found"]
 
 
 def test_rate_limiter_env(monkeypatch):
     monkeypatch.setenv("RATE_LIMIT_DELAY", "1.5")
     import importlib
+
     sw_reload = importlib.reload(sw)
     assert sw_reload.Config.RATE_LIMIT_DELAY == 1.5
     assert sw_reload.rate_limiter.min_delay == 1.5
@@ -1005,9 +1149,18 @@ def test_parallelism_env(monkeypatch):
     monkeypatch.setenv("MAX_THREADS", "7")
     monkeypatch.setenv("MAX_PROCESSES", "3")
     import importlib
+
     sw_reload = importlib.reload(sw)
     assert sw_reload.Config.MAX_THREADS == 7
     assert sw_reload.Config.MAX_PROCESSES == 3
+
+
+def test_worker_concurrency_env(monkeypatch):
+    monkeypatch.setenv("WORKER_CONCURRENCY", "9")
+    import importlib
+
+    sw_reload = importlib.reload(sw)
+    assert sw_reload.Config.WORKER_CONCURRENCY == 9
 
 
 def test_rate_limiter_backoff(monkeypatch):
@@ -1025,6 +1178,7 @@ def test_rate_limiter_range_and_async(monkeypatch):
     recorded_async = []
     rl = sw.RateLimiter(0.1, 0.2)
     monkeypatch.setattr(sw.time, "sleep", lambda d: recorded_sync.append(d))
+
     async def fake_async_sleep(d):
         recorded_async.append(d)
 
@@ -1036,6 +1190,7 @@ def test_rate_limiter_range_and_async(monkeypatch):
         await rl.async_wait()
 
     import asyncio as aio
+
     aio.run(run())
 
     assert recorded_sync == [0.2]
@@ -1044,9 +1199,10 @@ def test_rate_limiter_range_and_async(monkeypatch):
 
 def test_fetch_with_retry_failure_increments_counter(monkeypatch):
     import asyncio
+
     class DummyResp:
         async def __aenter__(self):
-            raise sw.aiohttp.ClientError('fail')
+            raise sw.aiohttp.ClientError("fail")
 
         async def __aexit__(self, exc_type, exc, tb):
             pass
@@ -1061,30 +1217,34 @@ def test_fetch_with_retry_failure_increments_counter(monkeypatch):
         def get(self, *a, **k):
             return DummyResp()
 
-    calls = {'fail': 0}
+    calls = {"fail": 0}
 
     class Marker(Exception):
         pass
 
     def inc_fail():
-        calls['fail'] += 1
+        calls["fail"] += 1
         raise Marker
 
-    monkeypatch.setattr(sw.aiohttp, 'ClientSession', lambda *a, **k: DummySession())
-    monkeypatch.setattr(sw.aiohttp, 'ClientTimeout', lambda *a, **k: None)
-    monkeypatch.setattr(sw, 'log_failed_url', lambda url: None)
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_block=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=inc_fail),
-        request_retries_total=SimpleNamespace(inc=lambda: None),
-    ))
+    monkeypatch.setattr(sw.aiohttp, "ClientSession", lambda *a, **k: DummySession())
+    monkeypatch.setattr(sw.aiohttp, "ClientTimeout", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "log_failed_url", lambda url: None)
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_block=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=inc_fail),
+            request_retries_total=SimpleNamespace(inc=lambda: None),
+        ),
+    )
 
     import pytest
 
     with pytest.raises(Marker):
-        asyncio.run(sw.fetch_with_retry('http://x'))
+        asyncio.run(sw.fetch_with_retry("http://x"))
 
-    assert calls['fail'] == 1
+    assert calls["fail"] == 1
 
 
 def test_fetch_with_retry_counts_retries(monkeypatch):
@@ -1092,7 +1252,7 @@ def test_fetch_with_retry_counts_retries(monkeypatch):
 
     class DummyFail:
         async def __aenter__(self):
-            raise sw.aiohttp.ClientError('fail')
+            raise sw.aiohttp.ClientError("fail")
 
         async def __aexit__(self, exc_type, exc, tb):
             pass
@@ -1100,7 +1260,7 @@ def test_fetch_with_retry_counts_retries(monkeypatch):
     class DummySuccess:
         status = 200
         request_info = history = headers = None
-        reason = 'OK'
+        reason = "OK"
 
         async def __aenter__(self):
             return self
@@ -1109,7 +1269,7 @@ def test_fetch_with_retry_counts_retries(monkeypatch):
             pass
 
         async def text(self):
-            return 'ok'
+            return "ok"
 
         def raise_for_status(self):
             pass
@@ -1129,24 +1289,28 @@ def test_fetch_with_retry_counts_retries(monkeypatch):
                 return DummyFail()
             return DummySuccess()
 
-    recorded = {'r': 0}
+    recorded = {"r": 0}
 
     def inc_retry():
-        recorded['r'] += 1
+        recorded["r"] += 1
 
-    monkeypatch.setattr(sw.aiohttp, 'ClientSession', lambda *a, **k: DummySession())
-    monkeypatch.setattr(sw.aiohttp, 'ClientTimeout', lambda *a, **k: None)
-    monkeypatch.setattr(sw, 'log_failed_url', lambda url: None)
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_block=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-        request_retries_total=SimpleNamespace(inc=inc_retry),
-    ))
+    monkeypatch.setattr(sw.aiohttp, "ClientSession", lambda *a, **k: DummySession())
+    monkeypatch.setattr(sw.aiohttp, "ClientTimeout", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "log_failed_url", lambda url: None)
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_block=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            request_retries_total=SimpleNamespace(inc=inc_retry),
+        ),
+    )
 
-    status, text = asyncio.run(sw.fetch_with_retry('http://x', retries=2))
+    status, text = asyncio.run(sw.fetch_with_retry("http://x", retries=2))
 
     assert status == 200
-    assert recorded['r'] == 1
+    assert recorded["r"] == 1
 
 
 def test_rate_limiter_reset_after_success():
@@ -1160,20 +1324,21 @@ def test_rate_limiter_reset_after_success():
 
 def test_fetch_with_retry_429_increases_delay(monkeypatch):
     import asyncio
+
     rl = sw.RateLimiter(0.1)
-    monkeypatch.setattr(sw, 'rate_limiter', rl)
+    monkeypatch.setattr(sw, "rate_limiter", rl)
 
     class DummyError(Exception):
         def __init__(self, status):
             super().__init__()
             self.status = status
 
-    monkeypatch.setattr(sw.aiohttp, 'ClientResponseError', DummyError)
+    monkeypatch.setattr(sw.aiohttp, "ClientResponseError", DummyError)
 
     class DummyResp:
         status = 429
         request_info = history = headers = None
-        reason = 'Too Many'
+        reason = "Too Many"
 
         async def __aenter__(self):
             return self
@@ -1182,7 +1347,7 @@ def test_fetch_with_retry_429_increases_delay(monkeypatch):
             pass
 
         async def text(self):
-            return ''
+            return ""
 
         def raise_for_status(self):
             raise sw.aiohttp.ClientResponseError(self.status)
@@ -1197,18 +1362,22 @@ def test_fetch_with_retry_429_increases_delay(monkeypatch):
         def get(self, *a, **k):
             return DummyResp()
 
-    monkeypatch.setattr(sw.aiohttp, 'ClientSession', lambda *a, **k: DummySession())
-    monkeypatch.setattr(sw.aiohttp, 'ClientTimeout', lambda *a, **k: None)
-    monkeypatch.setattr(sw, 'log_failed_url', lambda url: None)
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_block=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-    ))
+    monkeypatch.setattr(sw.aiohttp, "ClientSession", lambda *a, **k: DummySession())
+    monkeypatch.setattr(sw.aiohttp, "ClientTimeout", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "log_failed_url", lambda url: None)
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_block=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+        ),
+    )
 
     import pytest
 
     with pytest.raises(sw.aiohttp.ClientResponseError):
-        asyncio.run(sw.fetch_with_retry('http://x', retries=1))
+        asyncio.run(sw.fetch_with_retry("http://x", retries=1))
 
     assert rl.consecutive_failures == 1
     assert rl.min_delay == 0.2
@@ -1220,7 +1389,7 @@ def test_fetch_with_retry_uses_proxy(monkeypatch):
     class DummyResp:
         status = 200
         request_info = history = headers = None
-        reason = 'OK'
+        reason = "OK"
 
         async def __aenter__(self):
             return self
@@ -1229,7 +1398,7 @@ def test_fetch_with_retry_uses_proxy(monkeypatch):
             pass
 
         async def text(self):
-            return 'ok'
+            return "ok"
 
         def raise_for_status(self):
             pass
@@ -1246,25 +1415,29 @@ def test_fetch_with_retry_uses_proxy(monkeypatch):
             pass
 
         def get(self, *a, **k):
-            self.calls.append(k.get('proxy'))
+            self.calls.append(k.get("proxy"))
             return DummyResp()
 
     session_inst = DummySession()
 
-    monkeypatch.setattr(sw.aiohttp, 'ClientSession', lambda *a, **k: session_inst)
-    monkeypatch.setattr(sw.aiohttp, 'ClientTimeout', lambda *a, **k: None)
-    monkeypatch.setattr(sw.random, 'choice', lambda seq: seq[0])
-    monkeypatch.setattr(sw.Config, 'PROXIES', ['http://p1'])
-    monkeypatch.setattr(sw, 'log_failed_url', lambda url: None)
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_block=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-        request_retries_total=SimpleNamespace(inc=lambda: None),
-    ))
+    monkeypatch.setattr(sw.aiohttp, "ClientSession", lambda *a, **k: session_inst)
+    monkeypatch.setattr(sw.aiohttp, "ClientTimeout", lambda *a, **k: None)
+    monkeypatch.setattr(sw.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(sw.Config, "PROXIES", ["http://p1"])
+    monkeypatch.setattr(sw, "log_failed_url", lambda url: None)
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_block=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            request_retries_total=SimpleNamespace(inc=lambda: None),
+        ),
+    )
 
-    asyncio.run(sw.fetch_with_retry('http://x'))
+    asyncio.run(sw.fetch_with_retry("http://x"))
 
-    assert session_inst.calls == ['http://p1']
+    assert session_inst.calls == ["http://p1"]
 
 
 def test_fetch_with_retry_semaphore_limits_concurrency(monkeypatch):
@@ -1273,7 +1446,7 @@ def test_fetch_with_retry_semaphore_limits_concurrency(monkeypatch):
     class DummyResp:
         status = 200
         request_info = history = headers = None
-        reason = 'OK'
+        reason = "OK"
 
         async def __aenter__(self):
             await asyncio.sleep(0)
@@ -1283,7 +1456,7 @@ def test_fetch_with_retry_semaphore_limits_concurrency(monkeypatch):
             pass
 
         async def text(self):
-            return 'ok'
+            return "ok"
 
         def raise_for_status(self):
             pass
@@ -1298,15 +1471,19 @@ def test_fetch_with_retry_semaphore_limits_concurrency(monkeypatch):
         def get(self, *a, **k):
             return DummyResp()
 
-    monkeypatch.setattr(sw.aiohttp, 'ClientSession', lambda *a, **k: DummySession())
-    monkeypatch.setattr(sw.aiohttp, 'ClientTimeout', lambda *a, **k: None)
-    monkeypatch.setattr(sw, 'log_failed_url', lambda url: None)
-    monkeypatch.setattr(sw.Config, 'PROXIES', [])
-    monkeypatch.setattr(sw, 'metrics', SimpleNamespace(
-        scrape_block=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-        request_retries_total=SimpleNamespace(inc=lambda: None),
-    ))
+    monkeypatch.setattr(sw.aiohttp, "ClientSession", lambda *a, **k: DummySession())
+    monkeypatch.setattr(sw.aiohttp, "ClientTimeout", lambda *a, **k: None)
+    monkeypatch.setattr(sw, "log_failed_url", lambda url: None)
+    monkeypatch.setattr(sw.Config, "PROXIES", [])
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_block=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            request_retries_total=SimpleNamespace(inc=lambda: None),
+        ),
+    )
 
     class DummySemaphore:
         def __init__(self, limit):
@@ -1318,34 +1495,44 @@ def test_fetch_with_retry_semaphore_limits_concurrency(monkeypatch):
             self.active += 1
             self.max_active = max(self.max_active, self.active)
             if self.active > self.limit:
-                raise AssertionError('limit exceeded')
+                raise AssertionError("limit exceeded")
 
         async def __aexit__(self, exc_type, exc, tb):
             self.active -= 1
 
     sem = DummySemaphore(2)
-    monkeypatch.setattr(sw, 'fetch_semaphore', sem)
+    monkeypatch.setattr(sw, "fetch_semaphore", sem)
 
-    urls = ['http://a', 'http://b', 'http://c']
+    urls = ["http://a", "http://b", "http://c"]
     asyncio.run(sw.fetch_all(urls))
 
     assert sem.max_active <= 2
 
 
 def test_main_records_session_histogram(monkeypatch):
-    observed = {'c': 0}
+    observed = {"c": 0}
 
     def observe(v):
-        observed['c'] += 1
+        observed["c"] += 1
 
-    monkeypatch.setattr(sw.metrics, 'scrape_session_seconds', SimpleNamespace(observe=observe))
-    monkeypatch.setattr(sw.metrics, 'start_metrics_server', lambda *a, **k: None)
-    monkeypatch.setattr(sw.metrics, 'scrape_success', SimpleNamespace(inc=lambda: None))
-    monkeypatch.setattr(sw.metrics, 'scrape_error', SimpleNamespace(inc=lambda: None))
-    monkeypatch.setattr(sw.metrics, 'pages_scraped_total', SimpleNamespace(inc=lambda: None))
-    monkeypatch.setattr(sw.metrics, 'requests_failed_total', SimpleNamespace(inc=lambda: None))
-    monkeypatch.setattr(sw.metrics, 'request_retries_total', SimpleNamespace(inc=lambda: None))
-    monkeypatch.setattr(sw.metrics, 'page_processing_seconds', SimpleNamespace(observe=lambda v: None))
+    monkeypatch.setattr(
+        sw.metrics, "scrape_session_seconds", SimpleNamespace(observe=observe)
+    )
+    monkeypatch.setattr(sw.metrics, "start_metrics_server", lambda *a, **k: None)
+    monkeypatch.setattr(sw.metrics, "scrape_success", SimpleNamespace(inc=lambda: None))
+    monkeypatch.setattr(sw.metrics, "scrape_error", SimpleNamespace(inc=lambda: None))
+    monkeypatch.setattr(
+        sw.metrics, "pages_scraped_total", SimpleNamespace(inc=lambda: None)
+    )
+    monkeypatch.setattr(
+        sw.metrics, "requests_failed_total", SimpleNamespace(inc=lambda: None)
+    )
+    monkeypatch.setattr(
+        sw.metrics, "request_retries_total", SimpleNamespace(inc=lambda: None)
+    )
+    monkeypatch.setattr(
+        sw.metrics, "page_processing_seconds", SimpleNamespace(observe=lambda v: None)
+    )
 
     class DummyWiki:
         def __init__(self, lang):
@@ -1357,29 +1544,36 @@ def test_main_records_session_histogram(monkeypatch):
     class DummyBuilder:
         def __init__(self, *a, **k):
             pass
+
         def build_from_pages(self, pages, progress_desc, client=None):
             pass
 
         def enhance_with_clustering(self):
             pass
 
-        def save_dataset(self, format='all'):
+        def save_dataset(self, format="all"):
             pass
 
-    monkeypatch.setattr(sw, 'WikipediaAdvanced', DummyWiki)
-    monkeypatch.setattr(sw, 'DatasetBuilder', DummyBuilder)
-    sys.modules['plugins'] = SimpleNamespace(load_plugin=lambda name: SimpleNamespace(fetch_items=lambda l, c: [], parse_item=lambda i: None))
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "DatasetBuilder", DummyBuilder)
+    sys.modules["plugins"] = SimpleNamespace(
+        load_plugin=lambda name: SimpleNamespace(
+            fetch_items=lambda l, c: [], parse_item=lambda i: None
+        )
+    )
 
-    sw.main(langs=['en'], categories=['prog'], fmt='json', rate_limit_delay=0, client=None)
+    sw.main(
+        langs=["en"], categories=["prog"], fmt="json", rate_limit_delay=0, client=None
+    )
 
-    assert observed['c'] == 1
+    assert observed["c"] == 1
 
 
 def test_crawl_links_uses_visited(monkeypatch):
     mapping = {
-        'Start': ['A', 'B'],
-        'A': ['C'],
-        'B': [],
+        "Start": ["A", "B"],
+        "A": ["C"],
+        "B": [],
     }
 
     def fake_fetch(title, lang):
@@ -1388,23 +1582,29 @@ def test_crawl_links_uses_visited(monkeypatch):
     def fake_extract(html, base):
         return [f"{base}/wiki/{p}" for p in mapping.get(html, [])]
 
-    monkeypatch.setattr(sw, 'fetch_html_content', fake_fetch)
-    monkeypatch.setattr(sw, 'extract_links', fake_extract)
+    monkeypatch.setattr(sw, "fetch_html_content", fake_fetch)
+    monkeypatch.setattr(sw, "extract_links", fake_extract)
 
-    wiki = sw.WikipediaAdvanced('en')
-    visited = {'A'}
-    result = wiki.crawl_links('Start', depth=1, visited=visited)
-    base = sw.get_base_url('en')
-    assert all(r['title'] != 'A' for r in result)
+    wiki = sw.WikipediaAdvanced("en")
+    visited = {"A"}
+    result = wiki.crawl_links("Start", depth=1, visited=visited)
+    base = sw.get_base_url("en")
+    assert all(r["title"] != "A" for r in result)
     assert result == [
-        {'title': 'B', 'url': f'{base}/wiki/B', 'lang': 'en', 'category': 'Start', 'depth': 0},
+        {
+            "title": "B",
+            "url": f"{base}/wiki/B",
+            "lang": "en",
+            "category": "Start",
+            "depth": 0,
+        },
     ]
 
 
 def test_crawl_links_async_uses_visited(monkeypatch):
     mapping = {
-        'Start': ['A'],
-        'A': ['B'],
+        "Start": ["A"],
+        "A": ["B"],
     }
 
     async def fake_fetch_async(title, lang):
@@ -1413,25 +1613,28 @@ def test_crawl_links_async_uses_visited(monkeypatch):
     def fake_extract(html, base):
         return [f"{base}/wiki/{p}" for p in mapping.get(html, [])]
 
-    monkeypatch.setattr(sw, 'fetch_html_content_async', fake_fetch_async)
-    monkeypatch.setattr(sw, 'extract_links', fake_extract)
+    monkeypatch.setattr(sw, "fetch_html_content_async", fake_fetch_async)
+    monkeypatch.setattr(sw, "extract_links", fake_extract)
 
-    wiki = sw.WikipediaAdvanced('en')
-    visited = {'A'}
+    wiki = sw.WikipediaAdvanced("en")
+    visited = {"A"}
     import asyncio as aio
-    result = aio.run(wiki.crawl_links_async('Start', depth=1, visited=visited))
-    base = sw.get_base_url('en')
+
+    result = aio.run(wiki.crawl_links_async("Start", depth=1, visited=visited))
+    base = sw.get_base_url("en")
     assert result == []
 
 
 def test_advanced_clean_text_removes_templates_and_tables():
     raw = 'Intro {{Infobox}} text {| class="wikitable" | data |}'
-    cleaned = sw.advanced_clean_text(raw, 'en')
-    assert 'Infobox' not in cleaned and 'wikitable' not in cleaned
+    cleaned = sw.advanced_clean_text(raw, "en")
+    assert "Infobox" not in cleaned and "wikitable" not in cleaned
+
+
 def test_advanced_clean_text_removes_see_also_section():
-    raw = 'Something\n== See also ==\nOther info'
-    cleaned = sw.advanced_clean_text(raw, 'en')
-    assert 'See also' not in cleaned
+    raw = "Something\n== See also ==\nOther info"
+    cleaned = sw.advanced_clean_text(raw, "en")
+    assert "See also" not in cleaned
 
 
 def test_get_revision_history(monkeypatch):
@@ -1442,7 +1645,11 @@ def test_get_revision_history(monkeypatch):
             pass
 
         def json(self):
-            return {"query": {"pages": {"1": {"revisions": [{"timestamp": "t", "user": "u"}]}}}}
+            return {
+                "query": {
+                    "pages": {"1": {"revisions": [{"timestamp": "t", "user": "u"}]}}
+                }
+            }
 
     def fake_get(url, params=None, headers=None, timeout=None):
         called["params"] = params
@@ -1450,11 +1657,15 @@ def test_get_revision_history(monkeypatch):
 
     monkeypatch.setattr(sw.requests, "get", fake_get)
     fake_cache = {}
-    monkeypatch.setattr(sw, "cache", SimpleNamespace(
-        get=lambda k: fake_cache.get(k),
-        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
-        stats=lambda: {},
-    ))
+    monkeypatch.setattr(
+        sw,
+        "cache",
+        SimpleNamespace(
+            get=lambda k: fake_cache.get(k),
+            set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+            stats=lambda: {},
+        ),
+    )
     revs = sw.get_revision_history("Title", "en", 1)
     assert revs == [{"timestamp": "t", "user": "u"}]
     assert called["params"]["prop"] == "revisions"
@@ -1462,7 +1673,7 @@ def test_get_revision_history(monkeypatch):
 
 def test_process_page_includes_revisions(monkeypatch):
     class DummyPage:
-        text = 'x' * 200
+        text = "x" * 200
 
         def exists(self):
             return True
@@ -1479,23 +1690,41 @@ def test_process_page_includes_revisions(monkeypatch):
 
     monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
     monkeypatch.setattr(sw, "clean_text", lambda t: t)
-    monkeypatch.setattr(sw, "advanced_clean_text", lambda t, lang, remove_stopwords=False: t)
-    monkeypatch.setattr(sw, "summarize_text", lambda *a, **k: '')
-    monkeypatch.setattr(sw.DatasetBuilder, "generate_qa_pairs", lambda self, **k: {"metadata": {}, "content_embedding": [], "summary_embedding": [], "questions": [], "answers": [], "summary": '', "content": ''})
+    monkeypatch.setattr(
+        sw, "advanced_clean_text", lambda t, lang, remove_stopwords=False: t
+    )
+    monkeypatch.setattr(sw, "summarize_text", lambda *a, **k: "")
+    monkeypatch.setattr(
+        sw.DatasetBuilder,
+        "generate_qa_pairs",
+        lambda self, **k: {
+            "metadata": {},
+            "content_embedding": [],
+            "summary_embedding": [],
+            "questions": [],
+            "answers": [],
+            "summary": "",
+            "content": "",
+        },
+    )
     monkeypatch.setattr(sw, "extract_entities", lambda text: [])
     monkeypatch.setattr(sw, "extract_images", lambda html: [])
-    monkeypatch.setattr(sw, "metrics", SimpleNamespace(
-        scrape_success=SimpleNamespace(inc=lambda: None),
-        scrape_error=SimpleNamespace(inc=lambda: None),
-        pages_scraped_total=SimpleNamespace(inc=lambda: None),
-        requests_failed_total=SimpleNamespace(inc=lambda: None),
-        page_processing_seconds=SimpleNamespace(observe=lambda v: None),
-    ))
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_success=SimpleNamespace(inc=lambda: None),
+            scrape_error=SimpleNamespace(inc=lambda: None),
+            pages_scraped_total=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            page_processing_seconds=SimpleNamespace(observe=lambda v: None),
+        ),
+    )
     sw.NLPProcessor._embedding_model = None
 
     builder = sw.DatasetBuilder(include_revisions=True, rev_limit=1)
-    res = builder.process_page({'title': 'T', 'lang': 'en'})
-    assert res['metadata']['revisions'] == [{"timestamp": "t", "user": "u"}]
+    res = builder.process_page({"title": "T", "lang": "en"})
+    assert res["metadata"]["revisions"] == [{"timestamp": "t", "user": "u"}]
 
 
 def test_resume_from_checkpoint(tmp_path, monkeypatch):
@@ -1504,7 +1733,10 @@ def test_resume_from_checkpoint(tmp_path, monkeypatch):
     data_path = tmp_path / "checkpoint_data.json"
     pages_path = tmp_path / "checkpoint_pages.json"
     data_path.write_text(json.dumps([{"title": "Done"}]), encoding="utf-8")
-    pages_path.write_text(json.dumps([{"title": "A", "lang": "en"}, {"title": "B", "lang": "en"}]), encoding="utf-8")
+    pages_path.write_text(
+        json.dumps([{"title": "A", "lang": "en"}, {"title": "B", "lang": "en"}]),
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(sw, "ThreadPoolExecutor", DummyExecutor)
     monkeypatch.setattr(sw, "ProcessPoolExecutor", DummyExecutor)
@@ -1527,12 +1759,20 @@ def test_resume_from_checkpoint(tmp_path, monkeypatch):
 
 def test_get_revision_history_from_cache(monkeypatch):
     fake_cache = {"revisions_en_Title_5": [{"timestamp": "t", "user": "u"}]}
-    monkeypatch.setattr(sw, "cache", SimpleNamespace(
-        get=lambda k: fake_cache.get(k),
-        set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
-        stats=lambda: {},
-    ))
-    monkeypatch.setattr(sw.requests, "get", lambda *a, **k: (_ for _ in ()).throw(AssertionError("network called")))
+    monkeypatch.setattr(
+        sw,
+        "cache",
+        SimpleNamespace(
+            get=lambda k: fake_cache.get(k),
+            set=lambda k, v, ttl=None: fake_cache.__setitem__(k, v),
+            stats=lambda: {},
+        ),
+    )
+    monkeypatch.setattr(
+        sw.requests,
+        "get",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("network called")),
+    )
     res = sw.get_revision_history("Title", "en", 5)
     assert res == [{"timestamp": "t", "user": "u"}]
 
@@ -1556,8 +1796,12 @@ def test_dataset_builder_initializes_from_checkpoints(tmp_path, monkeypatch):
 
     data = [{"title": "D"}]
     pages = [{"title": "P", "lang": "en"}]
-    (Path(tmp_path) / "checkpoint_data.json").write_text(json.dumps(data), encoding="utf-8")
-    (Path(tmp_path) / "checkpoint_pages.json").write_text(json.dumps(pages), encoding="utf-8")
+    (Path(tmp_path) / "checkpoint_data.json").write_text(
+        json.dumps(data), encoding="utf-8"
+    )
+    (Path(tmp_path) / "checkpoint_pages.json").write_text(
+        json.dumps(pages), encoding="utf-8"
+    )
 
     builder = sw.DatasetBuilder()
 

--- a/worker.py
+++ b/worker.py
@@ -1,13 +1,16 @@
 """Background worker that consumes page tasks and publishes results."""
+
+import asyncio
 import logging
 from task_queue import consume, publish
-from scraper_wiki import DatasetBuilder
+from scraper_wiki import DatasetBuilder, Config
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def main():
+def main_sync() -> None:
+    """Run worker in synchronous mode."""
     builder = DatasetBuilder()
     for task in consume("scrape_tasks"):
         logger.info("Processing %s", task.get("title"))
@@ -16,5 +19,35 @@ def main():
             publish("scrape_results", result)
 
 
+async def _handle_task(
+    task: dict, builder: DatasetBuilder, sem: asyncio.Semaphore
+) -> None:
+    async with sem:
+        logger.info("Processing %s", task.get("title"))
+        result = await builder.process_page_async(task)
+        if result:
+            await asyncio.to_thread(publish, "scrape_results", result)
+
+
+async def main_async() -> None:
+    """Run worker using asynchronous scraping."""
+    builder = DatasetBuilder()
+    sem = asyncio.Semaphore(Config.WORKER_CONCURRENCY)
+    iterator = consume("scrape_tasks")
+    while True:
+        task = await asyncio.to_thread(next, iterator)
+        asyncio.create_task(_handle_task(task, builder, sem))
+
+
+def main(async_mode: bool = False) -> None:
+    """Entry point for the worker."""
+    if async_mode:
+        asyncio.run(main_async())
+    else:
+        main_sync()
+
+
 if __name__ == "__main__":
-    main()
+    import sys
+
+    main(async_mode="--async" in sys.argv)


### PR DESCRIPTION
## Summary
- implement `RedisQueue` for tasks alongside RabbitMQ
- add asynchronous worker mode with concurrency control
- document concurrency settings and queue options
- expose `WORKER_CONCURRENCY` setting
- test environment variable parsing for new setting

## Testing
- `black task_queue.py worker.py scraper_wiki.py tests/test_scraper_wiki.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685872ab471c832098b5702fdefd80ea