### PR TITLE
Add YAML dataset config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,26 @@ plg = load_plugin("wikidata")
 records = run_plugin(plg, ["en"], ["Artificial intelligence"])
 ```
 
+### Configuração via YAML
+
+O arquivo `examples/code_dataset_config.yaml` demonstra como definir idiomas,
+categorias e opções específicas de cada plugin em um único lugar. Para executar
+o scraping carregando essa configuração utilize:
+
+```python
+import yaml
+from plugins import load_plugin, run_plugin
+
+cfg = yaml.safe_load(open("examples/code_dataset_config.yaml", encoding="utf-8"))
+langs = cfg.get("languages", [])
+cats = cfg.get("categories", [])
+fmt = cfg.get("format", "json")
+for name, opts in cfg.get("plugins", {}).items():
+    plugin = load_plugin(name)(**opts)
+    run_plugin(plugin, langs, cats, fmt)
+```
+
+
 ## Limpeza e NLP
 
 Estas funções podem ser utilizadas isoladamente ou combinadas com o

--- a/examples/code_dataset_config.yaml
+++ b/examples/code_dataset_config.yaml
@@ -1,0 +1,23 @@
+# Example configuration for building a code dataset from multiple sources
+languages:
+  - en
+  - pt
+categories:
+  - machine-learning
+  - algorithms
+format: jsonl
+plugins:
+  stackoverflow:
+    site: stackoverflow
+    api_key: YOUR_STACKEXCHANGE_API_KEY
+    min_score: 5
+  github_scraper:
+    token: YOUR_GITHUB_TOKEN
+    api_url: https://api.github.com
+  gitlab_scraper:
+    token: YOUR_GITLAB_TOKEN
+    api_url: https://gitlab.com/api/v4
+  api_docs:
+    allowed_domains:
+      - docs.python.org
+      - developer.mozilla.org


### PR DESCRIPTION
## Summary
- provide `examples/code_dataset_config.yaml` describing code dataset options
- document YAML-driven scraping workflow in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68593be5b0248320bf41666e4bb97313