### PR TITLE
Implement code_sniffer integration

### DIFF
--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -72,6 +72,7 @@ from utils.code import (
     parse_function_signature,
 )
 from utils.ast_tools import get_functions_complexity
+from utils.code_sniffer import scan as scan_code
 
 
 # ============================
@@ -1740,6 +1741,8 @@ class DatasetBuilder:
         complexities = {}
         docstring = ""
         signature = ""
+        problems: list[str] = []
+        fixed_version = content
         if code_lang != "unknown":
             signature = parse_function_signature(content)
             try:
@@ -1760,12 +1763,15 @@ class DatasetBuilder:
                 pass
             content = normalize_indentation(remove_comments(content, code_lang))
             complexities = get_functions_complexity(content, code_lang)
+            problems, fixed_version = scan_code(content)
             if self.min_complexity is not None and complexities:
                 if max(complexities.values()) < self.min_complexity:
                     return {}
             if self.max_complexity is not None and complexities:
                 if max(complexities.values()) > self.max_complexity:
                     return {}
+        else:
+            problems, fixed_version = scan_code(content)
 
         # Extrai keywords para gerar perguntas variadas
         keywords = extract_keywords(content, lang)
@@ -1807,10 +1813,8 @@ class DatasetBuilder:
             "raw_code": raw_code if code_lang != "unknown" else "",
             "summary": summary,
             "context": summary,
-            "problems": extra_metadata.get("problems", []) if extra_metadata else [],
-            "fixed_version": (
-                extra_metadata.get("fixed_version", "") if extra_metadata else ""
-            ),
+            "problems": problems,
+            "fixed_version": fixed_version,
             "lessons": extra_metadata.get("lessons", "") if extra_metadata else "",
             "origin_metrics": (
                 extra_metadata.get("origin_metrics", {}) if extra_metadata else {}

--- a/tests/test_code_sniffer.py
+++ b/tests/test_code_sniffer.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from types import SimpleNamespace
+
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault(
+    "googletrans",
+    SimpleNamespace(
+        Translator=lambda: SimpleNamespace(
+            translate=lambda text, dest: SimpleNamespace(text=f"{text}-{dest}")
+        )
+    ),
+)
+
+from utils.code_sniffer import scan
+
+
+def test_scan_detects_and_fixes():
+    code = """\
+def foo(x):
+    if x == True:
+        eval('x')
+        exec('y')
+    return x
+"""
+    problems, fixed = scan(code)
+    assert any("eval" in p for p in problems)
+    assert any("exec" in p for p in problems)
+    assert any("True" in p for p in problems)
+    lines = fixed.splitlines()
+    # line with eval should be commented
+    assert lines[3].lstrip().startswith("#")
+    assert "is True" in fixed
+
+
+def test_scan_returns_original_on_invalid():
+    code = "foo ="
+    problems, fixed = scan(code)
+    assert problems == []
+    assert fixed == code

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -15,6 +15,7 @@ from .code import (
     parse_function_signature,
 )
 from .ast_tools import parse_code, get_functions_complexity
+from .code_sniffer import scan
 
 __all__ = [
     "clean_text",
@@ -32,4 +33,5 @@ __all__ = [
     "parse_function_signature",
     "parse_code",
     "get_functions_complexity",
+    "scan",
 ]

--- a/utils/code_sniffer.py
+++ b/utils/code_sniffer.py
@@ -1,0 +1,48 @@
+import ast
+from typing import List, Tuple
+
+
+def scan(code: str) -> Tuple[List[str], str]:
+    """Analyze ``code`` and return detected problems and a fixed version."""
+    problems: List[str] = []
+    lines = code.splitlines()
+    try:
+        tree = ast.parse(code)
+    except Exception:
+        return problems, code
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = ""
+            if isinstance(node.func, ast.Name):
+                name = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                name = node.func.attr
+            if name in {"eval", "exec"}:
+                problems.append(f"Use of {name} on line {node.lineno}")
+                idx = node.lineno - 1
+                if 0 <= idx < len(lines):
+                    if not lines[idx].lstrip().startswith("#"):
+                        lines[idx] = "# " + lines[idx]
+        if isinstance(node, ast.Compare):
+            if len(node.ops) == 1 and isinstance(node.ops[0], ast.Eq):
+                left = node.left
+                right = node.comparators[0]
+                bool_val = None
+                if isinstance(right, ast.Constant) and isinstance(right.value, bool):
+                    bool_val = right.value
+                elif isinstance(left, ast.Constant) and isinstance(left.value, bool):
+                    bool_val = left.value
+                if bool_val is not None:
+                    problems.append(f"Comparison to {bool_val} on line {node.lineno}")
+                    idx = node.lineno - 1
+                    if 0 <= idx < len(lines):
+                        target = "== True" if bool_val else "== False"
+                        replacement = "is True" if bool_val else "is False"
+                        lines[idx] = lines[idx].replace(target, replacement)
+
+    fixed_version = "\n".join(lines)
+    return problems, fixed_version
+
+
+__all__ = ["scan"]


### PR DESCRIPTION
## Summary
- add a simple AST based code_sniffer
- integrate code_sniffer into DatasetBuilder.generate_qa_pairs
- expose scan() in utils package
- test the sniffer

## Testing
- `black utils/code_sniffer.py utils/__init__.py scraper_wiki/__init__.py tests/test_code_sniffer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596795034c8320a7f8b6a8ee99fbe0