### PR TITLE
Improve DB storage and cloud uploads

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -3,9 +3,38 @@ import json
 import csv
 from typing import List
 
+
+def _maybe_upload_large(data: List[dict], name: str) -> None:
+    """Upload dataset to cloud storage if it exceeds the configured threshold."""
+    threshold = int(os.environ.get("UPLOAD_THRESHOLD_MB", "10")) * 1024 * 1024
+    payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    if len(payload) < threshold:
+        return
+
+    bucket = os.environ.get("S3_UPLOAD_BUCKET")
+    if bucket:
+        try:
+            import boto3
+
+            boto3.client("s3").put_object(Bucket=bucket, Key=name, Body=payload)
+        except Exception:  # pragma: no cover - missing deps
+            return
+    bucket = os.environ.get("GCS_UPLOAD_BUCKET")
+    if bucket:
+        try:
+            from google.cloud import storage as gcs
+
+            client = gcs.Client()
+            blob = client.bucket(bucket).blob(name)
+            blob.upload_from_string(payload)
+        except Exception:  # pragma: no cover - missing deps
+            return
+
+
 class StorageBackend:
     """Interface for storage backends."""
-    def save_dataset(self, data: List[dict], fmt: str = 'all') -> None:
+
+    def save_dataset(self, data: List[dict], fmt: str = "all") -> None:
         raise NotImplementedError
 
 
@@ -14,149 +43,209 @@ class LocalStorage(StorageBackend):
         self.output_dir = output_dir
         os.makedirs(output_dir, exist_ok=True)
 
-    def save_dataset(self, data: List[dict], fmt: str = 'all') -> None:
-        if fmt in ['all', 'json']:
-            json_file = os.path.join(self.output_dir, 'wikipedia_qa.json')
-            with open(json_file, 'w', encoding='utf-8') as f:
+    def save_dataset(self, data: List[dict], fmt: str = "all") -> None:
+        if fmt in ["all", "json"]:
+            json_file = os.path.join(self.output_dir, "wikipedia_qa.json")
+            with open(json_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=4)
-        if fmt in ['all', 'jsonl']:
-            jsonl_file = os.path.join(self.output_dir, 'wikipedia_qa.jsonl')
-            with open(jsonl_file, 'w', encoding='utf-8') as f:
+        if fmt in ["all", "jsonl"]:
+            jsonl_file = os.path.join(self.output_dir, "wikipedia_qa.jsonl")
+            with open(jsonl_file, "w", encoding="utf-8") as f:
                 for row in data:
-                    f.write(json.dumps(row, ensure_ascii=False) + '\n')
-        if fmt in ['all', 'csv']:
-            csv_file = os.path.join(self.output_dir, 'wikipedia_qa.csv')
-            with open(csv_file, 'w', newline='', encoding='utf-8') as f:
+                    f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        if fmt in ["all", "csv"]:
+            csv_file = os.path.join(self.output_dir, "wikipedia_qa.csv")
+            with open(csv_file, "w", newline="", encoding="utf-8") as f:
                 writer = csv.DictWriter(f, fieldnames=data[0].keys())
                 writer.writeheader()
                 rows = []
                 for row in data:
-                    converted = {k: json.dumps(v, ensure_ascii=False) if isinstance(v, (list, dict)) else v for k, v in row.items()}
+                    converted = {
+                        k: (
+                            json.dumps(v, ensure_ascii=False)
+                            if isinstance(v, (list, dict))
+                            else v
+                        )
+                        for k, v in row.items()
+                    }
                     rows.append(converted)
                 writer.writerows(rows)
-        if fmt in ['all', 'parquet']:
+        if fmt in ["all", "parquet"]:
             try:
                 import pyarrow as pa
                 import pyarrow.parquet as pq
-                parquet_file = os.path.join(self.output_dir, 'wikipedia_qa.parquet')
+
+                parquet_file = os.path.join(self.output_dir, "wikipedia_qa.parquet")
                 table = pa.Table.from_pylist(data)
                 pq.write_table(table, parquet_file)
             except Exception:
                 pass
-        if fmt in ['all', 'tfrecord']:
+        if fmt in ["all", "tfrecord"]:
             try:
                 import tensorflow as tf
-                tf_path = os.path.join(self.output_dir, 'wikipedia_qa.tfrecord')
+
+                tf_path = os.path.join(self.output_dir, "wikipedia_qa.tfrecord")
                 with tf.io.TFRecordWriter(tf_path) as writer:
                     for row in data:
-                        writer.write(json.dumps(row, ensure_ascii=False).encode('utf-8'))
+                        writer.write(
+                            json.dumps(row, ensure_ascii=False).encode("utf-8")
+                        )
             except Exception:
                 pass
+        _maybe_upload_large(data, "wikipedia_qa.json")
 
 
 class S3Storage(StorageBackend):
-    def __init__(self, bucket: str, prefix: str = '', endpoint_url: str | None = None, client=None):
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str = "",
+        endpoint_url: str | None = None,
+        client=None,
+    ):
         try:
             import boto3
         except Exception as e:
-            raise ImportError('boto3 is required for S3Storage') from e
+            raise ImportError("boto3 is required for S3Storage") from e
         self.bucket = bucket
         self.prefix = prefix
-        self.s3 = client or boto3.client('s3', endpoint_url=endpoint_url)
+        self.s3 = client or boto3.client("s3", endpoint_url=endpoint_url)
 
     def _key(self, name: str) -> str:
         return f"{self.prefix}/{name}" if self.prefix else name
 
-    def save_dataset(self, data: List[dict], fmt: str = 'all') -> None:
-        if fmt in ['all', 'json']:
-            body = json.dumps(data, ensure_ascii=False, indent=4).encode('utf-8')
-            self.s3.put_object(Bucket=self.bucket, Key=self._key('wikipedia_qa.json'), Body=body)
-        if fmt in ['all', 'jsonl']:
-            lines = '\n'.join(json.dumps(row, ensure_ascii=False) for row in data)
+    def save_dataset(self, data: List[dict], fmt: str = "all") -> None:
+        if fmt in ["all", "json"]:
+            body = json.dumps(data, ensure_ascii=False, indent=4).encode("utf-8")
+            self.s3.put_object(
+                Bucket=self.bucket, Key=self._key("wikipedia_qa.json"), Body=body
+            )
+        if fmt in ["all", "jsonl"]:
+            lines = "\n".join(json.dumps(row, ensure_ascii=False) for row in data)
             self.s3.put_object(
                 Bucket=self.bucket,
-                Key=self._key('wikipedia_qa.jsonl'),
-                Body=lines.encode('utf-8'),
+                Key=self._key("wikipedia_qa.jsonl"),
+                Body=lines.encode("utf-8"),
             )
-        if fmt in ['all', 'csv']:
+        if fmt in ["all", "csv"]:
             import io
+
             buffer = io.StringIO()
             writer = csv.DictWriter(buffer, fieldnames=data[0].keys())
             writer.writeheader()
             for row in data:
-                writer.writerow({k: json.dumps(v, ensure_ascii=False) if isinstance(v, (list, dict)) else v for k, v in row.items()})
-            self.s3.put_object(Bucket=self.bucket, Key=self._key('wikipedia_qa.csv'), Body=buffer.getvalue().encode('utf-8'))
-        if fmt in ['all', 'parquet']:
+                writer.writerow(
+                    {
+                        k: (
+                            json.dumps(v, ensure_ascii=False)
+                            if isinstance(v, (list, dict))
+                            else v
+                        )
+                        for k, v in row.items()
+                    }
+                )
+            self.s3.put_object(
+                Bucket=self.bucket,
+                Key=self._key("wikipedia_qa.csv"),
+                Body=buffer.getvalue().encode("utf-8"),
+            )
+        if fmt in ["all", "parquet"]:
             try:
                 import pyarrow as pa
                 import pyarrow.parquet as pq
+
                 table = pa.Table.from_pylist(data)
                 buf = pa.BufferOutputStream()
                 pq.write_table(table, buf)
-                self.s3.put_object(Bucket=self.bucket, Key=self._key('wikipedia_qa.parquet'), Body=buf.getvalue().to_pybytes())
+                self.s3.put_object(
+                    Bucket=self.bucket,
+                    Key=self._key("wikipedia_qa.parquet"),
+                    Body=buf.getvalue().to_pybytes(),
+                )
             except Exception:
                 pass
-        if fmt in ['all', 'tfrecord']:
+        if fmt in ["all", "tfrecord"]:
             import tempfile
+
             try:
                 import tensorflow as tf
+
                 with tempfile.NamedTemporaryFile(delete=False) as tmp:
                     with tf.io.TFRecordWriter(tmp.name) as writer:
                         for row in data:
-                            writer.write(json.dumps(row, ensure_ascii=False).encode('utf-8'))
+                            writer.write(
+                                json.dumps(row, ensure_ascii=False).encode("utf-8")
+                            )
                     tmp.flush()
                     tmp.seek(0)
                     body = tmp.read()
-                self.s3.put_object(Bucket=self.bucket, Key=self._key('wikipedia_qa.tfrecord'), Body=body)
+                self.s3.put_object(
+                    Bucket=self.bucket,
+                    Key=self._key("wikipedia_qa.tfrecord"),
+                    Body=body,
+                )
             except Exception:
                 pass
 
 
 class MongoDBStorage(StorageBackend):
-    def __init__(self, uri: str, db_name: str = 'scraper', collection: str = 'dataset'):
+    def __init__(self, uri: str, db_name: str = "scraper", collection: str = "dataset"):
         try:
             from pymongo import MongoClient
         except Exception as e:
-            raise ImportError('pymongo is required for MongoDBStorage') from e
+            raise ImportError("pymongo is required for MongoDBStorage") from e
         client = MongoClient(uri)
         self.collection = client[db_name][collection]
 
-    def save_dataset(self, data: List[dict], fmt: str = 'all') -> None:
+    def save_dataset(self, data: List[dict], fmt: str = "all") -> None:
         if not data:
             return
         self.collection.insert_many(data)
+        _maybe_upload_large(data, "mongodb_dataset.json")
 
 
 class PostgreSQLStorage(StorageBackend):
-    def __init__(self, dsn: str, table: str = 'dataset'):
+    def __init__(self, dsn: str, table: str = "dataset"):
         try:
             import psycopg2
         except Exception as e:
-            raise ImportError('psycopg2 is required for PostgreSQLStorage') from e
+            raise ImportError("psycopg2 is required for PostgreSQLStorage") from e
         self.conn = psycopg2.connect(dsn)
         self.table = table
+        with self.conn, self.conn.cursor() as cur:
+            cur.execute(
+                f"CREATE TABLE IF NOT EXISTS {self.table} (id SERIAL PRIMARY KEY, data JSONB NOT NULL)"
+            )
 
-    def save_dataset(self, data: List[dict], fmt: str = 'all') -> None:
+    def save_dataset(self, data: List[dict], fmt: str = "all") -> None:
         import json as _json
+
         with self.conn, self.conn.cursor() as cur:
             for row in data:
-                cur.execute(f"INSERT INTO {self.table} (data) VALUES (%s)", [_json.dumps(row)])
+                cur.execute(
+                    f"INSERT INTO {self.table} (data) VALUES (%s)", [_json.dumps(row)]
+                )
+        _maybe_upload_large(data, "postgres_dataset.json")
 
 
 def get_backend(name: str, output_dir: str):
-    name = (name or 'local').lower()
-    if name in ['s3', 'minio']:
-        bucket = os.environ.get('S3_BUCKET', 'datasets')
-        prefix = os.environ.get('S3_PREFIX', '')
-        endpoint = os.environ.get('S3_ENDPOINT') if name == 's3' else os.environ.get('MINIO_ENDPOINT')
+    name = (name or "local").lower()
+    if name in ["s3", "minio"]:
+        bucket = os.environ.get("S3_BUCKET", "datasets")
+        prefix = os.environ.get("S3_PREFIX", "")
+        endpoint = (
+            os.environ.get("S3_ENDPOINT")
+            if name == "s3"
+            else os.environ.get("MINIO_ENDPOINT")
+        )
         return S3Storage(bucket, prefix=prefix, endpoint_url=endpoint)
-    if name == 'mongodb':
-        uri = os.environ.get('MONGODB_URI', 'mongodb://localhost:27017')
-        db = os.environ.get('MONGODB_DB', 'scraper')
-        col = os.environ.get('MONGODB_COLLECTION', 'dataset')
+    if name == "mongodb":
+        uri = os.environ.get("MONGODB_URI", "mongodb://localhost:27017")
+        db = os.environ.get("MONGODB_DB", "scraper")
+        col = os.environ.get("MONGODB_COLLECTION", "dataset")
         return MongoDBStorage(uri, db, col)
-    if name == 'postgres':
-        dsn = os.environ.get('POSTGRES_DSN', 'dbname=scraper user=postgres')
-        table = os.environ.get('POSTGRES_TABLE', 'dataset')
+    if name == "postgres":
+        dsn = os.environ.get("POSTGRES_DSN", "dbname=scraper user=postgres")
+        table = os.environ.get("POSTGRES_TABLE", "dataset")
         return PostgreSQLStorage(dsn, table)
     return LocalStorage(output_dir)

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,0 +1,114 @@
+import importlib
+import sys
+import os
+from types import SimpleNamespace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _reload(monkeypatch, modules=None):
+    if modules:
+        for name, mod in modules.items():
+            monkeypatch.setitem(sys.modules, name, mod)
+    return importlib.reload(importlib.import_module("storage"))
+
+
+def test_get_backend_postgres(monkeypatch, tmp_path):
+    class DummyCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, *args, **kwargs):
+            pass
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    pg_mod = SimpleNamespace(connect=lambda dsn: DummyConn())
+    storage_mod = _reload(monkeypatch, {"psycopg2": pg_mod})
+    backend = storage_mod.get_backend("postgres", str(tmp_path))
+    assert isinstance(backend, storage_mod.PostgreSQLStorage)
+
+
+def test_get_backend_mongodb(monkeypatch, tmp_path):
+    class DummyCollection:
+        def insert_many(self, data):
+            self.data = data
+
+    class DummyDB:
+        def __getitem__(self, name):
+            return DummyCollection()
+
+    class DummyClient:
+        def __init__(self, uri):
+            self.uri = uri
+
+        def __getitem__(self, name):
+            return DummyDB()
+
+    pymod = SimpleNamespace(MongoClient=DummyClient)
+    storage_mod = _reload(monkeypatch, {"pymongo": pymod})
+    backend = storage_mod.get_backend("mongodb", str(tmp_path))
+    assert isinstance(backend, storage_mod.MongoDBStorage)
+
+
+def test_get_backend_s3(monkeypatch, tmp_path):
+    class DummyClient:
+        def put_object(self, **kw):
+            self.kw = kw
+
+    boto = SimpleNamespace(client=lambda *a, **k: DummyClient())
+    storage_mod = _reload(monkeypatch, {"boto3": boto})
+    backend = storage_mod.get_backend("s3", str(tmp_path))
+    assert isinstance(backend, storage_mod.S3Storage)
+
+
+def test_get_backend_local(monkeypatch, tmp_path):
+    storage_mod = _reload(monkeypatch, {})
+    backend = storage_mod.get_backend("local", str(tmp_path))
+    assert isinstance(backend, storage_mod.LocalStorage)
+
+
+def test_offload_to_s3(monkeypatch, tmp_path):
+    uploaded = {}
+
+    class DummyClient:
+        def put_object(self, **kw):
+            uploaded.update(kw)
+
+    boto = SimpleNamespace(client=lambda *a, **k: DummyClient())
+
+    class DummyCollection:
+        def insert_many(self, data):
+            self.data = data
+
+    class DummyDB:
+        def __getitem__(self, name):
+            return DummyCollection()
+
+    class DummyClientDB:
+        def __init__(self, uri):
+            self.uri = uri
+
+        def __getitem__(self, name):
+            return DummyDB()
+
+    pymod = SimpleNamespace(MongoClient=DummyClientDB)
+    monkeypatch.setenv("S3_UPLOAD_BUCKET", "bucket")
+    monkeypatch.setenv("UPLOAD_THRESHOLD_MB", "0")
+    storage_mod = _reload(monkeypatch, {"boto3": boto, "pymongo": pymod})
+    backend = storage_mod.get_backend("mongodb", str(tmp_path))
+    backend.save_dataset([{"a": 1}])
+    assert uploaded["Bucket"] == "bucket"


### PR DESCRIPTION
## Summary
- handle large dataset uploads to S3/GCS
- automatically create postgres tables and insert docs
- insert mongodb docs and optionally offload
- add backend tests for env selection

## Testing
- `black storage.py tests/test_backend_selection.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685887d364148320b802e719abdf7e9d