### PR TITLE
Add Scrapy and Spark support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ por `MAX_CONCURRENT_REQUESTS`.
 
 ### URLs base personalizadas
 
-O módulo `scraper_wiki.py` define o dicionário `BASE_URLS` com os domínios
+O pacote `scraper_wiki` define o dicionário `BASE_URLS` com os domínios
 principais para cada idioma. A função `get_base_url(lang)` consulta esse mapa e
 retorna `"https://{lang}.wikipedia.org"` quando o idioma não está definido.
 
@@ -325,6 +325,26 @@ python cli.py scrape --distributed --lang pt --category "Programação"
 ```
 
 O `DatasetBuilder` enviará as tarefas para o cluster usando `client.submit`.
+
+## Scrapy
+
+Para rastrear páginas em larga escala é possível usar o spider
+`scraper_wiki.scrapy_spider.WikiSpider`. Execute com `scrapy runspider` e
+defina `lang` e `category` se desejar iniciar por uma categoria específica:
+
+```bash
+scrapy runspider scraper_wiki/scrapy_spider.py -a lang=pt -a category=Programacao
+```
+
+## Spark Pipeline
+
+O módulo `training.spark_pipeline` oferece uma etapa de pré-processamento
+distribuído com PySpark. Basta informar o dataset de entrada e o diretório de
+saída para gerar os pares pergunta/resposta em cluster:
+
+```bash
+python -m training.spark_pipeline dataset.json out_dir
+```
 
 ## Controle de Qualidade
 

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -179,6 +179,19 @@ class Config:
         return random.choice(cls.USER_AGENTS)
 
 
+_proxy_index = 0
+
+
+def get_next_proxy() -> str | None:
+    """Return the next proxy from ``Config.PROXIES`` cycling sequentially."""
+    global _proxy_index
+    if not Config.PROXIES:
+        return None
+    proxy = Config.PROXIES[_proxy_index % len(Config.PROXIES)]
+    _proxy_index += 1
+    return proxy
+
+
 BASE_URLS = {
     "en": "https://en.wikipedia.org",
     "pt": "https://pt.wikipedia.org",
@@ -920,7 +933,7 @@ async def fetch_with_retry(
     """Fetch a URL using ``aiohttp`` with automatic retries and logging."""
 
     if proxy is None and Config.PROXIES:
-        proxy = random.choice(Config.PROXIES)
+        proxy = get_next_proxy()
 
     for attempt in range(1, retries + 1):
         try:
@@ -1132,7 +1145,7 @@ class WikipediaAdvanced:
         """Refresh User-Agent and proxy settings before a request."""
         self.session.headers["User-Agent"] = Config.get_random_user_agent()
         if Config.PROXIES:
-            self.session.proxies = random.choice(Config.PROXIES)
+            self.session.proxies = get_next_proxy()
         else:
             self.session.proxies = {}
 

--- a/scraper_wiki/scrapy_spider.py
+++ b/scraper_wiki/scrapy_spider.py
@@ -1,0 +1,34 @@
+"""Scrapy spider for large scale Wikipedia crawling."""
+
+from __future__ import annotations
+
+import scrapy
+
+from . import Config, get_base_url
+
+
+class WikiSpider(scrapy.Spider):
+    """Spider that recursively downloads Wikipedia pages."""
+
+    name = "wiki_spider"
+
+    def __init__(self, lang: str = "en", category: str | None = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lang = lang
+        self.category = category
+        if category:
+            self.start_urls = [f"{get_base_url(lang)}/wiki/{category}"]
+        else:
+            self.start_urls = []
+
+    custom_settings = {"USER_AGENT": Config.get_random_user_agent()}
+
+    def parse(self, response: scrapy.http.Response):
+        yield {"url": response.url, "html": response.text}
+        for href in response.css("a::attr(href)").getall():
+            if not href.startswith("/wiki/"):
+                continue
+            if ":" in href:
+                continue
+            url = response.urljoin(href)
+            yield scrapy.Request(url, callback=self.parse)

--- a/training/spark_pipeline.py
+++ b/training/spark_pipeline.py
@@ -1,0 +1,28 @@
+"""PySpark preprocessing pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, explode
+
+
+def load_dataset(path: str | Path) -> List[Dict]:
+    """Load JSON dataset using Spark."""
+
+    spark = SparkSession.builder.getOrCreate()
+    df = spark.read.json(str(path))
+    return [row.asDict() for row in df.collect()]
+
+
+def run_spark_pipeline(path: str | Path, out_dir: str | Path) -> None:
+    """Simple Spark job that explodes questions and answers."""
+
+    spark = SparkSession.builder.getOrCreate()
+    df = spark.read.json(str(path))
+    qa = df.select(
+        explode(col("questions")).alias("q"), explode(col("answers")).alias("a")
+    )
+    qa.write.json(str(Path(out_dir) / "qa_pairs"), mode="overwrite")


### PR DESCRIPTION
## Summary
- convert `scraper_wiki.py` into package and add `scrapy_spider.py`
- implement rotating proxy selection in `fetch_with_retry`
- provide `training.spark_pipeline` for PySpark preprocessing
- document Scrapy spider and Spark pipeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68592e1da7548320b3ce23a17c52dfcb