### PR TITLE
Add PDF books plugin

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -25,6 +25,7 @@ AVAILABLE_PLUGINS = {
     "competitions": "competitions",
     "codepen_scraper": "codepen_scraper",
     "legacy_forums": "legacy_forums",
+    "pdf_books": "pdf_books",
 }
 
 

--- a/plugins/pdf_books.py
+++ b/plugins/pdf_books.py
@@ -1,0 +1,47 @@
+"""Plugin to extract text from PDF books."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from PyPDF2 import PdfReader
+
+from .base import Plugin
+
+
+class PDFBooksPlugin(Plugin):  # type: ignore[misc]
+    """Parse PDF files in a directory or a single PDF."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return PDF file paths for a directory or single file."""
+        path = Path(category)
+        if path.is_file() and path.suffix.lower() == ".pdf":
+            return [{"path": str(path), "lang": lang, "category": category}]
+        if path.is_dir():
+            pdfs = sorted(p for p in path.glob("*.pdf"))
+            return [{"path": str(p), "lang": lang, "category": category} for p in pdfs]
+        return []
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Extract text from a PDF file."""
+        file_path = item.get("path")
+        if not file_path:
+            return {}
+        try:
+            reader = PdfReader(file_path)
+        except Exception:
+            return {}
+        text_parts: List[str] = []
+        for page in reader.pages:
+            page_text = page.extract_text() or ""
+            text_parts.append(page_text)
+        return {
+            "path": file_path,
+            "language": item.get("lang", "en"),
+            "content": "\n".join(text_parts),
+        }
+
+
+# Registry alias
+Plugin = PDFBooksPlugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ simhash>=2.1.2
 tensorflow>=2.16.0  # optional
 transformers>=4.40.0
 googletrans==4.0.0rc1
+PyPDF2>=3.0.1
+fpdf>=1.7.2

--- a/tests/test_pdf_books.py
+++ b/tests/test_pdf_books.py
@@ -1,0 +1,57 @@
+import importlib
+from pathlib import Path
+import sys
+from types import ModuleType, SimpleNamespace
+
+from fpdf import FPDF
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def create_pdf(path: Path, text: str) -> None:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("helvetica", size=12)
+    pdf.cell(40, 10, text)
+    pdf.output(str(path))
+
+
+def test_pdf_books_single(monkeypatch, tmp_path):
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    pdf_path = tmp_path / "sample.pdf"
+    create_pdf(pdf_path, "Hello World")
+
+    mod = importlib.import_module("plugins.pdf_books")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", str(pdf_path))
+    assert items == [{"path": str(pdf_path), "lang": "en", "category": str(pdf_path)}]
+    parsed = plugin.parse_item(items[0])
+    assert "Hello World" in parsed["content"]
+    assert parsed["language"] == "en"
+
+
+def test_pdf_books_directory(monkeypatch, tmp_path):
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    dir_path = tmp_path / "pdfs"
+    dir_path.mkdir()
+    pdf1 = dir_path / "a.pdf"
+    pdf2 = dir_path / "b.pdf"
+    create_pdf(pdf1, "A")
+    create_pdf(pdf2, "B")
+
+    mod = importlib.import_module("plugins.pdf_books")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", str(dir_path))
+    paths = [str(pdf1), str(pdf2)]
+    assert [it["path"] for it in items] == paths
+    parsed = plugin.parse_item(items[0])
+    assert "A" in parsed["content"]


### PR DESCRIPTION
## Summary
- implement `pdf_books` plugin for extracting text from PDFs
- register plugin in `plugins/__init__.py`
- add `PyPDF2` and `fpdf` to requirements
- provide unit tests for the new plugin

## Testing
- `black plugins/pdf_books.py tests/test_pdf_books.py plugins/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859560f2b8c8320bd354c145b96d264