### PR TITLE
Enhance training exports and add preprocessing

### DIFF
--- a/examples/export_dataset.py
+++ b/examples/export_dataset.py
@@ -1,0 +1,39 @@
+"""Example script demonstrating dataset export formats."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from training import run_pipeline, chunk_text, tokenize_texts
+from training.formats import save_hf_dataset, save_tfrecord_dataset, save_arrow_table
+
+
+def main(in_file: str, out_dir: str = "exported") -> None:
+    """Run the training pipeline and export in several formats."""
+    run_pipeline(in_file)
+
+    records = json.load(open(in_file, encoding="utf-8"))
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    save_hf_dataset(records, out / "hf")
+    save_tfrecord_dataset(records, out / "data.tfrecord")
+    save_arrow_table(records, out / "data.arrow")
+
+    texts = [r.get("content", "") for r in records]
+    tokenize_texts(texts)
+    for t in texts:
+        chunk_text(t, 128, overlap=32)
+
+    print(f"Export completed to: {out.resolve()}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description="Export dataset examples")
+    p.add_argument("input", help="Path to the JSON dataset")
+    p.add_argument("--out", default="exported", help="Output directory")
+    args = p.parse_args()
+    main(args.input, args.out)

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -1,0 +1,40 @@
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+# Stub transformers to avoid heavy dependency
+class DummyTokenizer:
+    def __call__(self, texts, padding=True, truncation=True):
+        return {"input_ids": texts}
+
+
+sys.modules["transformers"] = SimpleNamespace(
+    AutoTokenizer=SimpleNamespace(from_pretrained=lambda name: DummyTokenizer())
+)
+
+spec = importlib.util.spec_from_file_location(
+    "training.preprocessing",
+    ROOT / "training" / "preprocessing.py",
+)
+preprocess = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(preprocess)
+
+
+def test_tokenize_texts():
+    res = preprocess.tokenize_texts(["a", "b"])
+    assert "input_ids" in res
+    assert len(res["input_ids"]) == 2
+
+
+def test_chunk_text():
+    text = " ".join(str(i) for i in range(10))
+    chunks = preprocess.chunk_text(text, 4, overlap=2)
+    assert chunks[0] == "0 1 2 3"
+    assert chunks[1] == "2 3 4 5"

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,1 +1,4 @@
+"""Training utilities and preprocessing helpers."""
+
 from .pipeline import run_pipeline
+from .preprocessing import chunk_text, tokenize_texts

--- a/training/formats.py
+++ b/training/formats.py
@@ -5,6 +5,54 @@ from typing import List, Dict
 from utils.text import clean_text
 
 
+def save_hf_dataset(records: List[Dict], directory: Path) -> None:
+    """Save ``records`` to a Hugging Face dataset directory.
+
+    Parameters
+    ----------
+    records : list[dict]
+        Dataset records.
+    directory : pathlib.Path
+        Target directory to store the dataset.
+    """
+    try:
+        from datasets import Dataset
+
+        ds = Dataset.from_list(records)
+        directory.mkdir(parents=True, exist_ok=True)
+        ds.save_to_disk(str(directory))
+    except Exception:  # pragma: no cover - optional deps
+        return
+
+
+def save_tfrecord_dataset(records: List[Dict], path: Path) -> None:
+    """Write ``records`` to a TFRecord file."""
+    try:
+        import tensorflow as tf
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tf.io.TFRecordWriter(str(path)) as writer:
+            for rec in records:
+                writer.write(json.dumps(rec, ensure_ascii=False).encode("utf-8"))
+    except Exception:  # pragma: no cover - optional deps
+        return
+
+
+def save_arrow_table(records: List[Dict], path: Path) -> None:
+    """Export ``records`` to an Apache Arrow file."""
+    try:
+        import pyarrow as pa
+        import pyarrow.ipc as ipc
+
+        table = pa.Table.from_pylist(records)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with pa.OSFile(str(path), "wb") as sink:
+            with ipc.new_file(sink, table.schema) as writer:
+                writer.write(table)
+    except Exception:  # pragma: no cover - optional deps
+        return
+
+
 def save_qa_dataset(records: List[Dict], path: Path) -> None:
     """Save question/answer pairs in a simple JSON list."""
     pairs = []

--- a/training/pipeline.py
+++ b/training/pipeline.py
@@ -2,6 +2,12 @@ import json
 from pathlib import Path
 from typing import List, Dict
 
+from .formats import (
+    save_arrow_table,
+    save_hf_dataset,
+    save_tfrecord_dataset,
+)
+
 
 def load_dataset(path: str | Path) -> List[Dict]:
     """Load dataset from JSON file."""
@@ -31,10 +37,7 @@ def convert_to_embeddings(records: List[Dict]) -> List[Dict]:
     """Extract embeddings from dataset."""
     emb = []
     for rec in records:
-        emb.append({
-            "id": rec.get("id"),
-            "embedding": rec.get("content_embedding")
-        })
+        emb.append({"id": rec.get("id"), "embedding": rec.get("content_embedding")})
     return emb
 
 
@@ -62,3 +65,7 @@ def run_pipeline(dataset_path: str | Path) -> None:
 
     triples = convert_to_triples(records)
     save_json(triples, base.with_name(base.name + "_triples.json"))
+
+    save_hf_dataset(records, base.with_name(base.name + "_hf"))
+    save_tfrecord_dataset(records, base.with_suffix(".tfrecord"))
+    save_arrow_table(records, base.with_suffix(".arrow"))

--- a/training/preprocessing.py
+++ b/training/preprocessing.py
@@ -1,0 +1,57 @@
+"""Preprocessing utilities for training datasets."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+
+def tokenize_texts(texts: List[str], tokenizer_name: str = "bert-base-uncased") -> Dict:
+    """Tokenize a list of texts using a Hugging Face tokenizer.
+
+    Parameters
+    ----------
+    texts : list[str]
+        Text samples to tokenize.
+    tokenizer_name : str, optional
+        Name of the tokenizer to load, by default ``"bert-base-uncased"``.
+
+    Returns
+    -------
+    dict
+        Tokenization output from the tokenizer.
+    """
+    try:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(tokenizer_name)
+        return tok(texts, padding=True, truncation=True)
+    except Exception:  # pragma: no cover - optional deps
+        return {"input_ids": [t.split() for t in texts]}
+
+
+def chunk_text(text: str, max_length: int, overlap: int = 0) -> List[str]:
+    """Split ``text`` into word chunks of ``max_length`` tokens.
+
+    Parameters
+    ----------
+    text : str
+        Input text.
+    max_length : int
+        Maximum number of words per chunk.
+    overlap : int, optional
+        Number of overlapping words between consecutive chunks.
+
+    Returns
+    -------
+    list[str]
+        List of text chunks.
+    """
+    words = text.split()
+    chunks: List[str] = []
+    start = 0
+    step = max_length - overlap if overlap < max_length else max_length
+    while start < len(words):
+        end = start + max_length
+        chunks.append(" ".join(words[start:end]))
+        start += step
+    return chunks


### PR DESCRIPTION
## Summary
- add utility module `training.preprocessing` with tokenization and chunking helpers
- extend `training.formats` to support Hugging Face, TFRecord and Arrow exports
- update pipeline to write these new formats
- expose preprocessing utilities in package init
- provide example script `examples/export_dataset.py`
- add tests for preprocessing utilities

## Testing
- `pip install beautifulsoup4 requests datasets pyarrow`
- `pip install simhash`
- `pip install prometheus-client`
- `pip install typer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a63cc9b08320bf90635941d93a07