### PR TITLE
Add contextual discussion links

### DIFF
--- a/plugins/github_scraper.py
+++ b/plugins/github_scraper.py
@@ -79,7 +79,13 @@ class GitHubScraper:
         for issue, commit in self.get_issue_commit_pairs(repo_url, since=since):
             problem = f"{issue.get('title', '')}\n\n{issue.get('body', '')}"
             solution = commit.get("commit", {}).get("message", "")
-            records.append({"problem": problem, "solution": solution})
+            link = issue.get("html_url") or issue.get("url")
+            rec = {
+                "problem": problem,
+                "solution": solution,
+            }
+            rec["discussion_links"] = [link] if link else []
+            records.append(rec)
         return records
 
 

--- a/plugins/stackexchange.py
+++ b/plugins/stackexchange.py
@@ -84,6 +84,7 @@ class StackExchangePlugin(Plugin):
         record.setdefault("lessons", "")
         record.setdefault("origin_metrics", {})
         record.setdefault("challenge", "")
+        record.setdefault("discussion_links", [item.get("link", "")])
         return record
 
 

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -76,6 +76,7 @@ from utils.code import (
 )
 from utils.ast_tools import get_functions_complexity
 from utils.code_sniffer import scan as scan_code
+from utils.contextualizer import search_discussions
 
 
 # ============================
@@ -1882,6 +1883,15 @@ class DatasetBuilder:
                 record["wikidata_id"] = extra_metadata["wikidata_id"]
             if "image_url" in extra_metadata:
                 record["image_url"] = extra_metadata["image_url"]
+            if "discussion_links" in extra_metadata:
+                record["discussion_links"] = extra_metadata["discussion_links"]
+
+        if "discussion_links" not in record:
+            try:
+                links = search_discussions(record["id"])
+            except Exception:
+                links = []
+            record["discussion_links"] = links
         try:
             storage_sqlite.save_to_db(
                 {"id": record["id"], "metadata": record.get("metadata", {})}

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -97,6 +97,7 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
     monkeypatch.setattr(builder, "_generate_questions", lambda *a, **k: [])
     monkeypatch.setattr(builder, "_generate_answers", lambda *a, **k: [])
     monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "search_discussions", lambda _id: ["d1"])
     import numpy as np
 
     monkeypatch.setattr(
@@ -116,8 +117,10 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
         "lessons",
         "origin_metrics",
         "challenge",
+        "discussion_links",
     ]:
         assert field in result
+    assert result["discussion_links"] == ["d1"]
 
 
 def test_generate_qa_pairs_extracts_docstring_and_signature(monkeypatch):
@@ -125,6 +128,7 @@ def test_generate_qa_pairs_extracts_docstring_and_signature(monkeypatch):
     monkeypatch.setattr(builder, "_generate_questions", lambda *a, **k: [])
     monkeypatch.setattr(builder, "_generate_answers", lambda *a, **k: [])
     monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "search_discussions", lambda _id: [])
     import numpy as np
 
     monkeypatch.setattr(

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -77,8 +77,18 @@ def test_issue_commit_pairs(monkeypatch):
         if url.endswith("/issues"):
             return DummyResp(
                 data=[
-                    {"number": 1, "title": "Bug", "body": "Fix bug"},
-                    {"number": 2, "title": "Feature", "body": "Add feature"},
+                    {
+                        "number": 1,
+                        "title": "Bug",
+                        "body": "Fix bug",
+                        "html_url": "https://gh/1",
+                    },
+                    {
+                        "number": 2,
+                        "title": "Feature",
+                        "body": "Add feature",
+                        "html_url": "https://gh/2",
+                    },
                 ]
             )
         if url.endswith("/commits"):
@@ -97,6 +107,14 @@ def test_issue_commit_pairs(monkeypatch):
     assert len(pairs) == 2
     records = scraper.build_problem_solution_records("https://github.com/user/repo")
     assert records == [
-        {"problem": "Bug\n\nFix bug", "solution": "Fix bug\n\nCloses #1"},
-        {"problem": "Feature\n\nAdd feature", "solution": "Add feature #2"},
+        {
+            "problem": "Bug\n\nFix bug",
+            "solution": "Fix bug\n\nCloses #1",
+            "discussion_links": ["https://gh/1"],
+        },
+        {
+            "problem": "Feature\n\nAdd feature",
+            "solution": "Add feature #2",
+            "discussion_links": ["https://gh/2"],
+        },
     ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -16,6 +16,7 @@ from .code import (
 )
 from .ast_tools import parse_code, get_functions_complexity
 from .code_sniffer import scan
+from .contextualizer import search_discussions
 
 __all__ = [
     "clean_text",
@@ -34,4 +35,5 @@ __all__ = [
     "parse_code",
     "get_functions_complexity",
     "scan",
+    "search_discussions",
 ]

--- a/utils/contextualizer.py
+++ b/utils/contextualizer.py
@@ -1,0 +1,51 @@
+"""Search external discussions for a code snippet."""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+import requests
+
+
+def search_discussions(snippet_id: str) -> List[str]:
+    """Return URLs of StackOverflow or GitHub threads mentioning ``snippet_id``."""
+    from scraper_wiki import Config
+
+    links: List[str] = []
+    try:
+        params = {
+            "site": Config.STACKEXCHANGE_SITE,
+            "order": "desc",
+            "sort": "relevance",
+            "q": snippet_id,
+        }
+        if Config.STACKEXCHANGE_API_KEY:
+            params["key"] = Config.STACKEXCHANGE_API_KEY
+        resp = requests.get(
+            f"{Config.STACKEXCHANGE_API_ENDPOINT}/search/advanced",
+            params=params,
+            timeout=Config.TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        links.extend(it.get("link", "") for it in data.get("items", []))
+    except Exception:
+        pass
+    try:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        token = os.environ.get("GITHUB_TOKEN")
+        if token:
+            headers["Authorization"] = f"token {token}"
+        resp = requests.get(
+            "https://api.github.com/search/issues",
+            headers=headers,
+            params={"q": snippet_id},
+            timeout=Config.TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        links.extend(it.get("html_url", "") for it in data.get("items", []))
+    except Exception:
+        pass
+    return [l for l in links if l]


### PR DESCRIPTION
## Summary
- implement `utils.contextualizer.search_discussions`
- call contextualizer when generating QA pairs
- include discussion links in StackExchange and GitHub scraper plugins
- export helper through utils package
- test capturing of discussion links in dataset builder and plugins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685989a0149c8320b797517ced31c9f6