### PR TITLE
Extend code utils and QA dataset builder

### DIFF
--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -36,6 +36,7 @@ import aiohttp
 from training.formats import save_qa_dataset, save_text_corpus
 from urllib.parse import urlparse, urljoin
 import html2text
+import ast
 from typing import List, Dict, Tuple, Optional, Set, Protocol
 from datetime import datetime
 import multiprocessing
@@ -61,6 +62,8 @@ from utils.code import (
     normalize_indentation,
     remove_comments,
     detect_programming_language,
+    docstring_to_google,
+    parse_function_signature,
 )
 from utils.ast_tools import get_functions_complexity
 
@@ -1715,7 +1718,26 @@ class DatasetBuilder:
     ) -> dict:
         code_lang = detect_programming_language(content)
         complexities = {}
+        docstring = ""
+        signature = ""
         if code_lang != "unknown":
+            signature = parse_function_signature(content)
+            try:
+                tree = ast.parse(content)
+                func = next(
+                    (
+                        n
+                        for n in tree.body
+                        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    ),
+                    None,
+                )
+                if func:
+                    ds = ast.get_docstring(func)
+                    if ds:
+                        docstring = docstring_to_google(ds)
+            except Exception:
+                pass
             content = normalize_indentation(remove_comments(content, code_lang))
             complexities = get_functions_complexity(content, code_lang)
             if self.min_complexity is not None and complexities:
@@ -1776,6 +1798,10 @@ class DatasetBuilder:
             record["metadata"]["code_language"] = code_lang
             if complexities:
                 record["metadata"]["complexities"] = complexities
+            if docstring:
+                record["docstring"] = docstring
+            if signature:
+                record["signature"] = signature
         if extra_metadata:
             if "wikidata_id" in extra_metadata:
                 record["wikidata_id"] = extra_metadata["wikidata_id"]

--- a/tests/test_complexity_filter.py
+++ b/tests/test_complexity_filter.py
@@ -8,6 +8,16 @@ sys.path.insert(0, str(ROOT))
 sw = importlib.import_module("scraper_wiki")
 
 
+class DummyEmbed:
+    def encode(self, *a, **k):
+        import numpy as np
+
+        return np.array([0.0])
+
+
+sw.NLPProcessor.get_embedding_model = classmethod(lambda cls: DummyEmbed())
+
+
 def _setup_builder(monkeypatch, **kwargs):
     builder = sw.DatasetBuilder(**kwargs)
     monkeypatch.setattr(builder, "_generate_questions", lambda *a, **k: [])

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -1,12 +1,95 @@
 import importlib
 import sys
+from types import SimpleNamespace, ModuleType
 from pathlib import Path
 
 # Ensure repository root is on sys.path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+# Stub heavy dependencies to avoid installation
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(SentenceTransformer=object)
+)
+sys.modules.setdefault(
+    "datasets",
+    SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None),
+)
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault("unidecode", SimpleNamespace(unidecode=lambda x: x))
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault("html2text", SimpleNamespace())
+wiki_mod = ModuleType("wikipediaapi")
+wiki_mod.WikipediaException = Exception
+wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
+wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
+wiki_mod.WikipediaPage = object
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(
+    page=lambda *a, **k: SimpleNamespace(exists=lambda: False),
+    api=SimpleNamespace(article_url=lambda x: ""),
+)
+sys.modules.setdefault("wikipediaapi", wiki_mod)
+sys.modules.setdefault(
+    "aiohttp",
+    SimpleNamespace(
+        ClientSession=object,
+        ClientTimeout=lambda *a, **k: None,
+        ClientError=Exception,
+        ClientResponseError=Exception,
+    ),
+)
+sys.modules.setdefault(
+    "backoff",
+    SimpleNamespace(
+        on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None
+    ),
+)
+sklearn_mod = ModuleType("sklearn")
+sklearn_mod.cluster = SimpleNamespace(KMeans=object)
+sklearn_mod.feature_extraction = SimpleNamespace(
+    text=SimpleNamespace(TfidfVectorizer=object)
+)
+sys.modules.setdefault("sklearn", sklearn_mod)
+sys.modules.setdefault("sklearn.cluster", sklearn_mod.cluster)
+sys.modules.setdefault("sklearn.feature_extraction", sklearn_mod.feature_extraction)
+sys.modules.setdefault(
+    "sklearn.feature_extraction.text", sklearn_mod.feature_extraction.text
+)
+sumy_mod = ModuleType("sumy")
+parsers_mod = ModuleType("sumy.parsers")
+plaintext_mod = ModuleType("sumy.parsers.plaintext")
+plaintext_mod.PlaintextParser = object
+parsers_mod.plaintext = plaintext_mod
+nlp_mod = ModuleType("sumy.nlp")
+tokenizers_mod = ModuleType("sumy.nlp.tokenizers")
+tokenizers_mod.Tokenizer = object
+nlp_mod.tokenizers = tokenizers_mod
+summarizers_mod = ModuleType("sumy.summarizers")
+lsa_mod = ModuleType("sumy.summarizers.lsa")
+lsa_mod.LsaSummarizer = object
+summarizers_mod.lsa = lsa_mod
+sumy_mod.parsers = parsers_mod
+sumy_mod.nlp = nlp_mod
+sumy_mod.summarizers = summarizers_mod
+sys.modules.setdefault("sumy", sumy_mod)
+sys.modules.setdefault("sumy.parsers", parsers_mod)
+sys.modules.setdefault("sumy.parsers.plaintext", plaintext_mod)
+sys.modules.setdefault("sumy.nlp", nlp_mod)
+sys.modules.setdefault("sumy.nlp.tokenizers", tokenizers_mod)
+sys.modules.setdefault("sumy.summarizers", summarizers_mod)
+sys.modules.setdefault("sumy.summarizers.lsa", lsa_mod)
+
 sw = importlib.import_module("scraper_wiki")
+
+
+class DummyEmbed:
+    def encode(self, *a, **k):
+        import numpy as np
+
+        return np.array([0.0])
+
+
+sw.NLPProcessor.get_embedding_model = classmethod(lambda cls: DummyEmbed())
 
 
 def test_generate_qa_pairs_processes_code(monkeypatch):
@@ -23,3 +106,23 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
     assert result["content"] == "def foo():\n    pass"
     assert result["metadata"].get("code_language") == "python"
+
+
+def test_generate_qa_pairs_extracts_docstring_and_signature(monkeypatch):
+    builder = sw.DatasetBuilder()
+    monkeypatch.setattr(builder, "_generate_questions", lambda *a, **k: [])
+    monkeypatch.setattr(builder, "_generate_answers", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
+    import numpy as np
+
+    monkeypatch.setattr(
+        builder.embedding_model, "encode", lambda *a, **k: np.array([0.0])
+    )
+    code = """\
+def foo(x):
+    \"\"\"Return x.\"\"\"
+    return x
+"""
+    result = builder.generate_qa_pairs("T", code, "S", "en", "c")
+    assert result["docstring"] == "Return x."
+    assert result["signature"] == "foo(x)"

--- a/tests/test_utils_code.py
+++ b/tests/test_utils_code.py
@@ -1,10 +1,21 @@
 import importlib
 import sys
+from types import SimpleNamespace
 from pathlib import Path
 
 # Ensure repository root is on sys.path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault(
+    "googletrans",
+    SimpleNamespace(
+        Translator=lambda: SimpleNamespace(
+            translate=lambda text, dest: SimpleNamespace(text=f"{text}-{dest}")
+        )
+    ),
+)
 
 code_mod = importlib.import_module("utils.code")
 
@@ -22,3 +33,16 @@ def test_remove_comments_python():
 def test_detect_programming_language():
     assert code_mod.detect_programming_language("def f():\n    pass") == "python"
     assert code_mod.detect_programming_language("console.log('x');") == "javascript"
+
+
+def test_docstring_to_google_converts_rst():
+    doc = "Short.\n:param x: number\n:type x: int\n:return: result\n:rtype: int"
+    converted = code_mod.docstring_to_google(doc)
+    assert "Args:" in converted
+    assert "x (int): number" in converted
+    assert "Returns:" in converted
+
+
+def test_parse_function_signature_from_string():
+    code = "def foo(x, y=1, *args, **kwargs):\n    pass"
+    assert code_mod.parse_function_signature(code) == "foo(x, y, *args, **kwargs)"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -11,6 +11,8 @@ from .code import (
     normalize_indentation,
     remove_comments,
     detect_programming_language,
+    docstring_to_google,
+    parse_function_signature,
 )
 from .ast_tools import parse_code, get_functions_complexity
 
@@ -26,6 +28,8 @@ __all__ = [
     "normalize_indentation",
     "remove_comments",
     "detect_programming_language",
+    "docstring_to_google",
+    "parse_function_signature",
     "parse_code",
     "get_functions_complexity",
 ]

--- a/utils/code.py
+++ b/utils/code.py
@@ -1,5 +1,7 @@
 import re
 import textwrap
+import inspect
+import ast
 
 
 def normalize_indentation(code: str) -> str:
@@ -47,3 +49,71 @@ def detect_programming_language(code: str) -> str:
         if any(k.lower() in lowered for k in keys):
             return lang
     return "unknown"
+
+
+def docstring_to_google(docstring: str) -> str:
+    """Convert ``docstring`` written in reST style to Google style."""
+    lines = textwrap.dedent(docstring).strip().splitlines()
+    params: list[tuple[str, str, str | None]] = []
+    types: dict[str, str] = {}
+    returns = ""
+    rtype = ""
+    other = []
+    for line in lines:
+        m = re.match(r":param\s+(\w+)\s*:\s*(.*)", line)
+        if m:
+            params.append((m.group(1), m.group(2), None))
+            continue
+        m = re.match(r":type\s+(\w+)\s*:\s*(.*)", line)
+        if m:
+            types[m.group(1)] = m.group(2)
+            continue
+        m = re.match(r":returns?\s*:\s*(.*)", line)
+        if m:
+            returns = m.group(1)
+            continue
+        m = re.match(r":rtype\s*:\s*(.*)", line)
+        if m:
+            rtype = m.group(1)
+            continue
+        other.append(line)
+
+    params = [(n, d, types.get(n)) for n, d, _ in params]
+
+    out_lines = [l for l in other if l.strip()]
+    if params:
+        out_lines += ["", "Args:"]
+        for name, desc, typ in params:
+            t = f" ({typ})" if typ else ""
+            out_lines.append(f"    {name}{t}: {desc}".rstrip())
+    if returns:
+        out_lines += ["", "Returns:"]
+        t = f" ({rtype})" if rtype else ""
+        out_lines.append(f"    {returns}{t}".rstrip())
+    return "\n".join(out_lines).strip()
+
+
+def parse_function_signature(obj: object | str) -> str:
+    """Return the function signature from ``obj``."""
+    if callable(obj):
+        try:
+            sig = inspect.signature(obj)
+            return f"{obj.__name__}{sig}"
+        except Exception:
+            return ""
+    if isinstance(obj, str):
+        try:
+            tree = ast.parse(obj)
+        except Exception:
+            return ""
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                args = [a.arg for a in node.args.args]
+                if node.args.vararg:
+                    args.append("*" + node.args.vararg.arg)
+                if node.args.kwonlyargs:
+                    args.extend(a.arg for a in node.args.kwonlyargs)
+                if node.args.kwarg:
+                    args.append("**" + node.args.kwarg.arg)
+                return f"{node.name}({', '.join(args)})"
+    return ""


### PR DESCRIPTION
## Summary
- convert docstrings to Google style and parse function signatures in `utils.code`
- capture docstring and signature when building QA pairs
- stub heavy dependencies in dataset builder tests
- verify docstring/signature extraction in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c5fd9ff083209f279ae5e4340dc5