### PR TITLE
Add bug history scraper plugin

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -26,6 +26,7 @@ AVAILABLE_PLUGINS = {
     "codepen_scraper": "codepen_scraper",
     "legacy_forums": "legacy_forums",
     "pdf_books": "pdf_books",
+    "bug_history_scraper": "bug_history_scraper",
 }
 
 

--- a/plugins/bug_history_scraper.py
+++ b/plugins/bug_history_scraper.py
@@ -1,0 +1,65 @@
+"""Fetch commit histories from notable security bug repositories."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import requests
+
+from .base import Plugin
+
+
+class BugHistoryScraper(Plugin):  # type: ignore[misc]
+    """Retrieve commits from public Git repositories."""
+
+    def __init__(self, token: str | None = None, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://api.github.com"
+        self.token = token
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        return headers
+
+    def _parse_repo(self, repo_url: str) -> Tuple[str, str]:
+        parts = repo_url.rstrip("/").split("/")[-2:]
+        if len(parts) != 2:
+            raise ValueError("Invalid GitHub repository URL")
+        return parts[0], parts[1]
+
+    def fetch_items(
+        self, lang: str, category: str, since: str | None = None
+    ) -> List[Dict]:
+        """Return commit metadata for the repository URL provided in ``category``."""
+        owner, repo = self._parse_repo(category)
+        url = f"{self.api_url}/repos/{owner}/{repo}/commits"
+        params = {"since": since} if since else None
+        resp = requests.get(url, headers=self._headers(), params=params)
+        resp.raise_for_status()
+        commits = resp.json()
+        for c in commits:
+            c["lang"] = lang
+            c["category"] = category
+        return commits
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return key commit details."""
+        record = {
+            "commit": item.get("sha", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "message": item.get("commit", {}).get("message", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+# Registry alias
+Plugin = BugHistoryScraper

--- a/tests/test_bug_history_scraper.py
+++ b/tests/test_bug_history_scraper.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_bug_history_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    class DummyResp:
+        def __init__(self, data=None):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_get(url, headers=None, params=None):
+        if url.endswith("/commits"):
+            return DummyResp(data=[{"sha": "abc", "commit": {"message": "Fix"}}])
+        return DummyResp(data={})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    mod = importlib.import_module("plugins.bug_history_scraper")
+    scraper = mod.BugHistoryScraper()
+
+    items = scraper.fetch_items("en", "https://github.com/user/repo")
+    assert items[0]["sha"] == "abc"
+    record = scraper.parse_item(items[0])
+    assert record["commit"] == "abc"
+    assert record["message"] == "Fix"
+    assert record["language"] == "en"
+    assert record["category"] == "https://github.com/user/repo"
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record


### PR DESCRIPTION
## Summary
- implement `BugHistoryScraper` plugin to fetch commit histories from GitHub
- register plugin in `plugins/__init__.py`
- add tests covering the new plugin

## Testing
- `black plugins/bug_history_scraper.py plugins/__init__.py tests/test_bug_history_scraper.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859699b01b88320b53e99d441329b7f