### PR TITLE
Add diverse scraping plugins

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -27,6 +27,15 @@ AVAILABLE_PLUGINS = {
     "legacy_forums": "legacy_forums",
     "pdf_books": "pdf_books",
     "bug_history_scraper": "bug_history_scraper",
+    "mdn_docs": "mdn_docs",
+    "devdocs": "devdocs",
+    "university_courses": "university_courses",
+    "rfc_scraper": "rfc_scraper",
+    "npm_packages": "npm_packages",
+    "pip_packages": "pip_packages",
+    "cran_packages": "cran_packages",
+    "jira_scraper": "jira_scraper",
+    "bugzilla_scraper": "bugzilla_scraper",
 }
 
 

--- a/plugins/bugzilla_scraper.py
+++ b/plugins/bugzilla_scraper.py
@@ -1,0 +1,50 @@
+"""Plugin for scraping Bugzilla bug data."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class BugzillaScraper(Plugin):
+    """Retrieve bug information from Bugzilla."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or "https://bugzilla.mozilla.org/rest/bug"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a bug."""
+        url = f"{self.base_url}/{category}"
+        return [{"bug": category, "url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse bug metadata."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        bug = (data.get("bugs") or data.get("bug") or [{}])[0]
+        record = {
+            "bug": item.get("bug", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "title": bug.get("summary", ""),
+            "description": bug.get("description", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = BugzillaScraper

--- a/plugins/cran_packages.py
+++ b/plugins/cran_packages.py
@@ -1,0 +1,49 @@
+"""Plugin for fetching package info from CRAN."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class CRANPackagesPlugin(Plugin):
+    """Retrieve package metadata from CRAN."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or "https://crandb.r-pkg.org"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a package."""
+        url = f"{self.base_url}/{category}"
+        return [{"name": category, "url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse CRAN metadata."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        record = {
+            "name": item.get("name", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "title": data.get("Title", ""),
+            "description": data.get("Description", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = CRANPackagesPlugin

--- a/plugins/devdocs.py
+++ b/plugins/devdocs.py
@@ -1,0 +1,50 @@
+"""Plugin for scraping DevDocs documentation."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import html2text
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class DevDocsPlugin(Plugin):
+    """Fetch pages from DevDocs."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or "https://devdocs.io"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return a descriptor for a DevDocs page."""
+        url = f"{self.base_url}/{category}"
+        return [{"url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse a DevDocs page."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        html = resp.text
+        text = html2text.html2text(html) if hasattr(html2text, "html2text") else html
+        record = {
+            "url": url,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": text,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = DevDocsPlugin

--- a/plugins/jira_scraper.py
+++ b/plugins/jira_scraper.py
@@ -1,0 +1,50 @@
+"""Plugin for scraping JIRA issue data."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class JiraScraper(Plugin):
+    """Retrieve issue information from a JIRA instance."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or "https://jira.example.com/rest/api/2/issue"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for an issue."""
+        url = f"{self.base_url}/{category}"
+        return [{"issue": category, "url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse issue metadata."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        fields = data.get("fields", {})
+        record = {
+            "issue": item.get("issue", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "title": fields.get("summary", ""),
+            "description": fields.get("description", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = JiraScraper

--- a/plugins/mdn_docs.py
+++ b/plugins/mdn_docs.py
@@ -1,0 +1,47 @@
+"""Plugin for scraping MDN documentation."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import html2text
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class MDNDocsPlugin(Plugin):
+    """Fetch pages from MDN documentation."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return basic descriptors for an MDN page."""
+        url = f"https://developer.mozilla.org/{lang}/docs/{category}"
+        return [{"url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse an MDN page."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        html = resp.text
+        text = html2text.html2text(html) if hasattr(html2text, "html2text") else html
+        record = {
+            "url": url,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": text,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = MDNDocsPlugin

--- a/plugins/npm_packages.py
+++ b/plugins/npm_packages.py
@@ -1,0 +1,49 @@
+"""Plugin for fetching information from the npm registry."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class NPMPackagesPlugin(Plugin):
+    """Retrieve package metadata from npm."""
+
+    def __init__(self, registry_url: str | None = None) -> None:
+        self.registry_url = registry_url or "https://registry.npmjs.org"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a package."""
+        url = f"{self.registry_url}/{category}"
+        return [{"name": category, "url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse npm package metadata."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        record = {
+            "name": item.get("name", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "description": data.get("description", ""),
+            "readme": data.get("readme", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = NPMPackagesPlugin

--- a/plugins/pip_packages.py
+++ b/plugins/pip_packages.py
@@ -1,0 +1,50 @@
+"""Plugin for fetching metadata from the Python Package Index."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class PipPackagesPlugin(Plugin):
+    """Retrieve package info from PyPI."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or "https://pypi.org/pypi"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a package."""
+        url = f"{self.base_url}/{category}/json"
+        return [{"name": category, "url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse PyPI metadata."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        info = data.get("info", {})
+        record = {
+            "name": item.get("name", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "description": info.get("summary", ""),
+            "home_page": info.get("home_page", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = PipPackagesPlugin

--- a/plugins/rfc_scraper.py
+++ b/plugins/rfc_scraper.py
@@ -1,0 +1,52 @@
+"""Plugin for fetching RFC documents."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class RFCScraper(Plugin):
+    """Retrieve RFC text documents."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or "https://www.rfc-editor.org/rfc"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return a descriptor for an RFC file."""
+        if category.startswith("http"):
+            url = category
+        else:
+            num = category.lstrip("rfc").strip()
+            url = f"{self.base_url}/rfc{num}.txt"
+        return [{"url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download the RFC file."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        text = resp.text
+        record = {
+            "url": url,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": text,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = RFCScraper

--- a/plugins/university_courses.py
+++ b/plugins/university_courses.py
@@ -1,0 +1,46 @@
+"""Plugin for scraping university course materials."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import html2text
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class UniversityCoursesPlugin(Plugin):
+    """Download course pages from universities."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return a descriptor for the provided course URL."""
+        return [{"url": category, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Fetch and parse a course page."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        html = resp.text
+        text = html2text.html2text(html) if hasattr(html2text, "html2text") else html
+        record = {
+            "url": url,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": text,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = UniversityCoursesPlugin

--- a/tests/test_extra_plugins.py
+++ b/tests/test_extra_plugins.py
@@ -1,0 +1,233 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Minimal stub for html2text
+sys.modules.setdefault("html2text", SimpleNamespace(html2text=lambda x: x))
+scraper_stub = ModuleType("scraper_wiki")
+scraper_stub.Config = SimpleNamespace(TIMEOUT=5)
+sys.modules.setdefault("scraper_wiki", scraper_stub)
+
+
+def _check_defaults(record):
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record
+
+
+class DummyResp:
+    def __init__(self, data=None, text=""):
+        self._data = data
+        self._text = text
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+    @property
+    def text(self):
+        return self._text
+
+
+def test_mdn_docs(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(text="<h1>MDN</h1><p>Doc</p>")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.mdn_docs")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "Web/API")
+    assert items[0]["url"].endswith("/en/docs/Web/API")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["language"] == "en"
+    assert "Doc" in parsed["content"]
+    _check_defaults(parsed)
+
+
+def test_devdocs(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(text="<h1>DevDocs</h1>")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.devdocs")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "python")
+    assert "devdocs.io" in items[0]["url"]
+    parsed = plugin.parse_item(items[0])
+    assert "DevDocs" in parsed["content"]
+    _check_defaults(parsed)
+
+
+def test_university_courses(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(text="<h1>Course</h1>")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.university_courses")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "http://example.com/course")
+    assert items[0]["url"] == "http://example.com/course"
+    parsed = plugin.parse_item(items[0])
+    assert "Course" in parsed["content"]
+    _check_defaults(parsed)
+
+
+def test_rfc_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(text="RFC text")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.rfc_scraper")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "1234")
+    assert items[0]["url"].endswith("rfc1234.txt")
+    parsed = plugin.parse_item(items[0])
+    assert "RFC" in parsed["content"]
+    _check_defaults(parsed)
+
+
+def test_npm_packages(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(data={"description": "desc", "readme": "readme"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.npm_packages")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "pkg")
+    assert items[0]["name"] == "pkg"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["description"] == "desc"
+    assert parsed["readme"] == "readme"
+    _check_defaults(parsed)
+
+
+def test_pip_packages(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(data={"info": {"summary": "desc", "home_page": "home"}})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.pip_packages")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "pkg")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["description"] == "desc"
+    assert parsed["home_page"] == "home"
+    _check_defaults(parsed)
+
+
+def test_cran_packages(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(data={"Title": "T", "Description": "D"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.cran_packages")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "pkg")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["title"] == "T"
+    assert parsed["description"] == "D"
+    _check_defaults(parsed)
+
+
+def test_jira_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(data={"fields": {"summary": "Bug", "description": "Fix"}})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.jira_scraper")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "ABC-1")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["title"] == "Bug"
+    assert parsed["description"] == "Fix"
+    _check_defaults(parsed)
+
+
+def test_bugzilla_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(data={"bugs": [{"summary": "Bug", "description": "Desc"}]})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.bugzilla_scraper")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "123")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["title"] == "Bug"
+    assert parsed["description"] == "Desc"
+    _check_defaults(parsed)


### PR DESCRIPTION
## Summary
- add several new scraping plugins (MDN, DevDocs, university courses, RFCs, package registries, issue trackers)
- register the plugins
- provide unit tests covering new plugins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859853228808320b6225dd2f9713cc9