### PR TITLE
Add extended dataset fields

### DIFF
--- a/plugins/api_docs.py
+++ b/plugins/api_docs.py
@@ -47,11 +47,19 @@ class APIDocsScraper(Plugin):  # type: ignore[misc]
             if pre.previous_sibling and getattr(pre.previous_sibling, "get_text", None):
                 explanation = pre.previous_sibling.get_text(" ", strip=True)
             blocks.append({"code": code, "text": explanation})
-        return {
+        record = {
             "url": item["url"],
             "language": item.get("lang", "en"),
             "blocks": blocks,
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 # Registry alias

--- a/plugins/code_extractor.py
+++ b/plugins/code_extractor.py
@@ -83,7 +83,7 @@ class CodeExtractor:
         stars = repo.get("stargazers_count", 0)
         issues = repo.get("open_issues_count", 0)
         quality_score = stars / (issues + 1)
-        return {
+        record = {
             "repository": full_name,
             "stars": stars,
             "open_issues": issues,
@@ -94,6 +94,13 @@ class CodeExtractor:
             "docstring": "",
             "quality_score": quality_score,
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 class Plugin(CodeExtractor):

--- a/plugins/codepen_scraper.py
+++ b/plugins/codepen_scraper.py
@@ -63,13 +63,21 @@ class CodePenScraper(Plugin):
             if js_match:
                 js = js_match.group(1)
 
-        return {
+        record = {
             "url": item.get("url", ""),
             "language": item.get("lang", "en"),
             "html": html,
             "css": css,
             "js": js,
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 Plugin = CodePenScraper

--- a/plugins/competitions.py
+++ b/plugins/competitions.py
@@ -42,15 +42,31 @@ class CompetitionsPlugin(Plugin):  # type: ignore[misc]
         slug = item.get("slug")
         if source == "leetcode":
             data = self._fetch_leetcode(slug)
-            return {
+            record = {
                 "problem": data.get("content", ""),
                 "solution": data.get("solution", ""),
             }
+            record.setdefault("raw_code", "")
+            record.setdefault("context", "")
+            record.setdefault("problems", [])
+            record.setdefault("fixed_version", "")
+            record.setdefault("lessons", "")
+            record.setdefault("origin_metrics", {})
+            record.setdefault("challenge", "")
+            return record
         if source == "codewars":
             data = self._fetch_codewars(slug)
             solutions = data.get("solutions", [])
             solution = solutions[0] if solutions else ""
-            return {"problem": data.get("description", ""), "solution": solution}
+            record = {"problem": data.get("description", ""), "solution": solution}
+            record.setdefault("raw_code", "")
+            record.setdefault("context", "")
+            record.setdefault("problems", [])
+            record.setdefault("fixed_version", "")
+            record.setdefault("lessons", "")
+            record.setdefault("origin_metrics", {})
+            record.setdefault("challenge", "")
+            return record
         return {}
 
 

--- a/plugins/gist_scraper.py
+++ b/plugins/gist_scraper.py
@@ -37,7 +37,15 @@ class GistScraper:
             resp = requests.get(raw_url, headers=self._headers())
             resp.raise_for_status()
             files[info.get("filename", "file")] = resp.text
-        return {"description": item.get("description", ""), "files": files}
+        record = {"description": item.get("description", ""), "files": files}
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 # Registry alias

--- a/plugins/gitlab_scraper.py
+++ b/plugins/gitlab_scraper.py
@@ -81,7 +81,7 @@ class GitLabScraper:
         stars = repo.get("star_count", 0)
         issues = repo.get("open_issues_count", 0)
         quality_score = stars / (issues + 1)
-        return {
+        record = {
             "repository": repo.get("path_with_namespace"),
             "stars": stars,
             "open_issues": issues,
@@ -92,6 +92,13 @@ class GitLabScraper:
             "docstring": "",
             "quality_score": quality_score,
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 class Plugin(GitLabScraper):

--- a/plugins/gitlab_snippets.py
+++ b/plugins/gitlab_snippets.py
@@ -46,12 +46,20 @@ class GitLabSnippets(Plugin):  # type: ignore[misc]
             headers=self._headers(),
         )
         resp.raise_for_status()
-        return {
+        record = {
             "title": item.get("title", ""),
             "language": item.get("lang", "en"),
             "category": item.get("category", ""),
             "code": resp.text,
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 Plugin = GitLabSnippets

--- a/plugins/infobox_parser.py
+++ b/plugins/infobox_parser.py
@@ -1,4 +1,5 @@
 """Plugin to extract infobox data from Wikipedia pages."""
+
 from typing import List, Dict
 
 from bs4 import BeautifulSoup
@@ -23,8 +24,16 @@ class Plugin(Plugin):  # type: ignore[misc]
         data = extract_infobox(html)
         if not data:
             return {}
-        return {
+        record = {
             "title": item["title"],
             "language": item.get("lang", "en"),
             "infobox": data,
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record

--- a/plugins/legacy_forums.py
+++ b/plugins/legacy_forums.py
@@ -50,12 +50,20 @@ class LegacyForumsPlugin(Plugin):
             return {}
         question = data.get("question") or data.get("title", "")
         answer = data.get("answer") or data.get("reply") or data.get("content", "")
-        return {
+        record = {
             "question": question,
             "answer": answer,
             "source": source,
             "language": item.get("lang", "en"),
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 # Registry alias

--- a/plugins/pdf_books.py
+++ b/plugins/pdf_books.py
@@ -36,11 +36,19 @@ class PDFBooksPlugin(Plugin):  # type: ignore[misc]
         for page in reader.pages:
             page_text = page.extract_text() or ""
             text_parts.append(page_text)
-        return {
+        record = {
             "path": file_path,
             "language": item.get("lang", "en"),
             "content": "\n".join(text_parts),
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 # Registry alias

--- a/plugins/stackexchange.py
+++ b/plugins/stackexchange.py
@@ -65,7 +65,7 @@ class StackExchangePlugin(Plugin):
         clean = advanced_clean_text(text, item.get("lang", "en"))
         tags = item.get("tags", [])
         tag_data = [{"tag": t, "link": item.get("link", "")} for t in tags]
-        return {
+        record = {
             "title": item.get("title", ""),
             "language": item.get("lang", "en"),
             "category": item.get("category", ""),
@@ -78,6 +78,13 @@ class StackExchangePlugin(Plugin):
             "docstring": "",
             "quality_score": item.get("score", 0),
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
 
 
 # Backwards compatible alias

--- a/plugins/table_parser.py
+++ b/plugins/table_parser.py
@@ -1,4 +1,5 @@
 """Plugin to extract table data from Wikipedia pages."""
+
 from typing import List, Dict
 
 from bs4 import BeautifulSoup
@@ -23,8 +24,16 @@ class Plugin(Plugin):  # type: ignore[misc]
         tables = extract_tables(html)
         if not tables:
             return {}
-        return {
+        record = {
             "title": item["title"],
             "language": item.get("lang", "en"),
             "tables": tables,
         }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record

--- a/plugins/wikidata.py
+++ b/plugins/wikidata.py
@@ -51,9 +51,7 @@ class Plugin(Plugin):  # type: ignore[misc]
         if isinstance(claims, dict) and "P18" in claims:
             image_claim = claims.get("P18", [{}])[0]
             image_name = (
-                image_claim.get("mainsnak", {})
-                .get("datavalue", {})
-                .get("value")
+                image_claim.get("mainsnak", {}).get("datavalue", {}).get("value")
             )
         image_url = (
             f"https://commons.wikimedia.org/wiki/Special:FilePath/{image_name}"
@@ -62,12 +60,21 @@ class Plugin(Plugin):  # type: ignore[misc]
         )
 
         lang = item.get("lang", "en")
-        return {
+        record = {
             "title": labels.get(lang, {}).get("value", item.get("label", "")),
             "language": lang,
             "category": item.get("category", ""),
-            "description": descriptions.get(lang, {}).get("value", item.get("description", "")),
+            "description": descriptions.get(lang, {}).get(
+                "value", item.get("description", "")
+            ),
             "wikidata_id": qid,
             "image_url": image_url,
         }
-
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -1735,6 +1735,7 @@ class DatasetBuilder:
         category: str,
         extra_metadata: dict | None = None,
     ) -> dict:
+        raw_code = content
         code_lang = detect_programming_language(content)
         complexities = {}
         docstring = ""
@@ -1803,8 +1804,18 @@ class DatasetBuilder:
             "keywords": keywords,
             "tags": tags,
             "content": content,
+            "raw_code": raw_code if code_lang != "unknown" else "",
             "summary": summary,
             "context": summary,
+            "problems": extra_metadata.get("problems", []) if extra_metadata else [],
+            "fixed_version": (
+                extra_metadata.get("fixed_version", "") if extra_metadata else ""
+            ),
+            "lessons": extra_metadata.get("lessons", "") if extra_metadata else "",
+            "origin_metrics": (
+                extra_metadata.get("origin_metrics", {}) if extra_metadata else {}
+            ),
+            "challenge": extra_metadata.get("challenge", "") if extra_metadata else "",
             "content_embedding": content_embedding.tolist(),
             "summary_embedding": summary_embedding.tolist(),
             "quality_score": (

--- a/tests/test_code_extractors.py
+++ b/tests/test_code_extractors.py
@@ -85,6 +85,15 @@ def test_collect_repository_data(monkeypatch):
     assert len(data["files"]) == 2
     assert data["quality_score"] == 5 / 2
     assert data["context"] == "repo desc"
+    for field in [
+        "raw_code",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in data
 
 
 def test_gitlab_scraper_search(monkeypatch):
@@ -167,3 +176,12 @@ def test_gitlab_collect_repository_data(monkeypatch):
     assert data["has_tests"] is True
     assert data["quality_score"] == 4 / 2
     assert data["context"] == "desc"
+    for field in [
+        "raw_code",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in data

--- a/tests/test_codepen_scraper.py
+++ b/tests/test_codepen_scraper.py
@@ -52,21 +52,37 @@ def test_codepen_scraper(monkeypatch):
     items = scraper.fetch_items("en", "https://codepen.io/u/pen/1")
     assert called[0].endswith("/pen/1")
     record = scraper.parse_item(items[0])
-    assert record == {
-        "url": "https://codepen.io/u/pen/1",
-        "language": "en",
-        "html": "<h1>Hello</h1>",
-        "css": "h1{color:red;}",
-        "js": "console.log(1);",
-    }
+    assert record["url"] == "https://codepen.io/u/pen/1"
+    assert record["language"] == "en"
+    assert record["html"] == "<h1>Hello</h1>"
+    assert record["css"] == "h1{color:red;}"
+    assert record["js"] == "console.log(1);"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record
 
     items2 = scraper.fetch_items("en", "https://jsfiddle.net/test")
     assert called[1].endswith("/test")
     record2 = scraper.parse_item(items2[0])
-    assert record2 == {
-        "url": "https://jsfiddle.net/test",
-        "language": "en",
-        "html": "<h1>Hi</h1>",
-        "css": "body{}",
-        "js": "console.log(2);",
-    }
+    assert record2["url"] == "https://jsfiddle.net/test"
+    assert record2["language"] == "en"
+    assert record2["html"] == "<h1>Hi</h1>"
+    assert record2["css"] == "body{}"
+    assert record2["js"] == "console.log(2);"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record2

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -104,11 +104,20 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
     )
     code = "def foo():\n    pass  # comment"
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
+    assert result["raw_code"] == "def foo():\n    pass  # comment"
     assert result["content"] == "def foo():\n    pass"
     assert result["metadata"].get("code_language") == "python"
     assert result["context"] == "S"
     assert result["tests"] == []
     assert result["quality_score"] == 0.0
+    for field in [
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in result
 
 
 def test_generate_qa_pairs_extracts_docstring_and_signature(monkeypatch):

--- a/tests/test_gist_scraper.py
+++ b/tests/test_gist_scraper.py
@@ -60,4 +60,15 @@ def test_gist_scraper(monkeypatch):
     items = scraper.fetch_items("user")
     assert called[0].endswith("/users/user/gists")
     record = scraper.parse_item(items[0])
-    assert record == {"description": "d", "files": {"f1.txt": "content1"}}
+    assert record["description"] == "d"
+    assert record["files"] == {"f1.txt": "content1"}
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record

--- a/tests/test_gitlab_snippets.py
+++ b/tests/test_gitlab_snippets.py
@@ -47,9 +47,17 @@ def test_gitlab_snippets(monkeypatch):
     items = scraper.fetch_items("en", "example")
     assert called[0].endswith("/snippets")
     record = scraper.parse_item(items[0])
-    assert record == {
-        "title": "t",
-        "language": "en",
-        "category": "example",
-        "code": "code1",
-    }
+    assert record["title"] == "t"
+    assert record["language"] == "en"
+    assert record["category"] == "example"
+    assert record["code"] == "code1"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record

--- a/tests/test_legacy_forums.py
+++ b/tests/test_legacy_forums.py
@@ -110,23 +110,47 @@ def test_legacy_forums_plugin(monkeypatch):
     assert len(items) == 3
     assert items[0]["source"] == "yahoo"
     py = plugin.parse_item(items[0])
-    assert py == {
-        "question": "YQ",
-        "answer": "YA",
-        "source": "yahoo",
-        "language": "pt",
-    }
+    assert py["question"] == "YQ"
+    assert py["answer"] == "YA"
+    assert py["source"] == "yahoo"
+    assert py["language"] == "pt"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in py
     pd = plugin.parse_item(items[1])
-    assert pd == {
-        "question": "DQ",
-        "answer": "DA",
-        "source": "delphi",
-        "language": "pt",
-    }
+    assert pd["question"] == "DQ"
+    assert pd["answer"] == "DA"
+    assert pd["source"] == "delphi"
+    assert pd["language"] == "pt"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in pd
     pp = plugin.parse_item(items[2])
-    assert pp == {
-        "question": "PQ",
-        "answer": "PA",
-        "source": "php",
-        "language": "pt",
-    }
+    assert pp["question"] == "PQ"
+    assert pp["answer"] == "PA"
+    assert pp["source"] == "php"
+    assert pp["language"] == "pt"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in pp

--- a/tests/test_pdf_books.py
+++ b/tests/test_pdf_books.py
@@ -33,6 +33,16 @@ def test_pdf_books_single(monkeypatch, tmp_path):
     parsed = plugin.parse_item(items[0])
     assert "Hello World" in parsed["content"]
     assert parsed["language"] == "en"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed
 
 
 def test_pdf_books_directory(monkeypatch, tmp_path):
@@ -55,3 +65,13 @@ def test_pdf_books_directory(monkeypatch, tmp_path):
     assert [it["path"] for it in items] == paths
     parsed = plugin.parse_item(items[0])
     assert "A" in parsed["content"]
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -99,7 +99,19 @@ def test_infobox_parser(monkeypatch):
     items = plugin.fetch_items("en", "Prog")
     assert items == [{"title": "Page", "lang": "en", "category": "Prog"}]
     parsed = plugin.parse_item(items[0])
-    assert parsed == {"title": "Page", "language": "en", "infobox": {"Name": "Python"}}
+    assert parsed["title"] == "Page"
+    assert parsed["language"] == "en"
+    assert parsed["infobox"] == {"Name": "Python"}
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed
 
 
 def test_table_parser(monkeypatch):
@@ -111,11 +123,19 @@ def test_table_parser(monkeypatch):
     items = plugin.fetch_items("en", "Prog")
     assert items[0]["title"] == "Page"
     parsed = plugin.parse_item(items[0])
-    assert parsed == {
-        "title": "Page",
-        "language": "en",
-        "tables": [[["A", "B"], ["1", "2"]]],
-    }
+    assert parsed["title"] == "Page"
+    assert parsed["language"] == "en"
+    assert parsed["tables"] == [[["A", "B"], ["1", "2"]]]
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed
 
 
 def test_stackexchange_plugin(monkeypatch):
@@ -166,6 +186,16 @@ def test_stackexchange_plugin(monkeypatch):
     assert parsed["score"] == 5
     assert parsed["link"] == "url"
     assert parsed["tags"] == [{"tag": "python", "link": "url"}]
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed
 
 
 def test_wikidata_plugin(monkeypatch):
@@ -203,14 +233,25 @@ def test_wikidata_plugin(monkeypatch):
     items = plugin.fetch_items("en", "python")
     assert items[0]["category"] == "python"
     parsed = plugin.parse_item(items[0])
-    assert parsed == {
-        "title": "Item",
-        "language": "en",
-        "category": "python",
-        "description": "Desc",
-        "wikidata_id": "Q1",
-        "image_url": "https://commons.wikimedia.org/wiki/Special:FilePath/Pic.jpg",
-    }
+    assert parsed["title"] == "Item"
+    assert parsed["language"] == "en"
+    assert parsed["category"] == "python"
+    assert parsed["description"] == "Desc"
+    assert parsed["wikidata_id"] == "Q1"
+    assert (
+        parsed["image_url"]
+        == "https://commons.wikimedia.org/wiki/Special:FilePath/Pic.jpg"
+    )
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed
 
 
 def test_competitions_plugin(monkeypatch):
@@ -237,6 +278,28 @@ def test_competitions_plugin(monkeypatch):
     items = plugin.fetch_items("en", "two-sum")
     assert items[0]["slug"] == "two-sum"
     parsed = plugin.parse_item(items[0])
-    assert parsed == {"problem": "LC problem", "solution": "LC solution"}
+    assert parsed["problem"] == "LC problem"
+    assert parsed["solution"] == "LC solution"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed
     parsed2 = plugin.parse_item(items[1])
-    assert parsed2 == {"problem": "CW problem", "solution": "CW solution"}
+    assert parsed2["problem"] == "CW problem"
+    assert parsed2["solution"] == "CW solution"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in parsed2


### PR DESCRIPTION
## Summary
- support extra fields when generating dataset records
- update all scraping plugins to fill the new fields
- adjust tests for updated schema

## Testing
- `black -q scraper_wiki/__init__.py plugins/*.py tests/test_datasetbuilder_code.py tests/test_plugins.py tests/test_gist_scraper.py tests/test_gitlab_snippets.py tests/test_pdf_books.py tests/test_codepen_scraper.py tests/test_code_extractors.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595bf3b0048320ad76f1fb98281c55