### PR TITLE
Add GitHub/GitLab code extraction plugins

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -13,6 +13,8 @@ AVAILABLE_PLUGINS = {
     "infobox_parser": "infobox_parser",
     "table_parser": "table_parser",
     "github_scraper": "github_scraper",
+    "code_extractor": "code_extractor",
+    "gitlab_scraper": "gitlab_scraper",
 }
 
 

--- a/plugins/code_extractor.py
+++ b/plugins/code_extractor.py
@@ -1,0 +1,93 @@
+"""GitHub code extraction utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+
+from .base import Plugin
+
+
+class CodeExtractor:
+    """Extract repository code and metrics from GitHub."""
+
+    def __init__(self, token: str | None = None, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://api.github.com"
+        self.token = token
+        self._code_exts = {".py", ".js", ".ts", ".java", ".go", ".rb", ".php", ".rs"}
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        return headers
+
+    def search_repositories(
+        self, language: str, min_stars: int, per_page: int = 10
+    ) -> List[Dict]:
+        """Return repositories matching language and star count."""
+        query = f"language:{language} stars:>={min_stars}"
+        params = {"q": query, "sort": "stars", "order": "desc", "per_page": per_page}
+        resp = requests.get(
+            f"{self.api_url}/search/repositories",
+            headers=self._headers(),
+            params=params,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("items", [])
+
+    def _list_code_files(self, full_name: str, branch: str) -> List[str]:
+        url = f"{self.api_url}/repos/{full_name}/git/trees/{branch}?recursive=1"
+        resp = requests.get(url, headers=self._headers())
+        resp.raise_for_status()
+        tree = resp.json().get("tree", [])
+        paths = [
+            it["path"]
+            for it in tree
+            if it.get("type") == "blob"
+            and Path(it.get("path", "")).suffix in self._code_exts
+        ]
+        return paths
+
+    def download_repository_files(
+        self, full_name: str, branch: str | None = None
+    ) -> Dict[str, str]:
+        """Download source files for a repository."""
+        branch = branch or "master"
+        files = {}
+        for path in self._list_code_files(full_name, branch):
+            url = f"{self.api_url}/repos/{full_name}/contents/{path}"
+            resp = requests.get(
+                url,
+                headers={"Accept": "application/vnd.github.v3.raw"},
+                params={"ref": branch},
+            )
+            resp.raise_for_status()
+            files[path] = resp.text
+        return files
+
+    def collect_repository_data(self, repo: Dict) -> Dict:
+        """Return repository metrics and source file list."""
+        full_name = repo.get("full_name")
+        if not full_name:
+            return {}
+        branch = repo.get("default_branch", "master")
+        file_paths = self._list_code_files(full_name, branch)
+        has_tests = any(
+            "test" in Path(p).parts[0].lower() or "test" in Path(p).name.lower()
+            for p in file_paths
+        )
+        return {
+            "repository": full_name,
+            "stars": repo.get("stargazers_count", 0),
+            "open_issues": repo.get("open_issues_count", 0),
+            "has_tests": has_tests,
+            "files": file_paths,
+        }
+
+
+class Plugin(CodeExtractor):
+    """Alias for plugin registry."""

--- a/plugins/gitlab_scraper.py
+++ b/plugins/gitlab_scraper.py
@@ -1,0 +1,85 @@
+"""GitLab repository scraping utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+
+from .base import Plugin
+
+
+class GitLabScraper:
+    """Fetch projects and code data from GitLab."""
+
+    def __init__(self, token: str | None = None, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://gitlab.com/api/v4"
+        self.token = token
+        self._code_exts = {".py", ".js", ".ts", ".java", ".go", ".rb", ".php", ".rs"}
+
+    def _headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self.token:
+            headers["PRIVATE-TOKEN"] = self.token
+        return headers
+
+    def search_repositories(
+        self, language: str, min_stars: int, per_page: int = 20
+    ) -> List[Dict]:
+        """Return GitLab projects filtered by language and star count."""
+        params = {
+            "search": language,
+            "order_by": "star_count",
+            "sort": "desc",
+            "per_page": per_page,
+            "simple": True,
+        }
+        resp = requests.get(
+            f"{self.api_url}/projects",
+            headers=self._headers(),
+            params=params,
+        )
+        resp.raise_for_status()
+        items = resp.json()
+        return [it for it in items if it.get("star_count", 0) >= min_stars]
+
+    def _list_code_files(self, project_id: int, branch: str) -> List[str]:
+        url = f"{self.api_url}/projects/{project_id}/repository/tree"
+        resp = requests.get(
+            url,
+            headers=self._headers(),
+            params={"recursive": True, "ref": branch, "per_page": 100},
+        )
+        resp.raise_for_status()
+        tree = resp.json()
+        paths = [
+            it.get("path")
+            for it in tree
+            if it.get("type") == "blob"
+            and Path(it.get("path", "")).suffix in self._code_exts
+        ]
+        return paths
+
+    def collect_repository_data(self, repo: Dict) -> Dict:
+        """Return project metrics and file list."""
+        project_id = repo.get("id")
+        if project_id is None:
+            return {}
+        branch = repo.get("default_branch", "master")
+        file_paths = self._list_code_files(project_id, branch)
+        has_tests = any(
+            "test" in Path(p).name.lower() or "test" in Path(p).parts[0].lower()
+            for p in file_paths
+        )
+        return {
+            "repository": repo.get("path_with_namespace"),
+            "stars": repo.get("star_count", 0),
+            "open_issues": repo.get("open_issues_count", 0),
+            "has_tests": has_tests,
+            "files": file_paths,
+        }
+
+
+class Plugin(GitLabScraper):
+    """Alias for plugin registry."""

--- a/tests/test_code_extractors.py
+++ b/tests/test_code_extractors.py
@@ -1,0 +1,123 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_code_extractor_search(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    called = {}
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, headers=None, params=None):
+        called["url"] = url
+        called["params"] = params
+        return DummyResp({"items": [{"full_name": "u/r", "stargazers_count": 100}]})
+
+    mod = importlib.import_module("plugins.code_extractor")
+    monkeypatch.setattr(requests, "get", fake_get)
+    extractor = mod.CodeExtractor()
+    repos = extractor.search_repositories("python", 50)
+    assert called["params"]["q"] == "language:python stars:>=50"
+    assert repos[0]["full_name"] == "u/r"
+
+
+def test_collect_repository_data(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, headers=None, params=None):
+        return DummyResp(
+            {
+                "tree": [
+                    {"path": "app.py", "type": "blob"},
+                    {"path": "tests/test_app.py", "type": "blob"},
+                ]
+            }
+        )
+
+    mod = importlib.import_module("plugins.code_extractor")
+    monkeypatch.setattr(requests, "get", fake_get)
+    extractor = mod.CodeExtractor()
+    repo = {
+        "full_name": "u/r",
+        "default_branch": "master",
+        "stargazers_count": 5,
+        "open_issues_count": 1,
+    }
+    data = extractor.collect_repository_data(repo)
+    assert data["has_tests"] is True
+    assert data["stars"] == 5
+    assert data["open_issues"] == 1
+    assert len(data["files"]) == 2
+
+
+def test_gitlab_scraper_search(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    called = {}
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    response = [
+        {"id": 1, "path_with_namespace": "u/r", "star_count": 30},
+        {"id": 2, "path_with_namespace": "x/y", "star_count": 10},
+    ]
+
+    def fake_get(url, headers=None, params=None):
+        called["url"] = url
+        called["params"] = params
+        return DummyResp(response)
+
+    mod = importlib.import_module("plugins.gitlab_scraper")
+    monkeypatch.setattr(requests, "get", fake_get)
+    scraper = mod.GitLabScraper()
+    repos = scraper.search_repositories("python", 20)
+    assert called["params"]["search"] == "python"
+    assert len(repos) == 1
+    assert repos[0]["id"] == 1


### PR DESCRIPTION
## Summary
- implement `CodeExtractor` for GitHub search and code metrics
- add `GitLabScraper` for GitLab projects
- register both in plugin registry
- unit tests for search/filter logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b31428448320a958049a972b30f6