### PR TITLE
Add AST postprocessing utilities

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Scraper-Wiki Documentation
 
    modules
    code_fine_tuning
+   postprocessing
 
 Record Schema
 -------------

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -15,3 +15,6 @@ API Reference
 
 .. automodule:: training.pipeline
    :members:
+
+.. automodule:: training.postprocessing
+   :members:

--- a/docs/postprocessing.rst
+++ b/docs/postprocessing.rst
@@ -1,0 +1,17 @@
+Dataset Post-processing
+=======================
+
+Utilities in :mod:`training.postprocessing` help analyze code entries and filter
+records by cyclomatic complexity. They can be used after scraping to refine the
+final dataset.
+
+Example::
+
+    from training.postprocessing import analyze_code_ast, filter_by_complexity
+
+    stats = analyze_code_ast("def foo(x):\n    return x * 2")
+    print(stats["complexities"])  # {'foo': 1}
+
+    builder.enhance_with_clustering()
+    builder.dataset = filter_by_complexity(builder.dataset, min_complexity=2)
+

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -34,6 +34,7 @@ from bs4 import BeautifulSoup
 import requests
 import aiohttp
 from training.formats import save_qa_dataset, save_text_corpus
+from training.postprocessing import filter_by_complexity
 from urllib.parse import urlparse, urljoin
 import html2text
 import ast
@@ -407,11 +408,14 @@ def log_failed_url(url: str) -> None:
 
 
 class CacheBackend(Protocol):
-    def get(self, key: str): ...
+    def get(self, key: str):
+        ...
 
-    def set(self, key: str, data, ttl: Optional[int] = None): ...
+    def set(self, key: str, data, ttl: Optional[int] = None):
+        ...
 
-    def stats(self) -> dict: ...
+    def stats(self) -> dict:
+        ...
 
 
 class FileCache(CacheBackend):
@@ -1701,9 +1705,9 @@ class DatasetBuilder:
             images = extract_images(getattr(page, "_html", ""))
             qa_data["images"] = images
             if self.include_revisions:
-                qa_data.setdefault("metadata", {})["revisions"] = (
-                    wiki.get_revision_history(page_info["title"], self.rev_limit)
-                )
+                qa_data.setdefault("metadata", {})[
+                    "revisions"
+                ] = wiki.get_revision_history(page_info["title"], self.rev_limit)
             metrics.scrape_success.inc()
             metrics.pages_scraped_total.inc()
             return qa_data
@@ -2114,7 +2118,6 @@ class DatasetBuilder:
             ) as th_executor, ProcessPoolExecutor(
                 max_workers=Config.MAX_PROCESSES
             ) as pr_executor:
-
                 page_futures = {
                     th_executor.submit(self.process_page, page, pr_executor): page
                     for page in pages
@@ -2234,6 +2237,11 @@ class DatasetBuilder:
         # Adiciona clusters ao dataset
         for i, item in enumerate(self.dataset):
             item["cluster"] = int(clusters[i])
+
+        # Opcionalmente filtra registros pelo nível de complexidade
+        self.dataset = filter_by_complexity(
+            self.dataset, self.min_complexity, self.max_complexity
+        )
 
     def save_dataset(self, format: str = "all", output_dir: str = Config.OUTPUT_DIR):
         os.makedirs(output_dir, exist_ok=True)

--- a/tests/test_postprocessing.py
+++ b/tests/test_postprocessing.py
@@ -1,0 +1,26 @@
+import importlib
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+pp = importlib.import_module("training.postprocessing")
+
+
+def test_analyze_code_ast_returns_metrics():
+    code = "def foo(x):\n    if x:\n        return 1\n    return 0"
+    res = pp.analyze_code_ast(code)
+    assert res["language"] == "python"
+    assert res["complexities"]["foo"] >= 2
+
+
+def test_filter_by_complexity_filters_records():
+    data = [
+        {"content": "def a():\n    pass"},
+        {"content": "def b(x):\n    if x:\n        return x"},
+    ]
+    filtered = pp.filter_by_complexity(data, min_complexity=2)
+    assert len(filtered) == 1
+    assert filtered[0]["content"].startswith("def b")

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -2,3 +2,12 @@
 
 from .pipeline import run_pipeline
 from .preprocessing import chunk_text, tokenize_texts
+from .postprocessing import analyze_code_ast, filter_by_complexity
+
+__all__ = [
+    "run_pipeline",
+    "chunk_text",
+    "tokenize_texts",
+    "analyze_code_ast",
+    "filter_by_complexity",
+]

--- a/training/postprocessing.py
+++ b/training/postprocessing.py
@@ -1,0 +1,106 @@
+"""Dataset post-processing utilities."""
+
+from __future__ import annotations
+
+import ast
+from typing import Any, Dict, List
+
+from utils.code import (
+    detect_programming_language,
+    normalize_indentation,
+    remove_comments,
+    docstring_to_google,
+    parse_function_signature,
+)
+from utils.ast_tools import get_functions_complexity
+
+
+def analyze_code_ast(code: str, language: str | None = None) -> Dict[str, Any]:
+    """Analyze ``code`` and return AST-based metrics.
+
+    Args:
+        code: Source code string.
+        language: Optional language name. If ``None`` the language is guessed.
+
+    Returns:
+        dict: Dictionary with the cleaned ``content`` string, detected
+        ``language`` and the ``complexities`` mapping. For Python code the
+        ``docstring`` and ``signature`` fields are also provided.
+    """
+    lang = language or detect_programming_language(code)
+    cleaned = normalize_indentation(remove_comments(code, lang))
+    result: Dict[str, Any] = {
+        "content": cleaned,
+        "language": lang,
+        "complexities": get_functions_complexity(cleaned, lang),
+    }
+    if lang in {"python", "py"}:
+        result["signature"] = parse_function_signature(code)
+        doc = ""
+        try:
+            tree = ast.parse(code)
+            func = next(
+                (
+                    n
+                    for n in tree.body
+                    if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                ),
+                None,
+            )
+            if func:
+                ds = ast.get_docstring(func)
+                if ds:
+                    doc = docstring_to_google(ds)
+        except Exception:
+            pass
+        if doc:
+            result["docstring"] = doc
+    return result
+
+
+def filter_by_complexity(
+    records: List[Dict],
+    min_complexity: int | None = None,
+    max_complexity: int | None = None,
+) -> List[Dict]:
+    """Filter ``records`` by cyclomatic complexity.
+
+    Each record must contain a ``content`` field with source code. Complexity is
+    computed using :func:`analyze_code_ast` and records outside the range are
+    discarded. Detected metrics are added back to the records that are kept.
+
+    Args:
+        records: Dataset records to filter.
+        min_complexity: Minimum allowed complexity.
+        max_complexity: Maximum allowed complexity.
+
+    Returns:
+        list[dict]: Filtered dataset.
+    """
+    if min_complexity is None and max_complexity is None:
+        return records
+
+    filtered: List[Dict] = []
+    for rec in records:
+        code = rec.get("content", "")
+        analysis = analyze_code_ast(code, rec.get("metadata", {}).get("code_language"))
+        complexities = analysis.get("complexities", {})
+        max_c = max(complexities.values()) if complexities else 0
+        if min_complexity is not None and max_c < min_complexity:
+            continue
+        if max_complexity is not None and max_c > max_complexity:
+            continue
+        rec.setdefault("metadata", {})
+        rec["metadata"]["code_language"] = analysis["language"]
+        if complexities:
+            rec["metadata"]["complexities"] = complexities
+        if analysis.get("docstring"):
+            rec["docstring"] = analysis["docstring"]
+        if analysis.get("signature"):
+            rec["signature"] = analysis["signature"]
+        rec["content"] = analysis["content"]
+        filtered.append(rec)
+    return filtered
+
+
+__all__ = ["analyze_code_ast", "filter_by_complexity"]


### PR DESCRIPTION
## Summary
- create `training.postprocessing` with code analysis helpers
- expose postprocessing utilities from the `training` package
- run complexity filtering after clustering in `DatasetBuilder`
- document postprocessing utilities
- test new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68593859b3a483208e770dc25c769ed2