### PR TITLE
Extend dataset schema with quality metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,34 @@ G = relations_to_graph(data['relations'])
 nx.write_graphml(G, 'relations.graphml')
 ```
 
+#### Exemplo de registro
+
+```json
+{
+  "id": "123abc",
+  "title": "Title",
+  "language": "en",
+  "category": "History",
+  "topic": "computing",
+  "subtopic": "pioneers",
+  "keywords": ["Ada"],
+  "tags": [],
+  "content": "Ada worked at IBM.",
+  "summary": "Ada summary",
+  "context": "Ada summary",
+  "content_embedding": [0.0],
+  "summary_embedding": [0.0],
+  "quality_score": 0.0,
+  "tests": [],
+  "questions": [{"text": "Who was Ada?"}],
+  "answers": [{"text": "Ada worked at IBM."}],
+  "relations": [],
+  "docstring": "",
+  "created_at": "2024-01-01T00:00:00",
+  "metadata": {"source": "wikipedia", "length": 17}
+}
+```
+
 ### Fine-tuning de Modelos de Código
 
 O plugin `github_scraper` permite coletar READMEs e arquivos de projetos no

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,3 +6,21 @@ Scraper-Wiki Documentation
 
    modules
    code_fine_tuning
+
+Record Schema
+-------------
+
+Example dataset entry:
+
+.. code-block:: json
+
+    {
+        "id": "123abc",
+        "title": "Title",
+        "language": "en",
+        "category": "History",
+        "quality_score": 0.0,
+        "tests": [],
+        "context": "Ada summary",
+        "docstring": ""
+    }

--- a/plugins/code_extractor.py
+++ b/plugins/code_extractor.py
@@ -80,12 +80,19 @@ class CodeExtractor:
             "test" in Path(p).parts[0].lower() or "test" in Path(p).name.lower()
             for p in file_paths
         )
+        stars = repo.get("stargazers_count", 0)
+        issues = repo.get("open_issues_count", 0)
+        quality_score = stars / (issues + 1)
         return {
             "repository": full_name,
-            "stars": repo.get("stargazers_count", 0),
-            "open_issues": repo.get("open_issues_count", 0),
+            "stars": stars,
+            "open_issues": issues,
             "has_tests": has_tests,
             "files": file_paths,
+            "context": repo.get("description", ""),
+            "tests": has_tests,
+            "docstring": "",
+            "quality_score": quality_score,
         }
 
 

--- a/plugins/gitlab_scraper.py
+++ b/plugins/gitlab_scraper.py
@@ -72,12 +72,19 @@ class GitLabScraper:
             "test" in Path(p).name.lower() or "test" in Path(p).parts[0].lower()
             for p in file_paths
         )
+        stars = repo.get("star_count", 0)
+        issues = repo.get("open_issues_count", 0)
+        quality_score = stars / (issues + 1)
         return {
             "repository": repo.get("path_with_namespace"),
-            "stars": repo.get("star_count", 0),
-            "open_issues": repo.get("open_issues_count", 0),
+            "stars": stars,
+            "open_issues": issues,
             "has_tests": has_tests,
             "files": file_paths,
+            "context": repo.get("description", ""),
+            "tests": has_tests,
+            "docstring": "",
+            "quality_score": quality_score,
         }
 
 

--- a/plugins/stackexchange.py
+++ b/plugins/stackexchange.py
@@ -63,6 +63,10 @@ class StackExchangePlugin(Plugin):
             "link": item.get("link", ""),
             "content": clean,
             "tags": tag_data,
+            "context": item.get("title", ""),
+            "tests": [],
+            "docstring": "",
+            "quality_score": item.get("score", 0),
         }
 
 

--- a/scraper_wiki.py
+++ b/scraper_wiki.py
@@ -1785,11 +1785,17 @@ class DatasetBuilder:
             "tags": tags,
             "content": content,
             "summary": summary,
+            "context": summary,
             "content_embedding": content_embedding.tolist(),
             "summary_embedding": summary_embedding.tolist(),
+            "quality_score": (
+                extra_metadata.get("quality_score", 0.0) if extra_metadata else 0.0
+            ),
             "questions": questions,
             "answers": answers,
             "relations": relations,
+            "tests": extra_metadata.get("tests", []) if extra_metadata else [],
+            "docstring": docstring,
             "created_at": datetime.utcnow().isoformat(),
             "metadata": {
                 "length": len(content),

--- a/tests/test_code_extractors.py
+++ b/tests/test_code_extractors.py
@@ -76,12 +76,15 @@ def test_collect_repository_data(monkeypatch):
         "default_branch": "master",
         "stargazers_count": 5,
         "open_issues_count": 1,
+        "description": "repo desc",
     }
     data = extractor.collect_repository_data(repo)
     assert data["has_tests"] is True
     assert data["stars"] == 5
     assert data["open_issues"] == 1
     assert len(data["files"]) == 2
+    assert data["quality_score"] == 5 / 2
+    assert data["context"] == "repo desc"
 
 
 def test_gitlab_scraper_search(monkeypatch):
@@ -121,3 +124,46 @@ def test_gitlab_scraper_search(monkeypatch):
     assert called["params"]["search"] == "python"
     assert len(repos) == 1
     assert repos[0]["id"] == 1
+
+
+def test_gitlab_collect_repository_data(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, headers=None, params=None):
+        return DummyResp(
+            [
+                {"path": "main.py", "type": "blob"},
+                {"path": "tests/test_main.py", "type": "blob"},
+            ]
+        )
+
+    mod = importlib.import_module("plugins.gitlab_scraper")
+    monkeypatch.setattr(requests, "get", fake_get)
+    scraper = mod.GitLabScraper()
+    repo = {
+        "id": 1,
+        "path_with_namespace": "u/r",
+        "star_count": 4,
+        "open_issues_count": 1,
+        "description": "desc",
+        "default_branch": "master",
+    }
+    data = scraper.collect_repository_data(repo)
+    assert data["has_tests"] is True
+    assert data["quality_score"] == 4 / 2
+    assert data["context"] == "desc"

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -106,6 +106,9 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
     assert result["content"] == "def foo():\n    pass"
     assert result["metadata"].get("code_language") == "python"
+    assert result["context"] == "S"
+    assert result["tests"] == []
+    assert result["quality_score"] == 0.0
 
 
 def test_generate_qa_pairs_extracts_docstring_and_signature(monkeypatch):


### PR DESCRIPTION
## Summary
- add `tests`, `context`, `quality_score` and `docstring` to dataset records
- compute quality score from repo metrics or StackOverflow scores
- handle new fields in DatasetBuilder
- update docs with record schema example
- extend README with example record
- adjust unit tests for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685928e2571c8320965cec0e291156bf