### PR TITLE
Enable incremental scraping via metadata tracking

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -113,6 +113,9 @@ def scrape(
     train: bool = typer.Option(
         False, "--train", help="Executa conversões para treinamento"
     ),
+    incremental: bool = typer.Option(
+        False, "--incremental", help="Busca apenas novos itens", is_flag=True
+    ),
 ):
     """Executa o scraper imediatamente."""
     lang = lang or None
@@ -167,7 +170,7 @@ def scrape(
         plg = load_plugin(plugin)
         languages = lang or scraper_wiki.Config.LANGUAGES
         categories = cats or list(scraper_wiki.Config.CATEGORIES)
-        run_plugin(plg, languages, categories, fmt)
+        run_plugin(plg, languages, categories, fmt, incremental=incremental)
 
 
 @app.command()

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,9 +1,12 @@
 """Plugin utilities and registry."""
 
 import importlib
-from typing import List
+from typing import List, Optional
+from datetime import datetime
+
 from core.builder import DatasetBuilder
 from .base import Plugin
+import storage_sqlite
 
 # Mapping of available plugin names to module paths
 AVAILABLE_PLUGINS = {
@@ -30,17 +33,38 @@ def load_plugin(name: str) -> Plugin:
 
 
 def run_plugin(
-    plugin: Plugin, langs: List[str], categories: List[str], fmt: str = "all"
+    plugin: Plugin,
+    langs: List[str],
+    categories: List[str],
+    fmt: str = "all",
+    incremental: bool = False,
 ) -> List[dict]:
     """Execute scraping using a plugin."""
     builder = DatasetBuilder()
     for lang in langs:
         for category in categories:
-            items = plugin.fetch_items(lang, category)
+            key = f"{plugin.__class__.__name__}:{lang}:{category}"
+            since = storage_sqlite.get_last_processed(key) if incremental else None
+            if since:
+                items = plugin.fetch_items(lang, category, since=since)
+            else:
+                items = plugin.fetch_items(lang, category)
+            latest: Optional[str] = None
             for item in items:
                 result = plugin.parse_item(item)
                 if result:
                     builder.dataset.append(result)
+                ts = (
+                    item.get("created_at")
+                    or item.get("creation_date")
+                    or item.get("commit", {}).get("committer", {}).get("date")
+                )
+                if ts is not None:
+                    if isinstance(ts, (int, float)):
+                        ts = datetime.utcfromtimestamp(int(ts)).isoformat()
+                    latest = ts if latest is None or ts > latest else latest
+            if incremental and latest:
+                storage_sqlite.set_last_processed(key, str(latest))
     builder.save_dataset(fmt)
     return builder.dataset
 

--- a/plugins/github_scraper.py
+++ b/plugins/github_scraper.py
@@ -43,20 +43,21 @@ class GitHubScraper:
         resp.raise_for_status()
         return resp.json()
 
-    def get_commits(self, repo_url: str) -> List[Dict]:
+    def get_commits(self, repo_url: str, since: str | None = None) -> List[Dict]:
         """Return commit metadata for the repository."""
         owner, repo = self._parse_repo(repo_url)
         url = f"{self.api_url}/repos/{owner}/{repo}/commits"
-        resp = requests.get(url, headers=self._headers())
+        params = {"since": since} if since else None
+        resp = requests.get(url, headers=self._headers(), params=params)
         resp.raise_for_status()
         return resp.json()
 
     def get_issue_commit_pairs(
-        self, repo_url: str, state: str = "closed"
+        self, repo_url: str, state: str = "closed", since: str | None = None
     ) -> List[Tuple[Dict, Dict]]:
         """Return pairs of issues and commits that reference them."""
         issues = self.get_issues(repo_url, state=state)
-        commits = self.get_commits(repo_url)
+        commits = self.get_commits(repo_url, since=since)
         pairs: List[Tuple[Dict, Dict]] = []
         for issue in issues:
             number = issue.get("number")
@@ -70,10 +71,12 @@ class GitHubScraper:
                     break
         return pairs
 
-    def build_problem_solution_records(self, repo_url: str) -> List[Dict]:
+    def build_problem_solution_records(
+        self, repo_url: str, since: str | None = None
+    ) -> List[Dict]:
         """Return dataset records combining issues and closing commits."""
         records = []
-        for issue, commit in self.get_issue_commit_pairs(repo_url):
+        for issue, commit in self.get_issue_commit_pairs(repo_url, since=since):
             problem = f"{issue.get('title', '')}\n\n{issue.get('body', '')}"
             solution = commit.get("commit", {}).get("message", "")
             records.append({"problem": problem, "solution": solution})

--- a/plugins/gitlab_scraper.py
+++ b/plugins/gitlab_scraper.py
@@ -25,7 +25,11 @@ class GitLabScraper:
         return headers
 
     def search_repositories(
-        self, language: str, min_stars: int, per_page: int = 20
+        self,
+        language: str,
+        min_stars: int,
+        per_page: int = 20,
+        since: str | None = None,
     ) -> List[Dict]:
         """Return GitLab projects filtered by language and star count."""
         params = {
@@ -35,6 +39,8 @@ class GitLabScraper:
             "per_page": per_page,
             "simple": True,
         }
+        if since:
+            params["last_activity_after"] = since
         resp = requests.get(
             f"{self.api_url}/projects",
             headers=self._headers(),

--- a/plugins/stackexchange.py
+++ b/plugins/stackexchange.py
@@ -26,7 +26,9 @@ class StackExchangePlugin(Plugin):
             Config.STACKEXCHANGE_MIN_SCORE if min_score is None else min_score
         )
 
-    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+    def fetch_items(
+        self, lang: str, category: str, since: str | None = None
+    ) -> List[Dict]:
         params = {
             "site": self.site,
             "tagged": category,
@@ -37,6 +39,14 @@ class StackExchangePlugin(Plugin):
         }
         if self.api_key:
             params["key"] = self.api_key
+        if since:
+            try:
+                from datetime import datetime
+
+                ts = int(datetime.fromisoformat(since).timestamp())
+                params["fromdate"] = ts
+            except Exception:
+                pass
         resp = requests.get(
             f"{self.endpoint}/questions", params=params, timeout=Config.TIMEOUT
         )

--- a/storage_sqlite.py
+++ b/storage_sqlite.py
@@ -1,9 +1,12 @@
 import os
 import json
 import sqlite3
+from typing import Optional
 
 
-def save_to_db(data: dict, table: str = "infoboxes", db_path: str = "infoboxes.sqlite") -> None:
+def save_to_db(
+    data: dict, table: str = "infoboxes", db_path: str = "infoboxes.sqlite"
+) -> None:
     """Save a dictionary as a JSON blob in the given SQLite table."""
     dir_name = os.path.dirname(db_path)
     if dir_name:
@@ -16,6 +19,41 @@ def save_to_db(data: dict, table: str = "infoboxes", db_path: str = "infoboxes.s
         conn.execute(
             f"INSERT INTO {table} (data) VALUES (?)",
             (json.dumps(data, ensure_ascii=False),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_last_processed(name: str, db_path: str = "metadata.sqlite") -> Optional[str]:
+    """Return the last processed timestamp stored for ``name``."""
+    if os.path.dirname(db_path):
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS metadata (name TEXT PRIMARY KEY, ts TEXT)"
+        )
+        row = conn.execute("SELECT ts FROM metadata WHERE name=?", (name,)).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def set_last_processed(
+    name: str, timestamp: str, db_path: str = "metadata.sqlite"
+) -> None:
+    """Update the last processed timestamp for ``name``."""
+    if os.path.dirname(db_path):
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS metadata (name TEXT PRIMARY KEY, ts TEXT)"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (name, ts) VALUES (?, ?)",
+            (name, timestamp),
         )
         conn.commit()
     finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,64 +8,88 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 # Stub heavy dependencies to avoid installation
-sys.modules.setdefault('sentence_transformers', SimpleNamespace(SentenceTransformer=object))
-sys.modules.setdefault('datasets', SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None))
-sys.modules.setdefault('spacy', SimpleNamespace(load=lambda *a, **k: None))
-sys.modules.setdefault('unidecode', SimpleNamespace(unidecode=lambda x: x))
-sys.modules.setdefault('tqdm', SimpleNamespace(tqdm=lambda x, **k: x))
-sys.modules.setdefault('html2text', SimpleNamespace())
-wiki_mod = ModuleType('wikipediaapi')
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(SentenceTransformer=object)
+)
+sys.modules.setdefault(
+    "datasets",
+    SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None),
+)
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault("unidecode", SimpleNamespace(unidecode=lambda x: x))
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault("html2text", SimpleNamespace())
+wiki_mod = ModuleType("wikipediaapi")
 wiki_mod.WikipediaException = Exception
 wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
 wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
 wiki_mod.WikipediaPage = object
-wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(page=lambda *a, **k: SimpleNamespace(exists=lambda: False), api=SimpleNamespace(article_url=lambda x: ""))
-sys.modules.setdefault('wikipediaapi', wiki_mod)
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(
+    page=lambda *a, **k: SimpleNamespace(exists=lambda: False),
+    api=SimpleNamespace(article_url=lambda x: ""),
+)
+sys.modules.setdefault("wikipediaapi", wiki_mod)
 aiohttp_stub = SimpleNamespace(
     ClientSession=object,
     ClientTimeout=lambda *a, **k: None,
     ClientError=Exception,
     ClientResponseError=Exception,
 )
-sys.modules.setdefault('aiohttp', aiohttp_stub)
-sys.modules.setdefault('backoff', SimpleNamespace(on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None))
+sys.modules.setdefault("aiohttp", aiohttp_stub)
+sys.modules.setdefault(
+    "backoff",
+    SimpleNamespace(
+        on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None
+    ),
+)
 
-sklearn_mod = ModuleType('sklearn')
+sklearn_mod = ModuleType("sklearn")
 sklearn_mod.cluster = SimpleNamespace(KMeans=object)
-sklearn_mod.feature_extraction = SimpleNamespace(text=SimpleNamespace(TfidfVectorizer=object))
-sys.modules.setdefault('sklearn', sklearn_mod)
-sys.modules.setdefault('sklearn.cluster', sklearn_mod.cluster)
-sys.modules.setdefault('sklearn.feature_extraction', sklearn_mod.feature_extraction)
-sys.modules.setdefault('sklearn.feature_extraction.text', sklearn_mod.feature_extraction.text)
+sklearn_mod.feature_extraction = SimpleNamespace(
+    text=SimpleNamespace(TfidfVectorizer=object)
+)
+sys.modules.setdefault("sklearn", sklearn_mod)
+sys.modules.setdefault("sklearn.cluster", sklearn_mod.cluster)
+sys.modules.setdefault("sklearn.feature_extraction", sklearn_mod.feature_extraction)
+sys.modules.setdefault(
+    "sklearn.feature_extraction.text", sklearn_mod.feature_extraction.text
+)
 
-sumy_mod = ModuleType('sumy')
-parsers_mod = ModuleType('sumy.parsers')
-plaintext_mod = ModuleType('sumy.parsers.plaintext')
+sumy_mod = ModuleType("sumy")
+parsers_mod = ModuleType("sumy.parsers")
+plaintext_mod = ModuleType("sumy.parsers.plaintext")
 plaintext_mod.PlaintextParser = object
 parsers_mod.plaintext = plaintext_mod
-nlp_mod = ModuleType('sumy.nlp')
-tokenizers_mod = ModuleType('sumy.nlp.tokenizers')
+nlp_mod = ModuleType("sumy.nlp")
+tokenizers_mod = ModuleType("sumy.nlp.tokenizers")
 tokenizers_mod.Tokenizer = object
 nlp_mod.tokenizers = tokenizers_mod
-summarizers_mod = ModuleType('sumy.summarizers')
-lsa_mod = ModuleType('sumy.summarizers.lsa')
+summarizers_mod = ModuleType("sumy.summarizers")
+lsa_mod = ModuleType("sumy.summarizers.lsa")
 lsa_mod.LsaSummarizer = object
 summarizers_mod.lsa = lsa_mod
 sumy_mod.parsers = parsers_mod
 sumy_mod.nlp = nlp_mod
 sumy_mod.summarizers = summarizers_mod
-sys.modules.setdefault('sumy', sumy_mod)
-sys.modules.setdefault('sumy.parsers', parsers_mod)
-sys.modules.setdefault('sumy.parsers.plaintext', plaintext_mod)
-sys.modules.setdefault('sumy.nlp', nlp_mod)
-sys.modules.setdefault('sumy.nlp.tokenizers', tokenizers_mod)
-sys.modules.setdefault('sumy.summarizers', summarizers_mod)
-sys.modules.setdefault('sumy.summarizers.lsa', lsa_mod)
-sys.modules.setdefault('streamlit', SimpleNamespace())
-sys.modules.setdefault('psutil', SimpleNamespace(cpu_percent=lambda interval=1: 0, virtual_memory=lambda: SimpleNamespace(percent=0)))
+sys.modules.setdefault("sumy", sumy_mod)
+sys.modules.setdefault("sumy.parsers", parsers_mod)
+sys.modules.setdefault("sumy.parsers.plaintext", plaintext_mod)
+sys.modules.setdefault("sumy.nlp", nlp_mod)
+sys.modules.setdefault("sumy.nlp.tokenizers", tokenizers_mod)
+sys.modules.setdefault("sumy.summarizers", summarizers_mod)
+sys.modules.setdefault("sumy.summarizers.lsa", lsa_mod)
+sys.modules.setdefault("streamlit", SimpleNamespace())
+sys.modules.setdefault(
+    "psutil",
+    SimpleNamespace(
+        cpu_percent=lambda interval=1: 0,
+        virtual_memory=lambda: SimpleNamespace(percent=0),
+    ),
+)
 
 import wikipediaapi
-if not hasattr(wikipediaapi, 'WikipediaException'):
+
+if not hasattr(wikipediaapi, "WikipediaException"):
     wikipediaapi.WikipediaException = Exception
 
 from typer.testing import CliRunner
@@ -87,14 +111,19 @@ def test_queue_command(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "QUEUE_FILE", tmp_path / "queue.jsonl")
 
     runner = CliRunner()
-    result = runner.invoke(cli.app, [
-        "queue", "--lang", "en", "--category", "Programming", "--format", "json"
-    ])
+    result = runner.invoke(
+        cli.app,
+        ["queue", "--lang", "en", "--category", "Programming", "--format", "json"],
+    )
 
     assert result.exit_code == 0
     queue_content = (tmp_path / "queue.jsonl").read_text().strip()
     assert queue_content
-    assert "en" in queue_content and "Programming" in queue_content and "json" in queue_content
+    assert (
+        "en" in queue_content
+        and "Programming" in queue_content
+        and "json" in queue_content
+    )
 
 
 def test_queue_command_jsonl(tmp_path, monkeypatch):
@@ -201,7 +230,6 @@ def test_clear_cache_command(monkeypatch):
     assert called.get("ok")
 
 
-
 def test_load_progress(tmp_path, monkeypatch):
     monkeypatch.setattr(cli.dashboard, "PROGRESS_FILE", tmp_path / "prog.json")
     progress_data = {"pages_processed": 5}
@@ -221,6 +249,7 @@ def test_parallelism_options(monkeypatch):
     assert cli.scraper_wiki.Config.MAX_THREADS == 5
     assert cli.scraper_wiki.Config.MAX_PROCESSES == 2
 
+
 def test_scrape_with_training_option(monkeypatch, tmp_path):
     called = {}
 
@@ -230,9 +259,9 @@ def test_scrape_with_training_option(monkeypatch, tmp_path):
     def fake_run(path):
         called["train"] = str(path)
 
-    training_mod = ModuleType('training')
+    training_mod = ModuleType("training")
     training_mod.pipeline = SimpleNamespace(run_pipeline=fake_run)
-    sys.modules['training'] = training_mod
+    sys.modules["training"] = training_mod
 
     monkeypatch.setattr(cli.scraper_wiki, "main", fake_main)
     monkeypatch.setattr(cli.scraper_wiki.Config, "OUTPUT_DIR", str(tmp_path))
@@ -257,6 +286,7 @@ def test_scrape_distributed(monkeypatch):
         captured["client"] = kwargs.get("client")
 
     import cluster
+
     monkeypatch.setattr(cluster, "get_client", lambda: FakeClient())
     monkeypatch.setattr(cli.scraper_wiki, "main", fake_main)
     runner = CliRunner()
@@ -325,3 +355,21 @@ def test_scrape_revisions_option(monkeypatch):
     result = runner.invoke(cli.app, ["scrape", "--revisions", "--rev-limit", "3"])
     assert result.exit_code == 0
     assert captured["rev"] == (True, 3)
+
+
+def test_scrape_incremental_option(monkeypatch):
+    captured = {}
+
+    def fake_run_plugin(plg, langs, categories, fmt, incremental=False):
+        captured["inc"] = incremental
+
+    import plugins
+
+    monkeypatch.setattr(plugins, "run_plugin", fake_run_plugin)
+    monkeypatch.setattr(plugins, "load_plugin", lambda name: object())
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app, ["scrape", "--plugin", "stackexchange", "--incremental"]
+    )
+    assert result.exit_code == 0
+    assert captured.get("inc") is True

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -1,6 +1,10 @@
 import json
 import sqlite3
-from storage_sqlite import save_to_db
+from storage_sqlite import (
+    save_to_db,
+    get_last_processed,
+    set_last_processed,
+)
 
 
 def test_save_to_db_creates_table_and_inserts(tmp_path):
@@ -12,3 +16,12 @@ def test_save_to_db_creates_table_and_inserts(tmp_path):
     conn.close()
     assert row is not None
     assert json.loads(row[0]) == data
+
+
+def test_metadata_functions(tmp_path):
+    db_file = tmp_path / "meta.sqlite"
+    assert get_last_processed("repo", db_path=str(db_file)) is None
+    set_last_processed("repo", "2024-01-01T00:00:00Z", db_path=str(db_file))
+    assert get_last_processed("repo", db_path=str(db_file)) == "2024-01-01T00:00:00Z"
+    set_last_processed("repo", "2024-02-02T00:00:00Z", db_path=str(db_file))
+    assert get_last_processed("repo", db_path=str(db_file)) == "2024-02-02T00:00:00Z"


### PR DESCRIPTION
## Summary
- add metadata helpers to storage_sqlite
- fetch only new items in GitHub/GitLab/StackExchange plugins
- track latest processed timestamp in run_plugin
- expose `--incremental` option in CLI
- test new metadata functions and CLI flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593144e5a48320a7859fd92fe52305