### PR TITLE
Add configurable StackExchange plugin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,8 @@
 import json
 import logging
 from pathlib import Path
+from typing import List, Optional
+
 import typer
 
 import scraper_wiki
@@ -12,13 +14,33 @@ app = typer.Typer(help="Scraper Wiki command line interface")
 @app.callback(invoke_without_command=False)
 def main(
     ctx: typer.Context,
-    cache_backend: str = typer.Option(None, "--cache-backend", help="Backend de cache", show_default=False),
-    cache_ttl: int = typer.Option(None, "--cache-ttl", help="Tempo de vida do cache em segundos", show_default=False),
-    log_level: str = typer.Option(None, "--log-level", help="Nível de log (DEBUG, INFO, WARNING...)", show_default=False),
-    log_format: str = typer.Option("text", "--log-format", help="Formato do log (text ou json)"),
-    max_threads: int = typer.Option(None, "--max-threads", help="Número máximo de threads", show_default=False),
-    max_processes: int = typer.Option(None, "--max-processes", help="Número máximo de processos", show_default=False),
-    storage_backend: str = typer.Option(None, "--storage-backend", help="Backend de armazenamento", show_default=False),
+    cache_backend: str = typer.Option(
+        None, "--cache-backend", help="Backend de cache", show_default=False
+    ),
+    cache_ttl: int = typer.Option(
+        None,
+        "--cache-ttl",
+        help="Tempo de vida do cache em segundos",
+        show_default=False,
+    ),
+    log_level: str = typer.Option(
+        None,
+        "--log-level",
+        help="Nível de log (DEBUG, INFO, WARNING...)",
+        show_default=False,
+    ),
+    log_format: str = typer.Option(
+        "text", "--log-format", help="Formato do log (text ou json)"
+    ),
+    max_threads: int = typer.Option(
+        None, "--max-threads", help="Número máximo de threads", show_default=False
+    ),
+    max_processes: int = typer.Option(
+        None, "--max-processes", help="Número máximo de processos", show_default=False
+    ),
+    storage_backend: str = typer.Option(
+        None, "--storage-backend", help="Backend de armazenamento", show_default=False
+    ),
 ):
     if cache_backend is not None:
         scraper_wiki.Config.CACHE_BACKEND = cache_backend
@@ -27,8 +49,14 @@ def main(
         scraper_wiki.Config.CACHE_TTL = cache_ttl
 
     if log_level is not None or log_format != "text":
-        level = getattr(logging, log_level.upper(), logging.INFO) if log_level else logging.INFO
-        scraper_wiki.setup_logger("wiki_scraper", "scraper.log", level=level, fmt=log_format)
+        level = (
+            getattr(logging, log_level.upper(), logging.INFO)
+            if log_level
+            else logging.INFO
+        )
+        scraper_wiki.setup_logger(
+            "wiki_scraper", "scraper.log", level=level, fmt=log_format
+        )
     if max_threads is not None:
         scraper_wiki.Config.MAX_THREADS = max_threads
     if max_processes is not None:
@@ -36,12 +64,18 @@ def main(
     if storage_backend is not None:
         scraper_wiki.Config.STORAGE_BACKEND = storage_backend
 
+
 QUEUE_FILE = Path("jobs_queue.jsonl")
+
 
 @app.command()
 def scrape(
-    lang: list[str] = typer.Option(None, "--lang", help="Idioma a processar", show_default=False),
-    category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
+    lang: Optional[List[str]] = typer.Option(
+        None, "--lang", help="Idioma a processar", show_default=False
+    ),
+    category: Optional[List[str]] = typer.Option(
+        None, "--category", help="Categoria específica", show_default=False
+    ),
     fmt: str = typer.Option(
         "all",
         "--format",
@@ -58,28 +92,46 @@ def scrape(
         "--depth",
         help="Profundidade de navegação para páginas iniciais",
     ),
-    rate_limit_delay: float = typer.Option(None, "--rate-limit-delay", help="Delay entre requisições", show_default=False),
-    revisions: bool = typer.Option(False, "--revisions", help="Inclui histórico de revisões", is_flag=True),
+    rate_limit_delay: float = typer.Option(
+        None, "--rate-limit-delay", help="Delay entre requisições", show_default=False
+    ),
+    revisions: bool = typer.Option(
+        False, "--revisions", help="Inclui histórico de revisões", is_flag=True
+    ),
     rev_limit: int = typer.Option(5, "--rev-limit", help="Número máximo de revisões"),
-    async_mode: bool = typer.Option(False, "--async", help="Usa scraping assíncrono", is_flag=True),
+    async_mode: bool = typer.Option(
+        False, "--async", help="Usa scraping assíncrono", is_flag=True
+    ),
     plugin: str = typer.Option(
         "wikipedia",
         "--plugin",
         help="Plugin de scraping (wikipedia, infobox_parser, table_parser)",
     ),
-    distributed: bool = typer.Option(False, "--distributed", help="Usa cluster distribuído", is_flag=True),
-    train: bool = typer.Option(False, "--train", help="Executa conversões para treinamento"),
+    distributed: bool = typer.Option(
+        False, "--distributed", help="Usa cluster distribuído", is_flag=True
+    ),
+    train: bool = typer.Option(
+        False, "--train", help="Executa conversões para treinamento"
+    ),
 ):
     """Executa o scraper imediatamente."""
-    cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
+    lang = lang or None
+    category = category or None
+    cats = (
+        [scraper_wiki.normalize_category(c) or c for c in category]
+        if category
+        else None
+    )
     client = None
     if distributed:
         from cluster import get_client
+
         client = get_client()
 
     if plugin == "wikipedia":
         if async_mode:
             import asyncio
+
             asyncio.run(
                 scraper_wiki.main_async(
                     lang,
@@ -107,6 +159,7 @@ def scrape(
         dataset_file = Path(scraper_wiki.Config.OUTPUT_DIR) / "wikipedia_qa.json"
         if dataset_file.exists() and train:
             from training import pipeline
+
             pipeline.run_pipeline(dataset_file)
     else:
         from plugins import load_plugin, run_plugin
@@ -116,15 +169,21 @@ def scrape(
         categories = cats or list(scraper_wiki.Config.CATEGORIES)
         run_plugin(plg, languages, categories, fmt)
 
+
 @app.command()
 def monitor():
     """Inicia o dashboard para monitoramento."""
     dashboard.main()
 
+
 @app.command()
 def queue(
-    lang: list[str] = typer.Option(None, "--lang", help="Idioma a processar", show_default=False),
-    category: list[str] = typer.Option(None, "--category", help="Categoria específica", show_default=False),
+    lang: Optional[List[str]] = typer.Option(
+        None, "--lang", help="Idioma a processar", show_default=False
+    ),
+    category: Optional[List[str]] = typer.Option(
+        None, "--category", help="Categoria específica", show_default=False
+    ),
     fmt: str = typer.Option(
         "all",
         "--format",
@@ -132,7 +191,13 @@ def queue(
     ),
 ):
     """Enfileira um job de scraping."""
-    cats = [scraper_wiki.normalize_category(c) or c for c in category] if category else None
+    lang = lang or None
+    category = category or None
+    cats = (
+        [scraper_wiki.normalize_category(c) or c for c in category]
+        if category
+        else None
+    )
     job = {"lang": lang, "category": cats, "format": fmt}
     QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
     with QUEUE_FILE.open("a", encoding="utf-8") as f:
@@ -170,6 +235,7 @@ def clear_cache_cmd():
     """Remove entradas expiradas do cache."""
     scraper_wiki.clear_cache()
     typer.echo("Cache limpo")
+
 
 if __name__ == "__main__":
     app()

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -9,6 +9,7 @@ from .base import Plugin
 AVAILABLE_PLUGINS = {
     "wikipedia": "wikipedia",
     "wikidata": "wikidata",
+    "stackexchange": "stackexchange",
     "stackoverflow": "stackoverflow",
     "infobox_parser": "infobox_parser",
     "table_parser": "table_parser",

--- a/plugins/stackexchange.py
+++ b/plugins/stackexchange.py
@@ -1,0 +1,67 @@
+"""Stack Exchange scraping plugin."""
+
+from typing import List, Dict
+
+import html2text
+import requests
+
+from scraper_wiki import Config, advanced_clean_text
+from .base import Plugin
+
+
+class StackExchangePlugin(Plugin):
+    """Fetch questions from a Stack Exchange site by tag."""
+
+    def __init__(
+        self,
+        site: str | None = None,
+        api_key: str | None = None,
+        endpoint: str | None = None,
+        min_score: int | None = None,
+    ) -> None:
+        self.site = site or Config.STACKEXCHANGE_SITE
+        self.api_key = api_key or Config.STACKEXCHANGE_API_KEY
+        self.endpoint = (endpoint or Config.STACKEXCHANGE_API_ENDPOINT).rstrip("/")
+        self.min_score = (
+            Config.STACKEXCHANGE_MIN_SCORE if min_score is None else min_score
+        )
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        params = {
+            "site": self.site,
+            "tagged": category,
+            "pagesize": 10,
+            "order": "desc",
+            "sort": "votes",
+            "filter": "withbody",
+        }
+        if self.api_key:
+            params["key"] = self.api_key
+        resp = requests.get(
+            f"{self.endpoint}/questions", params=params, timeout=Config.TIMEOUT
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        items = data.get("items", [])
+        filtered = [it for it in items if it.get("score", 0) >= self.min_score]
+        for it in filtered:
+            it["lang"] = lang
+            it["category"] = category
+        return filtered
+
+    def parse_item(self, item: Dict) -> Dict:
+        body = item.get("body", "")
+        text = html2text.html2text(body) if hasattr(html2text, "html2text") else body
+        clean = advanced_clean_text(text, item.get("lang", "en"))
+        return {
+            "title": item.get("title", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "score": item.get("score", 0),
+            "link": item.get("link", ""),
+            "content": clean,
+        }
+
+
+# Backwards compatible alias
+Plugin = StackExchangePlugin

--- a/plugins/stackoverflow.py
+++ b/plugins/stackoverflow.py
@@ -1,51 +1,10 @@
-"""StackOverflow scraping plugin."""
+"""Backward compatible StackOverflow plugin wrapper."""
 
-from typing import List, Dict
-
-import html2text
-import requests
-
-from scraper_wiki import Config, advanced_clean_text
-from .base import Plugin
+from .stackexchange import StackExchangePlugin
 
 
-class Plugin(Plugin):  # type: ignore[misc]
-    """Fetch questions from StackOverflow by tag."""
+class Plugin(StackExchangePlugin):
+    """Alias for the StackExchange plugin preset for StackOverflow."""
 
-    def __init__(self, api_key: str | None = None, endpoint: str | None = None) -> None:
-        self.api_key = api_key or Config.STACKOVERFLOW_API_KEY
-        self.endpoint = endpoint or Config.STACKOVERFLOW_API_ENDPOINT.rstrip("/")
-
-    def fetch_items(self, lang: str, category: str) -> List[Dict]:
-        params = {
-            "site": "stackoverflow",
-            "tagged": category,
-            "pagesize": 10,
-            "order": "desc",
-            "sort": "votes",
-            "filter": "withbody",
-        }
-        if self.api_key:
-            params["key"] = self.api_key
-        resp = requests.get(f"{self.endpoint}/questions", params=params, timeout=Config.TIMEOUT)
-        resp.raise_for_status()
-        data = resp.json()
-        items = data.get("items", [])
-        for it in items:
-            it["lang"] = lang
-            it["category"] = category
-        return items
-
-    def parse_item(self, item: Dict) -> Dict:
-        body = item.get("body", "")
-        text = html2text.html2text(body) if hasattr(html2text, "html2text") else body
-        clean = advanced_clean_text(text, item.get("lang", "en"))
-        return {
-            "title": item.get("title", ""),
-            "language": item.get("lang", "en"),
-            "category": item.get("category", ""),
-            "score": item.get("score", 0),
-            "link": item.get("link", ""),
-            "content": clean,
-        }
-
+    def __init__(self, **kwargs) -> None:
+        super().__init__(site="stackoverflow", **kwargs)

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -156,6 +156,16 @@ class Config:
     STACKOVERFLOW_API_ENDPOINT = os.environ.get(
         "STACKOVERFLOW_API_ENDPOINT", "https://api.stackexchange.com/2.3"
     )
+
+    # Generic Stack Exchange configuration
+    STACKEXCHANGE_API_KEY = os.environ.get(
+        "STACKEXCHANGE_API_KEY", STACKOVERFLOW_API_KEY
+    )
+    STACKEXCHANGE_API_ENDPOINT = os.environ.get(
+        "STACKEXCHANGE_API_ENDPOINT", STACKOVERFLOW_API_ENDPOINT
+    )
+    STACKEXCHANGE_SITE = os.environ.get("STACKEXCHANGE_SITE", "stackoverflow")
+    STACKEXCHANGE_MIN_SCORE = int(os.environ.get("STACKEXCHANGE_MIN_SCORE", "0"))
     WIKIDATA_API_ENDPOINT = os.environ.get(
         "WIKIDATA_API_ENDPOINT", "https://www.wikidata.org/w/api.php"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import sys
+from types import SimpleNamespace, ModuleType
+
+
+class _DummyMetric:
+    def __init__(self, *a, **k):
+        pass
+
+    def inc(self, *a, **k):
+        pass
+
+    def observe(self, *a, **k):
+        pass
+
+    def set(self, *a, **k):
+        pass
+
+
+prometheus_stub = SimpleNamespace(
+    Counter=lambda *a, **k: _DummyMetric(),
+    Histogram=lambda *a, **k: _DummyMetric(),
+    Gauge=lambda *a, **k: _DummyMetric(),
+    start_http_server=lambda *a, **k: None,
+)
+sys.modules.setdefault("prometheus_client", prometheus_stub)
+
+pyarrow_stub = ModuleType("pyarrow")
+pyarrow_stub.Table = object
+pyarrow_stub.parquet = SimpleNamespace(write_table=lambda *a, **k: None)
+pyarrow_stub.ipc = SimpleNamespace()
+pyarrow_stub.csv = SimpleNamespace(read_csv=lambda *a, **k: None)
+sys.modules.setdefault("pyarrow", pyarrow_stub)
+sys.modules.setdefault("pyarrow.parquet", pyarrow_stub.parquet)
+sys.modules.setdefault("pyarrow.ipc", pyarrow_stub.ipc)
+sys.modules.setdefault("pyarrow.csv", pyarrow_stub.csv)
+
+sys.modules.setdefault("yaml", SimpleNamespace(safe_load=lambda *a, **k: {}))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -8,56 +8,84 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 # Stub heavy dependencies to avoid installing them
-sys.modules.setdefault('sentence_transformers', SimpleNamespace(SentenceTransformer=object))
-sys.modules.setdefault('datasets', SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None))
-sys.modules.setdefault('spacy', SimpleNamespace(load=lambda *a, **k: None))
-sys.modules.setdefault('tqdm', SimpleNamespace(tqdm=lambda x, **k: x))
-sys.modules.setdefault('html2text', SimpleNamespace(html2text=lambda x: x))
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(SentenceTransformer=object)
+)
+sys.modules.setdefault(
+    "datasets",
+    SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None),
+)
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault("html2text", SimpleNamespace(html2text=lambda x: x))
 sk_mod = SimpleNamespace(
     cluster=SimpleNamespace(KMeans=object),
-    feature_extraction=SimpleNamespace(text=SimpleNamespace(TfidfVectorizer=object))
+    feature_extraction=SimpleNamespace(text=SimpleNamespace(TfidfVectorizer=object)),
 )
-sys.modules.setdefault('sklearn', sk_mod)
-sys.modules.setdefault('sklearn.cluster', sk_mod.cluster)
-sys.modules.setdefault('sklearn.feature_extraction', sk_mod.feature_extraction)
-sys.modules.setdefault('sklearn.feature_extraction.text', sk_mod.feature_extraction.text)
+sys.modules.setdefault("sklearn", sk_mod)
+sys.modules.setdefault("sklearn.cluster", sk_mod.cluster)
+sys.modules.setdefault("sklearn.feature_extraction", sk_mod.feature_extraction)
+sys.modules.setdefault(
+    "sklearn.feature_extraction.text", sk_mod.feature_extraction.text
+)
 sumy_mod = SimpleNamespace(
     parsers=SimpleNamespace(plaintext=SimpleNamespace(PlaintextParser=object)),
     nlp=SimpleNamespace(tokenizers=SimpleNamespace(Tokenizer=object)),
-    summarizers=SimpleNamespace(lsa=SimpleNamespace(LsaSummarizer=object))
+    summarizers=SimpleNamespace(lsa=SimpleNamespace(LsaSummarizer=object)),
 )
-sys.modules.setdefault('sumy', sumy_mod)
-sys.modules.setdefault('sumy.parsers', sumy_mod.parsers)
-sys.modules.setdefault('sumy.parsers.plaintext', sumy_mod.parsers.plaintext)
-sys.modules.setdefault('sumy.nlp', sumy_mod.nlp)
-sys.modules.setdefault('sumy.nlp.tokenizers', sumy_mod.nlp.tokenizers)
-sys.modules.setdefault('sumy.summarizers', sumy_mod.summarizers)
-sys.modules.setdefault('sumy.summarizers.lsa', sumy_mod.summarizers.lsa)
-sys.modules.setdefault('streamlit', SimpleNamespace())
-sys.modules.setdefault('psutil', SimpleNamespace(cpu_percent=lambda interval=1: 0, virtual_memory=lambda: SimpleNamespace(percent=0)))
-sys.modules.setdefault('prometheus_client', SimpleNamespace(Counter=lambda *a, **k: object, start_http_server=lambda *a, **k: None))
-wiki_mod = ModuleType('wikipediaapi')
+sys.modules.setdefault("sumy", sumy_mod)
+sys.modules.setdefault("sumy.parsers", sumy_mod.parsers)
+sys.modules.setdefault("sumy.parsers.plaintext", sumy_mod.parsers.plaintext)
+sys.modules.setdefault("sumy.nlp", sumy_mod.nlp)
+sys.modules.setdefault("sumy.nlp.tokenizers", sumy_mod.nlp.tokenizers)
+sys.modules.setdefault("sumy.summarizers", sumy_mod.summarizers)
+sys.modules.setdefault("sumy.summarizers.lsa", sumy_mod.summarizers.lsa)
+sys.modules.setdefault("streamlit", SimpleNamespace())
+sys.modules.setdefault(
+    "psutil",
+    SimpleNamespace(
+        cpu_percent=lambda interval=1: 0,
+        virtual_memory=lambda: SimpleNamespace(percent=0),
+    ),
+)
+sys.modules.setdefault(
+    "prometheus_client",
+    SimpleNamespace(
+        Counter=lambda *a, **k: object, start_http_server=lambda *a, **k: None
+    ),
+)
+wiki_mod = ModuleType("wikipediaapi")
 wiki_mod.WikipediaException = Exception
 wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
 wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
 wiki_mod.WikipediaPage = object
-wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
-sys.modules.setdefault('wikipediaapi', wiki_mod)
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(
+    page=lambda *a, **k: SimpleNamespace(exists=lambda: False),
+    api=SimpleNamespace(article_url=lambda x: ""),
+)
+sys.modules.setdefault("wikipediaapi", wiki_mod)
 aiohttp_stub = SimpleNamespace(
     ClientSession=object,
     ClientTimeout=lambda *a, **k: None,
     ClientError=Exception,
     ClientResponseError=Exception,
 )
-sys.modules.setdefault('aiohttp', aiohttp_stub)
-sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
+sys.modules.setdefault("aiohttp", aiohttp_stub)
+sys.modules.setdefault(
+    "backoff",
+    SimpleNamespace(
+        on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None
+    ),
+)
 
 import scraper_wiki as sw
 import core
 
+
 class DummyWiki:
     def __init__(self, lang: str) -> None:
         self.lang = lang
+
     def get_category_members(self, category: str):
         return [{"title": "Page", "lang": self.lang, "category": category}]
 
@@ -76,7 +104,7 @@ def test_infobox_parser(monkeypatch):
 
 def test_table_parser(monkeypatch):
     monkeypatch.setattr(core, "WikipediaAdvanced", DummyWiki)
-    html = '<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>'
+    html = "<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>"
     monkeypatch.setattr(sw, "fetch_html_content", lambda title, lang: html)
     mod = importlib.reload(importlib.import_module("plugins.table_parser"))
     plugin = mod.Plugin()
@@ -90,22 +118,32 @@ def test_table_parser(monkeypatch):
     }
 
 
-def test_stackoverflow_plugin(monkeypatch):
+def test_stackexchange_plugin(monkeypatch):
     class DummyResp:
         def __init__(self, data):
             self._data = data
+
         def raise_for_status(self):
             pass
+
         def json(self):
             return self._data
 
     resp = {
-        "items": [{
-            "title": "Q1",
-            "body": "<p>code</p>",
-            "score": 5,
-            "link": "url",
-        }]
+        "items": [
+            {
+                "title": "Q1",
+                "body": "<p>code</p>",
+                "score": 5,
+                "link": "url",
+            },
+            {
+                "title": "Q2",
+                "body": "<p>low</p>",
+                "score": 1,
+                "link": "url2",
+            },
+        ]
     }
 
     def fake_get(url, params=None, timeout=None):
@@ -114,9 +152,10 @@ def test_stackoverflow_plugin(monkeypatch):
     import requests
 
     monkeypatch.setattr(requests, "get", fake_get)
-    mod = importlib.reload(importlib.import_module("plugins.stackoverflow"))
-    plugin = mod.Plugin()
+    mod = importlib.reload(importlib.import_module("plugins.stackexchange"))
+    plugin = mod.Plugin(site="superuser", min_score=5)
     items = plugin.fetch_items("en", "python")
+    assert len(items) == 1
     assert items[0]["category"] == "python"
     parsed = plugin.parse_item(items[0])
     assert parsed["title"] == "Q1"
@@ -130,24 +169,20 @@ def test_wikidata_plugin(monkeypatch):
     class DummyResp:
         def __init__(self, data):
             self._data = data
+
         def raise_for_status(self):
             pass
+
         def json(self):
             return self._data
 
-    search_resp = {
-        "search": [{"id": "Q1", "label": "Item", "description": "Desc"}]
-    }
+    search_resp = {"search": [{"id": "Q1", "label": "Item", "description": "Desc"}]}
     entity_resp = {
         "entities": {
             "Q1": {
                 "labels": {"en": {"value": "Item"}},
                 "descriptions": {"en": {"value": "Desc"}},
-                "claims": {
-                    "P18": [
-                        {"mainsnak": {"datavalue": {"value": "Pic.jpg"}}}
-                    ]
-                },
+                "claims": {"P18": [{"mainsnak": {"datavalue": {"value": "Pic.jpg"}}}]},
             }
         }
     }
@@ -173,4 +208,3 @@ def test_wikidata_plugin(monkeypatch):
         "wikidata_id": "Q1",
         "image_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Pic.jpg",
     }
-


### PR DESCRIPTION
## Summary
- create configurable StackExchange plugin with score filtering
- keep StackOverflow plugin as wrapper
- register new plugin and expose config options
- adapt CLI defaults and plugin tests
- add test helpers for optional deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b59082508320939ce614636fd905