### PR TITLE
Add tag extraction with plugin support

### DIFF
--- a/plugins/stackexchange.py
+++ b/plugins/stackexchange.py
@@ -53,6 +53,8 @@ class StackExchangePlugin(Plugin):
         body = item.get("body", "")
         text = html2text.html2text(body) if hasattr(html2text, "html2text") else body
         clean = advanced_clean_text(text, item.get("lang", "en"))
+        tags = item.get("tags", [])
+        tag_data = [{"tag": t, "link": item.get("link", "")} for t in tags]
         return {
             "title": item.get("title", ""),
             "language": item.get("lang", "en"),
@@ -60,6 +62,7 @@ class StackExchangePlugin(Plugin):
             "score": item.get("score", 0),
             "link": item.get("link", ""),
             "content": clean,
+            "tags": tag_data,
         }
 
 

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -1750,6 +1750,8 @@ class DatasetBuilder:
         # Extrai keywords para gerar perguntas variadas
         keywords = extract_keywords(content, lang)
 
+        tags = self._extract_tags(keywords, extra_metadata)
+
         # Gera múltiplas perguntas baseadas no conteúdo
         questions = self._generate_questions(title, content, lang, keywords)
 
@@ -1780,6 +1782,7 @@ class DatasetBuilder:
             "topic": topic,
             "subtopic": subtopic,
             "keywords": keywords,
+            "tags": tags,
             "content": content,
             "summary": summary,
             "content_embedding": content_embedding.tolist(),
@@ -2042,6 +2045,18 @@ class DatasetBuilder:
                 break
 
         return (main_topic, subtopic)
+
+    def _extract_tags(
+        self, keywords: List[str], extra_metadata: dict | None
+    ) -> List[dict]:
+        """Return tags with optional explanation links."""
+        if extra_metadata and extra_metadata.get("tags"):
+            tag_links = extra_metadata.get("tag_links", {})
+            return [
+                {"tag": t, "link": tag_links.get(t)}
+                for t in extra_metadata.get("tags", [])
+            ]
+        return [{"tag": kw, "link": None} for kw in keywords[:5]]
 
     def build_from_pages(
         self,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -136,12 +136,14 @@ def test_stackexchange_plugin(monkeypatch):
                 "body": "<p>code</p>",
                 "score": 5,
                 "link": "url",
+                "tags": ["python"],
             },
             {
                 "title": "Q2",
                 "body": "<p>low</p>",
                 "score": 1,
                 "link": "url2",
+                "tags": ["python"],
             },
         ]
     }
@@ -163,6 +165,7 @@ def test_stackexchange_plugin(monkeypatch):
     assert parsed["category"] == "python"
     assert parsed["score"] == 5
     assert parsed["link"] == "url"
+    assert parsed["tags"] == [{"tag": "python", "link": "url"}]
 
 
 def test_wikidata_plugin(monkeypatch):

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -156,10 +156,34 @@ def test_generate_qa_pairs_accepts_extra_metadata(monkeypatch):
         summary="sum",
         lang="en",
         category="c",
-        extra_metadata={"wikidata_id": "Q1", "image_url": "img"},
+        extra_metadata={
+            "wikidata_id": "Q1",
+            "image_url": "img",
+            "tags": ["python"],
+            "tag_links": {"python": "url"},
+        },
     )
     assert result["wikidata_id"] == "Q1"
     assert result["image_url"] == "img"
+    assert result["tags"] == [{"tag": "python", "link": "url"}]
+
+
+def test_generate_qa_pairs_extracts_tags(monkeypatch):
+    qb = sw.DatasetBuilder()
+    monkeypatch.setattr(qb, "_generate_questions", lambda *a, **k: [])
+    monkeypatch.setattr(qb, "_generate_answers", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
+    import numpy as np
+
+    monkeypatch.setattr(qb.embedding_model, "encode", lambda *a, **k: np.array([0.0]))
+    result = qb.generate_qa_pairs(
+        title="T",
+        content="content about Python",
+        summary="sum",
+        lang="en",
+        category="c",
+    )
+    assert {"tag": "python", "link": None} in result["tags"]
 
 
 def test_advanced_clean_text_removes_html():


### PR DESCRIPTION
## Summary
- parse Stack Exchange items with tags and explanation links
- generate tag field inside DatasetBuilder
- ensure generated dataset includes tag info
- test new tag extraction logic

## Testing
- `black plugins/stackexchange.py scraper_wiki.py tests/test_scraper_wiki.py tests/test_plugins.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591ead49e88320844f06c2b7a3a157