### PR TITLE
Add AST parsing utilities and complexity filtering

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -62,6 +62,7 @@ from utils.code import (
     remove_comments,
     detect_programming_language,
 )
+from utils.ast_tools import get_functions_complexity
 
 
 # ============================
@@ -1541,7 +1542,14 @@ def cpu_process_page(
 
 
 class DatasetBuilder:
-    def __init__(self, include_revisions: bool = False, rev_limit: int = 5, **_):
+    def __init__(
+        self,
+        include_revisions: bool = False,
+        rev_limit: int = 5,
+        min_complexity: int | None = None,
+        max_complexity: int | None = None,
+        **_,
+    ):
         self.embedding_model = NLPProcessor.get_embedding_model()
         self.dataset = []
         self.qa_pairs = []
@@ -1550,6 +1558,8 @@ class DatasetBuilder:
         self.invalid_records = 0
         self.include_revisions = include_revisions
         self.rev_limit = rev_limit
+        self.min_complexity = min_complexity
+        self.max_complexity = max_complexity
 
         # Load checkpoints if available
         pages_path = os.path.join(Config.LOG_DIR, "checkpoint_pages.json")
@@ -1704,8 +1714,16 @@ class DatasetBuilder:
         extra_metadata: dict | None = None,
     ) -> dict:
         code_lang = detect_programming_language(content)
+        complexities = {}
         if code_lang != "unknown":
             content = normalize_indentation(remove_comments(content, code_lang))
+            complexities = get_functions_complexity(content, code_lang)
+            if self.min_complexity is not None and complexities:
+                if max(complexities.values()) < self.min_complexity:
+                    return {}
+            if self.max_complexity is not None and complexities:
+                if max(complexities.values()) > self.max_complexity:
+                    return {}
 
         # Extrai keywords para gerar perguntas variadas
         keywords = extract_keywords(content, lang)
@@ -1756,6 +1774,8 @@ class DatasetBuilder:
         }
         if code_lang != "unknown":
             record["metadata"]["code_language"] = code_lang
+            if complexities:
+                record["metadata"]["complexities"] = complexities
         if extra_metadata:
             if "wikidata_id" in extra_metadata:
                 record["wikidata_id"] = extra_metadata["wikidata_id"]

--- a/tests/test_complexity_filter.py
+++ b/tests/test_complexity_filter.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+sw = importlib.import_module("scraper_wiki")
+
+
+def _setup_builder(monkeypatch, **kwargs):
+    builder = sw.DatasetBuilder(**kwargs)
+    monkeypatch.setattr(builder, "_generate_questions", lambda *a, **k: [])
+    monkeypatch.setattr(builder, "_generate_answers", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
+    import numpy as np
+
+    monkeypatch.setattr(
+        builder.embedding_model, "encode", lambda *a, **k: np.array([0.0])
+    )
+    return builder
+
+
+def test_trivial_function_filtered(monkeypatch):
+    builder = _setup_builder(monkeypatch, min_complexity=2)
+    code = "def foo():\n    pass"
+    result = builder.generate_qa_pairs("T", code, "S", "en", "c")
+    assert result == {}
+
+
+def test_complex_function_filtered(monkeypatch):
+    builder = _setup_builder(monkeypatch, max_complexity=3)
+    code = """
+def bar(x):
+    if x > 0:
+        for i in range(x):
+            if i % 2 == 0:
+                print(i)
+    else:
+        while x < 0:
+            x += 1
+    return x
+"""
+    result = builder.generate_qa_pairs("T", code, "S", "en", "c")
+    assert result == {}

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -12,6 +12,7 @@ from .code import (
     remove_comments,
     detect_programming_language,
 )
+from .ast_tools import parse_code, get_functions_complexity
 
 __all__ = [
     "clean_text",
@@ -25,4 +26,6 @@ __all__ = [
     "normalize_indentation",
     "remove_comments",
     "detect_programming_language",
+    "parse_code",
+    "get_functions_complexity",
 ]

--- a/utils/ast_tools.py
+++ b/utils/ast_tools.py
@@ -1,0 +1,91 @@
+"""Utilities for parsing code and calculating complexity metrics."""
+
+from __future__ import annotations
+
+import ast
+from typing import Any, Dict
+
+try:
+    from tree_sitter import Parser  # type: ignore
+    from tree_sitter_languages import get_language  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Parser = None
+    get_language = None
+
+
+def parse_code(code: str, language: str):
+    """Parse ``code`` using ``language`` rules.
+
+    Parameters
+    ----------
+    code: str
+        Source code.
+    language: str
+        Programming language name.
+
+    Returns
+    -------
+    Any
+        Parsed AST object or ``None`` if parsing fails.
+    """
+    lang = language.lower()
+    if lang in {"python", "py"}:
+        try:
+            return ast.parse(code)
+        except SyntaxError:
+            return None
+    if Parser and get_language:
+        try:
+            ts_lang = get_language(lang)
+            parser = Parser()
+            parser.set_language(ts_lang)
+            tree = parser.parse(code.encode("utf-8"))
+            return tree
+        except Exception:  # pragma: no cover - tree-sitter errors
+            return None
+    return None
+
+
+def _cyclomatic_complexity_py(func: ast.AST) -> int:
+    """Compute cyclomatic complexity for a Python function node."""
+    complexity = 1
+    for node in ast.walk(func):
+        if isinstance(
+            node,
+            (
+                ast.If,
+                ast.For,
+                ast.While,
+                ast.And,
+                ast.Or,
+                ast.ExceptHandler,
+                ast.With,
+                ast.Try,
+                ast.BoolOp,
+                ast.IfExp,
+                ast.comprehension,
+                ast.Assert,
+            ),
+        ):
+            complexity += 1
+    return complexity
+
+
+def get_functions_complexity(code: str, language: str = "python") -> Dict[str, int]:
+    """Return the complexity of each function defined in ``code``."""
+    if language.lower() not in {"python", "py"}:
+        return {}
+
+    tree = parse_code(code, language)
+    if tree is None:
+        return {}
+
+    funcs = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    return {func.name: _cyclomatic_complexity_py(func) for func in funcs}
+
+
+__all__ = ["parse_code", "get_functions_complexity"]


### PR DESCRIPTION
## Summary
- implement `utils.ast_tools` for parsing code with optional tree-sitter and for computing cyclomatic complexity
- expose new utilities in `utils.__init__`
- extend `DatasetBuilder` with `min_complexity` and `max_complexity` parameters
- skip QA generation for trivial or overly complex code snippets
- test complexity filtering behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c140d1a883209173dfb38def88c5