### PR TITLE
Add documentation and competition scraping plugins

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -16,6 +16,8 @@ AVAILABLE_PLUGINS = {
     "github_scraper": "github_scraper",
     "code_extractor": "code_extractor",
     "gitlab_scraper": "gitlab_scraper",
+    "api_docs": "api_docs",
+    "competitions": "competitions",
 }
 
 

--- a/plugins/api_docs.py
+++ b/plugins/api_docs.py
@@ -1,0 +1,58 @@
+"""Documentation scraping plugin."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class APIDocsScraper(Plugin):  # type: ignore[misc]
+    """Crawl documentation pages and extract code blocks."""
+
+    def __init__(self, allowed_domains: List[str] | None = None) -> None:
+        self.allowed_domains = allowed_domains or [
+            "docs.python.org",
+            "developer.mozilla.org",
+        ]
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return pages linked from the base URL."""
+        url = category
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        items = [{"url": url, "lang": lang, "category": category}]
+        for a in soup.select("a[href]"):
+            href = a["href"]
+            abs_url = urljoin(url, href)
+            if urlparse(abs_url).netloc in self.allowed_domains:
+                items.append({"url": abs_url, "lang": lang, "category": category})
+        return items
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Extract code blocks and surrounding text."""
+        resp = requests.get(item["url"], timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        blocks = []
+        for pre in soup.find_all("pre"):
+            code = pre.get_text("\n")
+            explanation = ""
+            if pre.previous_sibling and getattr(pre.previous_sibling, "get_text", None):
+                explanation = pre.previous_sibling.get_text(" ", strip=True)
+            blocks.append({"code": code, "text": explanation})
+        return {
+            "url": item["url"],
+            "language": item.get("lang", "en"),
+            "blocks": blocks,
+        }
+
+
+# Registry alias
+Plugin = APIDocsScraper

--- a/plugins/competitions.py
+++ b/plugins/competitions.py
@@ -1,0 +1,58 @@
+"""Programming competition scraping plugin."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class CompetitionsPlugin(Plugin):  # type: ignore[misc]
+    """Fetch problems and solutions from LeetCode and CodeWars."""
+
+    def __init__(
+        self, leetcode_url: str | None = None, codewars_url: str | None = None
+    ) -> None:
+        self.leetcode_url = leetcode_url or "https://leetcode.com/api/problems"
+        self.codewars_url = codewars_url or "https://www.codewars.com/api/v1"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return basic problem identifiers for both platforms."""
+        return [
+            {"source": "leetcode", "slug": category, "lang": lang},
+            {"source": "codewars", "slug": category, "lang": lang},
+        ]
+
+    def _fetch_leetcode(self, slug: str) -> Dict:
+        resp = requests.get(f"{self.leetcode_url}/{slug}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch_codewars(self, slug: str) -> Dict:
+        resp = requests.get(f"{self.codewars_url}/kata/{slug}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return problem statement and accepted solution."""
+        source = item.get("source")
+        slug = item.get("slug")
+        if source == "leetcode":
+            data = self._fetch_leetcode(slug)
+            return {
+                "problem": data.get("content", ""),
+                "solution": data.get("solution", ""),
+            }
+        if source == "codewars":
+            data = self._fetch_codewars(slug)
+            solutions = data.get("solutions", [])
+            solution = solutions[0] if solutions else ""
+            return {"problem": data.get("description", ""), "solution": solution}
+        return {}
+
+
+# Registry alias
+Plugin = CompetitionsPlugin

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -208,3 +208,32 @@ def test_wikidata_plugin(monkeypatch):
         "wikidata_id": "Q1",
         "image_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Pic.jpg",
     }
+
+
+def test_competitions_plugin(monkeypatch):
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, timeout=None):
+        if "leetcode" in url:
+            return DummyResp({"content": "LC problem", "solution": "LC solution"})
+        return DummyResp({"description": "CW problem", "solutions": ["CW solution"]})
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.reload(importlib.import_module("plugins.competitions"))
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "two-sum")
+    assert items[0]["slug"] == "two-sum"
+    parsed = plugin.parse_item(items[0])
+    assert parsed == {"problem": "LC problem", "solution": "LC solution"}
+    parsed2 = plugin.parse_item(items[1])
+    assert parsed2 == {"problem": "CW problem", "solution": "CW solution"}


### PR DESCRIPTION
## Summary
- implement new `api_docs` and `competitions` plugins
- register them in the plugin registry
- extend plugin tests for `competitions` plugin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bb26dac48320b5b579962b6e0f42