### PR TITLE
Add tutorial for code model fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,26 @@ G = relations_to_graph(data['relations'])
 nx.write_graphml(G, 'relations.graphml')
 ```
 
+### Fine-tuning de Modelos de Código
+
+O plugin `github_scraper` permite coletar READMEs e arquivos de projetos no
+GitHub. Esses textos podem ser usados para treinar modelos de geração de
+código, como os baseados em Transformers. Um fluxo simples é:
+
+```python
+from plugins import load_plugin, run_plugin
+from datasets import Dataset
+
+plugin = load_plugin("github_scraper")
+records = run_plugin(plugin, ["en"], ["machine-learning"])
+ds = Dataset.from_list(records)
+ds.save_to_disk("github_code")
+```
+
+O diretório salvo pode ser carregado por `datasets` e utilizado em
+`examples/code_fine_tuning.ipynb`, que demonstra o fine-tuning do modelo
+`codegen-350M-multi` utilizando o `Trainer` da biblioteca Transformers.
+
 ## Docker
 
 Para executar a API e o worker em contêineres, primeiro construa a imagem base:

--- a/cluster.py
+++ b/cluster.py
@@ -1,3 +1,5 @@
+"""Helpers to load distributed cluster configuration."""
+
 import os
 import yaml
 
@@ -8,23 +10,25 @@ def load_config(path: str | None = None) -> dict:
     path = path or DEFAULT_CONFIG
     if not os.path.exists(path):
         return {}
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
 
 def get_client(config: dict | None = None):
     cfg = config or load_config()
-    backend = cfg.get('cluster', {}).get('backend')
-    scheduler = cfg.get('cluster', {}).get('scheduler')
-    if backend == 'dask':
+    backend = cfg.get("cluster", {}).get("backend")
+    scheduler = cfg.get("cluster", {}).get("scheduler")
+    if backend == "dask":
         try:
             from dask.distributed import Client
+
             return Client(scheduler)
         except Exception:
-            raise RuntimeError('Dask not available')
-    elif backend == 'ray':
+            raise RuntimeError("Dask not available")
+    elif backend == "ray":
         try:
             import ray
+
             ray.init(address=scheduler)
 
             class _RayFuture:
@@ -42,5 +46,5 @@ def get_client(config: dict | None = None):
 
             return _RayClient()
         except Exception:
-            raise RuntimeError('Ray not available')
+            raise RuntimeError("Ray not available")
     return None

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,3 +1,5 @@
+"""Streamlit dashboard to visualize scraping statistics."""
+
 import json
 import os
 from pathlib import Path
@@ -71,7 +73,9 @@ def load_metrics():
         )
         resp.raise_for_status()
         count_data = resp.json()
-        if sum_data.get("data", {}).get("result") and count_data.get("data", {}).get("result"):
+        if sum_data.get("data", {}).get("result") and count_data.get("data", {}).get(
+            "result"
+        ):
             total = float(sum_data["data"]["result"][0]["value"][1])
             count = float(count_data["data"]["result"][0]["value"][1])
             if count:
@@ -92,7 +96,9 @@ def load_metrics():
         )
         resp.raise_for_status()
         sess_count = resp.json()
-        if sess_sum.get("data", {}).get("result") and sess_count.get("data", {}).get("result"):
+        if sess_sum.get("data", {}).get("result") and sess_count.get("data", {}).get(
+            "result"
+        ):
             total = float(sess_sum["data"]["result"][0]["value"][1])
             count = float(sess_count["data"]["result"][0]["value"][1])
             if count:

--- a/docs/code_fine_tuning.rst
+++ b/docs/code_fine_tuning.rst
@@ -1,0 +1,41 @@
+Code Model Fine-tuning
+======================
+
+This tutorial explains how to create datasets suitable for fine-tuning code generation models using the GitHub scraping plugin and the utilities provided in :mod:`training`.
+
+1. Run the GitHub plugin to download repositories by topic or user.
+   The example below collects the README files of popular projects tagged
+   ``machine-learning``::
+
+       from plugins import load_plugin, run_plugin
+
+       plugin = load_plugin("github_scraper")
+       records = run_plugin(plugin, ["en"], ["machine-learning"])
+
+   Each record contains the repository name, language and the cleaned text of the README.
+
+2. Save the dataset in the Hugging Face format so it can be loaded directly by ``datasets``::
+
+       from training.pipeline import save_json
+       from datasets import Dataset
+
+       save_json(records, "github_code.json")
+       ds = Dataset.from_json("github_code.json")
+       ds.push_to_hub("my/github-code")  # optional
+
+3. Prepare the inputs for your model. For encoder models use ``prepare_bert_inputs``::
+
+       from training.pretrained_utils import prepare_bert_inputs
+
+       batch = prepare_bert_inputs([r["content"] for r in records])
+
+4. Fine-tune the model with ``transformers``::
+
+       from transformers import AutoModelForCausalLM, Trainer, TrainingArguments
+
+       model = AutoModelForCausalLM.from_pretrained("Salesforce/codegen-350M-multi")
+       args = TrainingArguments(output_dir="ft-code", num_train_epochs=1)
+       trainer = Trainer(model=model, args=args, train_dataset=ds)
+       trainer.train()
+
+The resulting model can then be used to generate code snippets conditioned on the README text or other prompts.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,3 +5,4 @@ Scraper-Wiki Documentation
    :maxdepth: 2
 
    modules
+   code_fine_tuning

--- a/examples/code_fine_tuning.ipynb
+++ b/examples/code_fine_tuning.ipynb
@@ -1,0 +1,43 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Fine-tuning Code Models"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "Este notebook mostra como gerar um dataset de reposit\u00f3rios do GitHub e treinar um modelo de gera\u00e7\u00e3o de c\u00f3digo."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "!pip install -q transformers datasets"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "from plugins import load_plugin, run_plugin\nplugin = load_plugin('github_scraper')\nrecords = run_plugin(plugin, ['en'], ['machine-learning'])"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "from datasets import Dataset\nds = Dataset.from_list(records)\nprint(ds[0])"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "from transformers import AutoModelForCausalLM, Trainer, TrainingArguments\nmodel = AutoModelForCausalLM.from_pretrained('Salesforce/codegen-350M-multi')\nargs = TrainingArguments(output_dir='ft-code', num_train_epochs=1)\ntrainer = Trainer(model=model, args=args, train_dataset=ds)\ntrainer.train()"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/metrics.py
+++ b/metrics.py
@@ -1,3 +1,5 @@
+"""Prometheus metrics used to monitor scraping performance."""
+
 from prometheus_client import Counter, Histogram, Gauge, start_http_server
 
 scrape_success = Counter(


### PR DESCRIPTION
## Summary
- document `cluster`, `dashboard`, and `metrics` modules
- add tutorial on creating datasets for code models
- expose the new tutorial in docs index
- include example notebook `code_fine_tuning.ipynb`
- update README with code fine-tuning section

## Testing
- `black -q cluster.py metrics.py dashboard.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68589a1a14108320bb85f94e3e73e241