### PR TITLE
Implement challenge prompt generation

### DIFF
--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -62,6 +62,7 @@ from utils.quality import (
     classify_github_repo,
     classify_stackoverflow_answer,
     balance_quality,
+    generate_challenge_prompt,
 )
 from utils.cleaner import clean_wiki_text, split_sentences
 from utils.code import (
@@ -1819,7 +1820,8 @@ class DatasetBuilder:
             "origin_metrics": (
                 extra_metadata.get("origin_metrics", {}) if extra_metadata else {}
             ),
-            "challenge": extra_metadata.get("challenge", "") if extra_metadata else "",
+            "challenge": (extra_metadata.get("challenge") if extra_metadata else None)
+            or generate_challenge_prompt(problems),
             "content_embedding": content_embedding.tolist(),
             "summary_embedding": summary_embedding.tolist(),
             "quality_score": (

--- a/tests/test_challenge_prompt.py
+++ b/tests/test_challenge_prompt.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy dependencies before importing utils package
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(SentenceTransformer=lambda *a, **k: None)
+)
+
+quality = importlib.import_module("utils.quality")
+
+
+def test_generate_challenge_prompt_single():
+    msg = quality.generate_challenge_prompt(["Uso de eval"])
+    assert msg.startswith("Este código")
+    assert "eval" in msg

--- a/utils/quality.py
+++ b/utils/quality.py
@@ -81,3 +81,27 @@ def balance_quality(records: List[Dict]) -> List[Dict]:
     for q in ["high", "medium", "low"]:
         balanced.extend(groups.get(q, [])[:min_count])
     return balanced
+
+
+def generate_challenge_prompt(problems: List[str]) -> str:
+    """Generate a Portuguese prompt challenging the user to fix the code.
+
+    Parameters
+    ----------
+    problems: List[str]
+        List of problems detected in the code.
+
+    Returns
+    -------
+    str
+        A short text in Portuguese describing the issues.
+    """
+
+    if not problems:
+        return ""
+
+    if len(problems) == 1:
+        return f"Este código tem um bug: {problems[0]}. Corrija-o."
+
+    joined = "; ".join(problems)
+    return f"Este código tem alguns bugs: {joined}. Corrija-os."


### PR DESCRIPTION
## Summary
- add `generate_challenge_prompt` helper
- use the new helper in `DatasetBuilder.generate_qa_pairs`
- test new functionality

## Testing
- `black utils/quality.py scraper_wiki/__init__.py tests/test_challenge_prompt.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596b5bba348320a826b2c572f66b42