### PR TITLE
Implement quality classification utilities

### DIFF
--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -58,6 +58,11 @@ import metrics
 import storage_sqlite
 from utils.text import clean_text, extract_entities
 from utils.relation import extract_relations, extract_relations_regex
+from utils.quality import (
+    classify_github_repo,
+    classify_stackoverflow_answer,
+    balance_quality,
+)
 from utils.cleaner import clean_wiki_text, split_sentences
 from utils.code import (
     normalize_indentation,
@@ -408,14 +413,11 @@ def log_failed_url(url: str) -> None:
 
 
 class CacheBackend(Protocol):
-    def get(self, key: str):
-        ...
+    def get(self, key: str): ...
 
-    def set(self, key: str, data, ttl: Optional[int] = None):
-        ...
+    def set(self, key: str, data, ttl: Optional[int] = None): ...
 
-    def stats(self) -> dict:
-        ...
+    def stats(self) -> dict: ...
 
 
 class FileCache(CacheBackend):
@@ -1705,9 +1707,9 @@ class DatasetBuilder:
             images = extract_images(getattr(page, "_html", ""))
             qa_data["images"] = images
             if self.include_revisions:
-                qa_data.setdefault("metadata", {})[
-                    "revisions"
-                ] = wiki.get_revision_history(page_info["title"], self.rev_limit)
+                qa_data.setdefault("metadata", {})["revisions"] = (
+                    wiki.get_revision_history(page_info["title"], self.rev_limit)
+                )
             metrics.scrape_success.inc()
             metrics.pages_scraped_total.inc()
             return qa_data
@@ -1808,6 +1810,8 @@ class DatasetBuilder:
             "quality_score": (
                 extra_metadata.get("quality_score", 0.0) if extra_metadata else 0.0
             ),
+            "quality": None,
+            "reason": "",
             "questions": questions,
             "answers": answers,
             "relations": relations,
@@ -1820,6 +1824,26 @@ class DatasetBuilder:
                 "source_url": f"{get_base_url(lang)}/wiki/{title.replace(' ', '_')}",
             },
         }
+
+        # Determine quality classification when possible
+        if extra_metadata:
+            if any(
+                k in extra_metadata for k in ["stars", "stargazers_count", "repository"]
+            ):
+                q, r = classify_github_repo(extra_metadata)
+                record["quality"], record["reason"] = q, r
+            elif "score" in extra_metadata:
+                q, r = classify_stackoverflow_answer(extra_metadata)
+                record["quality"], record["reason"] = q, r
+        if record["quality"] is None:
+            score = record.get("quality_score", 0.0)
+            if score >= 5:
+                record["quality"] = "high"
+            elif score >= 2:
+                record["quality"] = "medium"
+            else:
+                record["quality"] = "low"
+            record["reason"] = "quality score"
         if code_lang != "unknown":
             record["metadata"]["code_language"] = code_lang
             if complexities:
@@ -2249,6 +2273,12 @@ class DatasetBuilder:
         if not self.dataset:
             logger.warning("Nenhum dado para salvar")
             return
+
+        # Balance records by quality before further processing
+        try:
+            self.dataset = balance_quality(self.dataset)
+        except Exception:
+            pass
 
         for rec in self.dataset:
             if "content" in rec:

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy dependencies before importing utils package
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault(
+    "sentence_transformers",
+    SimpleNamespace(SentenceTransformer=lambda *a, **k: None),
+)
+sys.modules.setdefault("networkx", SimpleNamespace())
+
+quality = importlib.import_module("utils.quality")
+
+
+def test_classify_github_repo_high_with_tests():
+    repo = {"stars": 10, "open_issues": 1, "has_tests": True}
+    q, reason = quality.classify_github_repo(repo)
+    assert q == "high"
+    assert "tests" in reason
+
+
+def test_classify_github_repo_low():
+    repo = {"stars": 1, "open_issues": 10}
+    q, _ = quality.classify_github_repo(repo)
+    assert q == "low"
+
+
+def test_classify_stackoverflow_answer_medium():
+    ans = {"score": 3, "is_accepted": False}
+    q, reason = quality.classify_stackoverflow_answer(ans)
+    assert q == "medium"
+    assert "community" in reason
+
+
+def test_balance_quality_truncates_groups():
+    recs = [
+        {"id": 1, "quality": "high"},
+        {"id": 2, "quality": "high"},
+        {"id": 3, "quality": "medium"},
+        {"id": 4, "quality": "low"},
+    ]
+    balanced = quality.balance_quality(recs)
+    counts = {
+        q: len([r for r in balanced if r["quality"] == q])
+        for q in ["high", "medium", "low"]
+    }
+    assert counts == {"high": 1, "medium": 1, "low": 1}

--- a/utils/quality.py
+++ b/utils/quality.py
@@ -1,0 +1,83 @@
+"""Quality classification utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+
+def classify_github_repo(repo: Dict) -> Tuple[str, str]:
+    """Classify the quality of a GitHub repository.
+
+    Parameters
+    ----------
+    repo: Dict
+        Repository metadata containing at least ``stars`` and ``open_issues``.
+
+    Returns
+    -------
+    Tuple[str, str]
+        Quality level (``high``, ``medium`` or ``low``) and reason.
+    """
+    stars = repo.get("stars") or repo.get("stargazers_count", 0)
+    issues = repo.get("open_issues") or repo.get("open_issues_count", 0)
+    score = repo.get("quality_score")
+    if score is None:
+        score = stars / (issues + 1)
+    has_tests = repo.get("has_tests") or repo.get("tests")
+
+    if score >= 5:
+        quality = "high"
+        reason = "high star to issue ratio"
+    elif score >= 2:
+        quality = "medium"
+        reason = "moderate star to issue ratio"
+    else:
+        quality = "low"
+        reason = "low star to issue ratio"
+
+    if has_tests:
+        reason += " with tests"
+    return quality, reason
+
+
+def classify_stackoverflow_answer(answer: Dict) -> Tuple[str, str]:
+    """Classify the quality of a StackOverflow answer.
+
+    Parameters
+    ----------
+    answer: Dict
+        Data containing ``score`` and optionally ``is_accepted``.
+
+    Returns
+    -------
+    Tuple[str, str]
+        Quality level and reason.
+    """
+    score = answer.get("score", 0)
+    accepted = answer.get("is_accepted") or answer.get("accepted", False)
+
+    if score >= 5 and accepted:
+        return "high", "accepted answer with high score"
+    if score >= 2:
+        return "medium", "community upvoted"
+    return "low", "low score"
+
+
+def balance_quality(records: List[Dict]) -> List[Dict]:
+    """Balance dataset records by quality level.
+
+    The function keeps the same number of records for each quality
+    class by truncating larger groups.
+    """
+    groups: Dict[str, List[Dict]] = {"high": [], "medium": [], "low": []}
+    for rec in records:
+        groups.setdefault(rec.get("quality", "medium"), []).append(rec)
+
+    counts = [len(v) for v in groups.values() if v]
+    if not counts:
+        return records
+    min_count = min(counts)
+    balanced: List[Dict] = []
+    for q in ["high", "medium", "low"]:
+        balanced.extend(groups.get(q, [])[:min_count])
+    return balanced


### PR DESCRIPTION
## Summary
- add `utils/quality.py` with helper functions to classify GitHub and StackOverflow data
- return `quality` and `reason` in `DatasetBuilder.generate_qa_pairs`
- balance dataset quality levels before saving
- test quality utilities

## Testing
- `black utils/quality.py scraper_wiki/__init__.py tests/test_quality.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859597810648320bd83482e79c8cd4c