### PR TITLE
Add legacy forums plugin

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -24,6 +24,7 @@ AVAILABLE_PLUGINS = {
     "api_docs": "api_docs",
     "competitions": "competitions",
     "codepen_scraper": "codepen_scraper",
+    "legacy_forums": "legacy_forums",
 }
 
 

--- a/plugins/legacy_forums.py
+++ b/plugins/legacy_forums.py
@@ -1,0 +1,62 @@
+"""Scrape legacy discussion forums like Yahoo Answers and Delphi/PHP boards."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class LegacyForumsPlugin(Plugin):
+    """Fetch question/answer pairs from multiple legacy forums."""
+
+    def __init__(
+        self,
+        yahoo_url: str | None = None,
+        delphi_url: str | None = None,
+        php_url: str | None = None,
+    ) -> None:
+        self.yahoo_url = yahoo_url or "https://answers.yahoo.com/api"
+        self.delphi_url = delphi_url or "https://forum.delphi.com/api"
+        self.php_url = php_url or "https://forum.phpdeveloper.com/api"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return basic query descriptors for all sources."""
+        return [
+            {"source": "yahoo", "query": category, "lang": lang},
+            {"source": "delphi", "query": category, "lang": lang},
+            {"source": "php", "query": category, "lang": lang},
+        ]
+
+    def _fetch(self, base: str, query: str) -> Dict:
+        resp = requests.get(f"{base}?q={query}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return a unified question/answer pair."""
+        source = item.get("source")
+        query = item.get("query", "")
+        if source == "yahoo":
+            data = self._fetch(self.yahoo_url, query)
+        elif source == "delphi":
+            data = self._fetch(self.delphi_url, query)
+        elif source == "php":
+            data = self._fetch(self.php_url, query)
+        else:
+            return {}
+        question = data.get("question") or data.get("title", "")
+        answer = data.get("answer") or data.get("reply") or data.get("content", "")
+        return {
+            "question": question,
+            "answer": answer,
+            "source": source,
+            "language": item.get("lang", "en"),
+        }
+
+
+# Registry alias
+Plugin = LegacyForumsPlugin

--- a/tests/test_legacy_forums.py
+++ b/tests/test_legacy_forums.py
@@ -1,0 +1,132 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy dependencies similar to other plugin tests
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(SentenceTransformer=object)
+)
+sys.modules.setdefault(
+    "datasets",
+    SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None),
+)
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault("html2text", SimpleNamespace(html2text=lambda x: x))
+sk_mod = SimpleNamespace(
+    cluster=SimpleNamespace(KMeans=object),
+    feature_extraction=SimpleNamespace(text=SimpleNamespace(TfidfVectorizer=object)),
+)
+sys.modules.setdefault("sklearn", sk_mod)
+sys.modules.setdefault("sklearn.cluster", sk_mod.cluster)
+sys.modules.setdefault("sklearn.feature_extraction", sk_mod.feature_extraction)
+sys.modules.setdefault(
+    "sklearn.feature_extraction.text", sk_mod.feature_extraction.text
+)
+sumy_mod = SimpleNamespace(
+    parsers=SimpleNamespace(plaintext=SimpleNamespace(PlaintextParser=object)),
+    nlp=SimpleNamespace(tokenizers=SimpleNamespace(Tokenizer=object)),
+    summarizers=SimpleNamespace(lsa=SimpleNamespace(LsaSummarizer=object)),
+)
+sys.modules.setdefault("sumy", sumy_mod)
+sys.modules.setdefault("sumy.parsers", sumy_mod.parsers)
+sys.modules.setdefault("sumy.parsers.plaintext", sumy_mod.parsers.plaintext)
+sys.modules.setdefault("sumy.nlp", sumy_mod.nlp)
+sys.modules.setdefault("sumy.nlp.tokenizers", sumy_mod.nlp.tokenizers)
+sys.modules.setdefault("sumy.summarizers", sumy_mod.summarizers)
+sys.modules.setdefault("sumy.summarizers.lsa", sumy_mod.summarizers.lsa)
+sys.modules.setdefault("streamlit", SimpleNamespace())
+sys.modules.setdefault(
+    "psutil",
+    SimpleNamespace(
+        cpu_percent=lambda interval=1: 0,
+        virtual_memory=lambda: SimpleNamespace(percent=0),
+    ),
+)
+sys.modules.setdefault(
+    "prometheus_client",
+    SimpleNamespace(
+        Counter=lambda *a, **k: object, start_http_server=lambda *a, **k: None
+    ),
+)
+wiki_mod = ModuleType("wikipediaapi")
+wiki_mod.WikipediaException = Exception
+wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
+wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
+wiki_mod.WikipediaPage = object
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(
+    page=lambda *a, **k: SimpleNamespace(exists=lambda: False),
+    api=SimpleNamespace(article_url=lambda x: ""),
+)
+sys.modules.setdefault("wikipediaapi", wiki_mod)
+aiohttp_stub = SimpleNamespace(
+    ClientSession=object,
+    ClientTimeout=lambda *a, **k: None,
+    ClientError=Exception,
+    ClientResponseError=Exception,
+)
+sys.modules.setdefault("aiohttp", aiohttp_stub)
+sys.modules.setdefault(
+    "backoff",
+    SimpleNamespace(
+        on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None
+    ),
+)
+
+
+def test_legacy_forums_plugin(monkeypatch):
+    import requests
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, params=None, timeout=None):
+        if url.startswith("http://yahoo"):
+            return DummyResp({"question": "YQ", "answer": "YA"})
+        if url.startswith("http://delphi"):
+            return DummyResp({"title": "DQ", "reply": "DA"})
+        if url.startswith("http://php"):
+            return DummyResp({"question": "PQ", "answer": "PA"})
+        return DummyResp({})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.reload(importlib.import_module("plugins.legacy_forums"))
+    plugin = mod.Plugin(
+        yahoo_url="http://yahoo", delphi_url="http://delphi", php_url="http://php"
+    )
+
+    items = plugin.fetch_items("pt", "duvida")
+    assert len(items) == 3
+    assert items[0]["source"] == "yahoo"
+    py = plugin.parse_item(items[0])
+    assert py == {
+        "question": "YQ",
+        "answer": "YA",
+        "source": "yahoo",
+        "language": "pt",
+    }
+    pd = plugin.parse_item(items[1])
+    assert pd == {
+        "question": "DQ",
+        "answer": "DA",
+        "source": "delphi",
+        "language": "pt",
+    }
+    pp = plugin.parse_item(items[2])
+    assert pp == {
+        "question": "PQ",
+        "answer": "PA",
+        "source": "php",
+        "language": "pt",
+    }


### PR DESCRIPTION
## Summary
- support scraping of legacy forums (Yahoo Answers, Delphi/PHP) with `plugins.legacy_forums`
- register the plugin name in `plugins/__init__.py`
- add unit tests covering the new plugin

## Testing
- `black plugins/legacy_forums.py tests/test_legacy_forums.py plugins/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685953f5a0bc83209d41f0540ca383c1