### PR TITLE
Add CodePen scraping plugin

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -23,6 +23,7 @@ AVAILABLE_PLUGINS = {
     "gist_scraper": "gist_scraper",
     "api_docs": "api_docs",
     "competitions": "competitions",
+    "codepen_scraper": "codepen_scraper",
 }
 
 

--- a/plugins/codepen_scraper.py
+++ b/plugins/codepen_scraper.py
@@ -1,0 +1,75 @@
+"""Scrape HTML, CSS and JS from CodePen or JSFiddle."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Dict, List
+
+import requests
+
+from .base import Plugin
+
+
+class CodePenScraper(Plugin):
+    """Fetch code snippets from CodePen or JSFiddle URLs."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return raw HTML for the provided URL."""
+        resp = requests.get(category)
+        resp.raise_for_status()
+        return [{"url": category, "content": resp.text, "lang": lang}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return extracted HTML, CSS and JS."""
+        content = item.get("content", "")
+        html = ""
+        css = ""
+        js = ""
+
+        # Try CodePen JSON data
+        match = re.search(r"__INITIAL_DATA__\s*=\s*(\{.*\})", content, re.S)
+        if match:
+            try:
+                data = json.loads(match.group(1))
+                files = data.get("project", {}).get("files", {})
+                html = files.get("html", {}).get("content", "")
+                css = files.get("css", {}).get("content", "")
+                js = files.get("js", {}).get("content", "")
+            except Exception:
+                pass
+
+        # Fallback for JSFiddle markup
+        if not any([html, css, js]):
+            html_match = re.search(
+                r"<textarea[^>]*id=\"(?:html|id_html)\"[^>]*>(.*?)</textarea>",
+                content,
+                re.S,
+            )
+            css_match = re.search(
+                r"<textarea[^>]*id=\"(?:css|id_css)\"[^>]*>(.*?)</textarea>",
+                content,
+                re.S,
+            )
+            js_match = re.search(
+                r"<textarea[^>]*id=\"(?:js|id_js)\"[^>]*>(.*?)</textarea>",
+                content,
+                re.S,
+            )
+            if html_match:
+                html = html_match.group(1)
+            if css_match:
+                css = css_match.group(1)
+            if js_match:
+                js = js_match.group(1)
+
+        return {
+            "url": item.get("url", ""),
+            "language": item.get("lang", "en"),
+            "html": html,
+            "css": css,
+            "js": js,
+        }
+
+
+Plugin = CodePenScraper

--- a/tests/test_codepen_scraper.py
+++ b/tests/test_codepen_scraper.py
@@ -1,0 +1,72 @@
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_codepen_scraper(monkeypatch):
+    import importlib
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    called = []
+
+    class DummyResp:
+        def __init__(self, text=""):
+            self._text = text
+
+        def raise_for_status(self):
+            pass
+
+        @property
+        def text(self):
+            return self._text
+
+    def fake_get(url):
+        called.append(url)
+        if "codepen" in url:
+            html = (
+                '<script>window.__INITIAL_DATA__ = {"project": {"files": {"html": '
+                '{"content": "<h1>Hello</h1>"}, "css": {"content": "h1{color:red;}"}, '
+                '"js": {"content": "console.log(1);"}}}};</script>'
+            )
+            return DummyResp(html)
+        html = (
+            '<textarea id="id_html"><h1>Hi</h1></textarea>'
+            '<textarea id="id_css">body{}</textarea>'
+            '<textarea id="id_js">console.log(2);</textarea>'
+        )
+        return DummyResp(html)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    mod = importlib.import_module("plugins.codepen_scraper")
+    scraper = mod.CodePenScraper()
+
+    items = scraper.fetch_items("en", "https://codepen.io/u/pen/1")
+    assert called[0].endswith("/pen/1")
+    record = scraper.parse_item(items[0])
+    assert record == {
+        "url": "https://codepen.io/u/pen/1",
+        "language": "en",
+        "html": "<h1>Hello</h1>",
+        "css": "h1{color:red;}",
+        "js": "console.log(1);",
+    }
+
+    items2 = scraper.fetch_items("en", "https://jsfiddle.net/test")
+    assert called[1].endswith("/test")
+    record2 = scraper.parse_item(items2[0])
+    assert record2 == {
+        "url": "https://jsfiddle.net/test",
+        "language": "en",
+        "html": "<h1>Hi</h1>",
+        "css": "body{}",
+        "js": "console.log(2);",
+    }


### PR DESCRIPTION
## Summary
- add `CodePenScraper` plugin for scraping CodePen or JSFiddle HTML/CSS/JS
- register plugin in `plugins.__init__`
- test plugin functionality

## Testing
- `black plugins/codepen_scraper.py tests/test_codepen_scraper.py plugins/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595183c0388320bd9060e9390431ec