### PR TITLE
Add plagiarism checks and credential stripping

### DIFF
--- a/dq.py
+++ b/dq.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import difflib
 import hashlib
-from typing import List, Dict, Tuple
+import re
+from typing import Dict, List, Tuple
 
 import numpy as np
 from simhash import Simhash
@@ -182,3 +184,32 @@ def complete_missing_fields(records: List[Dict], extra: List[Dict]) -> List[Dict
             elif k not in rec or rec[k] in (None, "", []):
                 rec[k] = v
     return records
+
+
+def strip_credentials(code: str) -> str:
+    """Return ``code`` with tokens and credentials redacted."""
+    patterns = [
+        r"ghp_[A-Za-z0-9]{36}",
+        r"github_pat_[A-Za-z0-9_]{80,}",
+        r"sk-[A-Za-z0-9]{16,}",
+        r"(?i)(?:api|secret|token|key)[^\n]{0,20}[\'\"]?[A-Za-z0-9_-]{16,}[\'\"]?",
+    ]
+    text = code
+    for pat in patterns:
+        text = re.sub(pat, "<REDACTED>", text)
+    return text
+
+
+def detect_code_plagiarism(records: List[Dict], threshold: float = 0.95) -> List[Dict]:
+    """Return records whose ``content`` is very similar to others."""
+    plagiarized: List[Dict] = []
+    for i, rec in enumerate(records):
+        code_i = rec.get("content", "")
+        for other in records[i + 1 :]:
+            code_j = other.get("content", "")
+            if not code_i or not code_j:
+                continue
+            sim = difflib.SequenceMatcher(None, code_i, code_j).ratio()
+            if sim >= threshold:
+                plagiarized.append(other)
+    return plagiarized

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -2242,12 +2242,25 @@ class DatasetBuilder:
             logger.warning("Nenhum dado para salvar")
             return
 
+        for rec in self.dataset:
+            if "content" in rec:
+                rec["content"] = dq.strip_credentials(rec["content"])
+
         # Remove near-duplicates based on Simhash
         try:
             self.dataset, rem_sim = dq.deduplicate_by_simhash(self.dataset)
             self.duplicates_removed += rem_sim
         except Exception as e:  # pragma: no cover - library issues
             logger.error(f"Erro na deduplicação Simhash: {e}")
+
+        try:
+            plag = dq.detect_code_plagiarism(self.dataset)
+            if plag:
+                logger.warning(f"Registros plagiados removidos: {len(plag)}")
+                self.dataset = [r for r in self.dataset if r not in plag]
+                self.invalid_records += len(plag)
+        except Exception as e:  # pragma: no cover - library issues
+            logger.error(f"Erro na verificação de plágio: {e}")
 
         # Validação dos registros antes de salvar
         validated_data = []

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -50,3 +50,19 @@ def test_detect_leaks_by_embedding_identifies_similar():
     ]
     leaks = dq.detect_leaks_by_embedding(recs, ref, threshold=0.98)
     assert len(leaks) == 1
+
+
+def test_strip_credentials_replaces_tokens():
+    code = "token = 'ghp_0123456789abcdef0123456789abcdef0123'"
+    sanitized = dq.strip_credentials(code)
+    assert "<REDACTED>" in sanitized
+
+
+def test_detect_code_plagiarism_flags_duplicates():
+    recs = [
+        {"content": "print('hi')"},
+        {"content": "print('hi')"},
+        {"content": "print('bye')"},
+    ]
+    plag = dq.detect_code_plagiarism(recs, threshold=0.9)
+    assert len(plag) == 1

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -1892,3 +1892,33 @@ def test_dataset_builder_initializes_from_checkpoints(tmp_path, monkeypatch):
     assert builder.dataset == data
     assert builder.pending_pages == pages
     assert (Path(tmp_path) / "progress.json").exists()
+
+
+def test_save_dataset_strips_credentials(tmp_path, monkeypatch):
+    builder = sw.DatasetBuilder()
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 5)
+    builder.dataset = [
+        {
+            "id": "1",
+            "title": "t",
+            "language": "en",
+            "category": "c",
+            "topic": "ai",
+            "subtopic": "nlp",
+            "keywords": [],
+            "content": "secret_key = 'sk-abcdef0123456789'",
+            "summary": "s" * 20,
+            "content_embedding": [0.0],
+            "summary_embedding": [0.0],
+            "questions": ["q"],
+            "answers": ["a"],
+            "relations": [],
+            "created_at": "now",
+            "metadata": {},
+        }
+    ]
+
+    builder.save_dataset("json", output_dir=tmp_path)
+
+    data = json.loads((tmp_path / "wikipedia_qa.json").read_text(encoding="utf-8"))
+    assert "<REDACTED>" in data[0]["content"]


### PR DESCRIPTION
## Summary
- detect plagiarized code with new `detect_code_plagiarism` utility
- remove credentials from code via `strip_credentials`
- run these checks inside `DatasetBuilder.save_dataset`
- test credential stripping and plagiarism detection
- verify dataset builder removes credentials before saving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685933ee3be48320b6a6c87d22b94dfa