### PR TITLE
Add GitLab snippets plugin

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -19,6 +19,7 @@ AVAILABLE_PLUGINS = {
     "github_scraper": "github_scraper",
     "code_extractor": "code_extractor",
     "gitlab_scraper": "gitlab_scraper",
+    "gitlab_snippets": "gitlab_snippets",
     "gist_scraper": "gist_scraper",
     "api_docs": "api_docs",
     "competitions": "competitions",

--- a/plugins/gitlab_snippets.py
+++ b/plugins/gitlab_snippets.py
@@ -1,0 +1,57 @@
+"""GitLab snippets scraping utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from .base import Plugin
+
+
+class GitLabSnippets(Plugin):  # type: ignore[misc]
+    """Fetch snippets from GitLab."""
+
+    def __init__(self, token: str | None = None, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://gitlab.com/api/v4"
+        self.token = token
+
+    def _headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self.token:
+            headers["PRIVATE-TOKEN"] = self.token
+        return headers
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return snippets matching the search query."""
+        resp = requests.get(
+            f"{self.api_url}/snippets",
+            headers=self._headers(),
+            params={"search": category, "per_page": 20},
+        )
+        resp.raise_for_status()
+        items = resp.json()
+        for it in items:
+            it["lang"] = lang
+            it["category"] = category
+        return items
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return snippet title and raw code."""
+        snippet_id = item.get("id")
+        if snippet_id is None:
+            return {}
+        resp = requests.get(
+            f"{self.api_url}/snippets/{snippet_id}/raw",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return {
+            "title": item.get("title", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "code": resp.text,
+        }
+
+
+Plugin = GitLabSnippets

--- a/tests/test_gitlab_snippets.py
+++ b/tests/test_gitlab_snippets.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_gitlab_snippets(monkeypatch):
+    import importlib
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    called = []
+
+    class DummyResp:
+        def __init__(self, data=None, text=""):
+            self._data = data
+            self._text = text
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+        @property
+        def text(self):
+            return self._text
+
+    def fake_get(url, headers=None, params=None):
+        called.append(url)
+        if url.endswith("/snippets"):
+            return DummyResp(data=[{"id": 1, "title": "t"}])
+        if url.endswith("/snippets/1/raw"):
+            return DummyResp(text="code1")
+        return DummyResp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.gitlab_snippets")
+    scraper = mod.GitLabSnippets()
+
+    items = scraper.fetch_items("en", "example")
+    assert called[0].endswith("/snippets")
+    record = scraper.parse_item(items[0])
+    assert record == {
+        "title": "t",
+        "language": "en",
+        "category": "example",
+        "code": "code1",
+    }


### PR DESCRIPTION
## Summary
- support collecting GitLab snippets
- hook new plugin into plugin registry
- test GitLab snippets scraping logic

## Testing
- `black plugins/gitlab_snippets.py tests/test_gitlab_snippets.py plugins/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594fd596b883208c8b41f58589ddac