### PR TITLE
Add GitHub Gist scraper plugin

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -19,6 +19,7 @@ AVAILABLE_PLUGINS = {
     "github_scraper": "github_scraper",
     "code_extractor": "code_extractor",
     "gitlab_scraper": "gitlab_scraper",
+    "gist_scraper": "gist_scraper",
     "api_docs": "api_docs",
     "competitions": "competitions",
 }

--- a/plugins/gist_scraper.py
+++ b/plugins/gist_scraper.py
@@ -1,0 +1,44 @@
+"""Simple GitHub Gist scraping utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+
+class GistScraper:
+    """Fetch public gists from GitHub."""
+
+    def __init__(self, token: str | None = None, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://api.github.com"
+        self.token = token
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        return headers
+
+    def fetch_items(self, username: str) -> List[Dict]:
+        """Return gists for the provided GitHub username."""
+        url = f"{self.api_url}/users/{username}/gists"
+        resp = requests.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return gist description and file contents."""
+        files: Dict[str, str] = {}
+        for info in item.get("files", {}).values():
+            raw_url = info.get("raw_url")
+            if not raw_url:
+                continue
+            resp = requests.get(raw_url, headers=self._headers())
+            resp.raise_for_status()
+            files[info.get("filename", "file")] = resp.text
+        return {"description": item.get("description", ""), "files": files}
+
+
+# Registry alias
+Plugin = GistScraper

--- a/tests/test_gist_scraper.py
+++ b/tests/test_gist_scraper.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_gist_scraper(monkeypatch):
+    import importlib
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    called = []
+
+    class DummyResp:
+        def __init__(self, data=None, text=""):
+            self._data = data
+            self._text = text
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+        @property
+        def text(self):
+            return self._text
+
+    def fake_get(url, headers=None):
+        called.append(url)
+        if url.endswith("/users/user/gists"):
+            return DummyResp(
+                data=[
+                    {
+                        "id": "1",
+                        "description": "d",
+                        "files": {
+                            "f1.txt": {
+                                "filename": "f1.txt",
+                                "raw_url": "raw1",
+                            }
+                        },
+                    }
+                ]
+            )
+        if url == "raw1":
+            return DummyResp(text="content1")
+        return DummyResp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.gist_scraper")
+    scraper = mod.GistScraper()
+
+    items = scraper.fetch_items("user")
+    assert called[0].endswith("/users/user/gists")
+    record = scraper.parse_item(items[0])
+    assert record == {"description": "d", "files": {"f1.txt": "content1"}}


### PR DESCRIPTION
## Summary
- implement `GistScraper` plugin for downloading user gists
- register the plugin in `AVAILABLE_PLUGINS`
- add unit tests mocking HTTP calls

## Testing
- `pytest tests/test_gist_scraper.py tests/test_github_scraper.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594ab920448320b9d921e6608a620b