### PR TITLE
Implement processing pipeline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -240,6 +240,22 @@ def clear_cache_cmd():
     typer.echo("Cache limpo")
 
 
+@app.command("process")
+def process_pipeline(
+    dataset: str = typer.Argument(..., help="Caminho do dataset"),
+    pipeline: str = typer.Option("default", "--pipeline", help="Nome do pipeline"),
+):
+    """Run processing pipeline on an existing dataset."""
+    from processing.pipeline import get_pipeline
+
+    data_path = Path(dataset)
+    records = json.loads(data_path.read_text(encoding="utf-8"))
+    pipe = get_pipeline(pipeline)
+    result = pipe(records)
+    data_path.write_text(json.dumps(result, ensure_ascii=False, indent=2))
+    typer.echo(f"Processados {len(result)} registros")
+
+
 @app.command("start-crawler")
 def start_crawler_cmd(
     config: str = typer.Option(None, "--config", help="Path to cluster config")

--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -1,0 +1,101 @@
+"""Data processing pipeline stages."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import re
+from typing import Callable, Dict, List
+
+import dq
+from training.postprocessing import analyze_code_ast
+
+
+def normalize_encoding(text: str) -> str:
+    """Return ``text`` re-encoded as UTF-8, dropping invalid sequences."""
+    if isinstance(text, bytes):
+        return text.decode("utf-8", "ignore")
+    return text.encode("utf-8", "ignore").decode("utf-8", "ignore")
+
+
+def tokenize(text: str) -> List[str]:
+    """Tokenize ``text`` preserving punctuation."""
+    return re.findall(r"\w+|\S", text)
+
+
+def lint_code(code: str) -> List[str]:
+    """Run flake8 on ``code`` returning warnings."""
+    try:
+        res = subprocess.run(
+            ["flake8", "-"],
+            input=code,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+    out = (res.stdout + res.stderr).strip()
+    return [l for l in out.splitlines() if l]
+
+
+def scan_vulnerabilities(code: str) -> List[str]:
+    """Scan ``code`` using semgrep if available."""
+    try:
+        result = subprocess.run(
+            ["semgrep", "--quiet", "--config=p/ci", "-"],
+            input=code,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+    output = result.stdout.strip()
+    return [l for l in output.splitlines() if l]
+
+
+def analyze_complexity(code: str, language: str | None = None) -> Dict[str, int]:
+    """Return complexity metrics for ``code`` without altering it."""
+    analysis = analyze_code_ast(code, language)
+    return analysis.get("complexities", {})
+
+
+def process_record(record: Dict) -> Dict:
+    """Process a single dataset record through all stages."""
+    content = record.get("content", "")
+    content = normalize_encoding(content)
+    record["content"] = content
+    record["tokens"] = tokenize(content)
+    record["lint"] = lint_code(content)
+    record["vulnerabilities"] = scan_vulnerabilities(content)
+    comp = analyze_complexity(content, record.get("metadata", {}).get("code_language"))
+    if comp:
+        record.setdefault("metadata", {})["complexities"] = comp
+    return record
+
+
+def run_pipeline(records: List[Dict]) -> List[Dict]:
+    """Run the full processing pipeline on ``records``."""
+    processed = [process_record(rec) for rec in records]
+    processed, _ = dq.deduplicate_by_embedding(processed)
+    return processed
+
+
+def get_pipeline(name: str = "default") -> Callable[[List[Dict]], List[Dict]]:
+    """Return pipeline callable by ``name``."""
+    if name == "default":
+        return run_pipeline
+    raise ValueError(f"Unknown pipeline: {name}")
+
+
+__all__ = [
+    "normalize_encoding",
+    "tokenize",
+    "lint_code",
+    "scan_vulnerabilities",
+    "analyze_complexity",
+    "process_record",
+    "run_pipeline",
+    "get_pipeline",
+]

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -22,6 +22,7 @@ import csv
 import random
 import logging
 import asyncio
+import inspect
 from tqdm import tqdm
 from unidecode import unidecode
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
@@ -77,6 +78,7 @@ from utils.code import (
 from utils.ast_tools import get_functions_complexity
 from utils.code_sniffer import scan as scan_code
 from utils.contextualizer import search_discussions
+from processing.pipeline import get_pipeline
 
 
 # ============================
@@ -2146,6 +2148,7 @@ class DatasetBuilder:
         progress_desc: str = "Processando páginas",
         use_queue: bool = False,
         client=None,
+        pipeline_name: str | None = None,
     ) -> List[dict]:
         """Process pages locally or enfileira tarefas para processamento."""
         if self.pending_pages:
@@ -2168,6 +2171,9 @@ class DatasetBuilder:
                 if result:
                     self.dataset.append(result)
                 self._update_progress()
+            if pipeline_name:
+                pipe = get_pipeline(pipeline_name)
+                self.dataset = pipe(self.dataset)
             return self.dataset
 
         if not use_queue:
@@ -2213,6 +2219,9 @@ class DatasetBuilder:
                         self.dataset.append(result)
                     self._update_progress()
 
+            if pipeline_name:
+                pipe = get_pipeline(pipeline_name)
+                self.dataset = pipe(self.dataset)
             return self.dataset
 
         # Queue based processing
@@ -2240,10 +2249,16 @@ class DatasetBuilder:
             if processed == total:
                 break
 
+        if pipeline_name:
+            pipe = get_pipeline(pipeline_name)
+            self.dataset = pipe(self.dataset)
         return self.dataset
 
     async def build_from_pages_async(
-        self, pages: List[dict], progress_desc: str = "Processando páginas"
+        self,
+        pages: List[dict],
+        progress_desc: str = "Processando páginas",
+        pipeline_name: str | None = None,
     ) -> List[dict]:
         """Asynchronous version of :meth:`build_from_pages`."""
         if self.pending_pages:
@@ -2283,6 +2298,9 @@ class DatasetBuilder:
                     self.dataset.append(result)
                 self._update_progress()
 
+        if pipeline_name:
+            pipe = get_pipeline(pipeline_name)
+            self.dataset = pipe(self.dataset)
         return self.dataset
 
     def enhance_with_clustering(self):
@@ -2503,7 +2521,16 @@ def main(
 
     logger.info(f"📚 Total de páginas coletadas: {len(all_pages)}")
 
-    builder.build_from_pages(all_pages, "Construindo dataset", client=client)
+    sig = inspect.signature(builder.build_from_pages)
+    if "pipeline_name" in sig.parameters:
+        builder.build_from_pages(
+            all_pages,
+            "Construindo dataset",
+            client=client,
+            pipeline_name="default",
+        )
+    else:
+        builder.build_from_pages(all_pages, "Construindo dataset", client=client)
 
     logger.info("🧠 Aplicando técnicas avançadas de NLP...")
     builder.enhance_with_clustering()
@@ -2617,7 +2644,13 @@ async def main_async(
 
     logger.info(f"📚 Total de páginas coletadas: {len(all_pages)}")
 
-    await builder.build_from_pages_async(all_pages, "Construindo dataset")
+    sig = inspect.signature(builder.build_from_pages_async)
+    if "pipeline_name" in sig.parameters:
+        await builder.build_from_pages_async(
+            all_pages, "Construindo dataset", pipeline_name="default"
+        )
+    else:
+        await builder.build_from_pages_async(all_pages, "Construindo dataset")
 
     logger.info("🧠 Aplicando técnicas avançadas de NLP...")
     builder.enhance_with_clustering()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,3 +397,20 @@ def test_stop_crawler_cli(monkeypatch):
     result = runner.invoke(cli.app, ["stop-crawler"])
     assert result.exit_code == 0
     assert called.get("ok")
+
+
+def test_process_pipeline_command(tmp_path, monkeypatch):
+    data_file = tmp_path / "data.json"
+    data_file.write_text("[]")
+
+    pp_mod = ModuleType("processing.pipeline")
+    pp_mod.get_pipeline = lambda name="default": (lambda data: [{"done": True}])
+    sys.modules["processing.pipeline"] = pp_mod
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app, ["process", str(data_file), "--pipeline", "default"]
+    )
+    assert result.exit_code == 0
+    output = json.loads(data_file.read_text(encoding="utf-8"))
+    assert output == [{"done": True}]

--- a/tests/test_processing_pipeline.py
+++ b/tests/test_processing_pipeline.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+pipeline = importlib.import_module("processing.pipeline")
+
+
+def test_pipeline_processes_records(monkeypatch):
+    data = [
+        {"content": "def foo(x):\n    # comment\n    if x:\n        eval('x')"},
+        {"content": "def foo(x):\n    # comment\n    if x:\n        eval('x')"},
+    ]
+    for rec in data:
+        rec["content_embedding"] = [0.1, 0.2]
+
+    monkeypatch.setattr(pipeline, "lint_code", lambda code: ["LINT"])
+    monkeypatch.setattr(pipeline, "scan_vulnerabilities", lambda code: ["VULN"])
+
+    processed = pipeline.get_pipeline()(data)
+    assert len(processed) == 1
+    rec = processed[0]
+    assert rec["lint"] == ["LINT"]
+    assert rec["vulnerabilities"] == ["VULN"]
+    assert "tokens" in rec
+    assert "complexities" in rec.get("metadata", {})


### PR DESCRIPTION
## Summary
- add processing pipeline with encoding normalization, deduplication, tokenization, linting, vulnerability scan and complexity metrics
- integrate pipeline into DatasetBuilder and CLI
- expose `process` command for running the pipeline
- test the new pipeline and CLI option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598dbc15ac8320891816162f898e10