### PR TITLE
Enhance quality assessment tools

### DIFF
--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -1840,6 +1840,8 @@ class DatasetBuilder:
             ),
             "quality": None,
             "reason": "",
+            "quality_level": None,
+            "quality_reason": "",
             "questions": questions,
             "answers": answers,
             "relations": relations,
@@ -1860,18 +1862,23 @@ class DatasetBuilder:
             ):
                 q, r = classify_github_repo(extra_metadata)
                 record["quality"], record["reason"] = q, r
+                record["quality_level"], record["quality_reason"] = q, r
             elif "score" in extra_metadata:
                 q, r = classify_stackoverflow_answer(extra_metadata)
                 record["quality"], record["reason"] = q, r
+                record["quality_level"], record["quality_reason"] = q, r
         if record["quality"] is None:
             score = record.get("quality_score", 0.0)
             if score >= 5:
-                record["quality"] = "high"
+                q = "high"
             elif score >= 2:
-                record["quality"] = "medium"
+                q = "medium"
             else:
-                record["quality"] = "low"
+                q = "low"
+            record["quality"] = q
+            record["quality_level"] = q
             record["reason"] = "quality score"
+            record["quality_reason"] = "quality score"
         if code_lang != "unknown":
             record["metadata"]["code_language"] = code_lang
             if complexities:

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -121,6 +121,8 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
     ]:
         assert field in result
     assert result["discussion_links"] == ["d1"]
+    assert result["quality_level"] == "low"
+    assert result["quality_reason"] == "quality score"
 
 
 def test_generate_qa_pairs_extracts_docstring_and_signature(monkeypatch):
@@ -142,3 +144,5 @@ def foo(x):
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
     assert result["docstring"] == "Return x."
     assert result["signature"] == "foo(x)"
+    assert result["quality_level"] == "low"
+    assert result["quality_reason"] == "quality score"

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -50,3 +50,25 @@ def test_balance_quality_truncates_groups():
         for q in ["high", "medium", "low"]
     }
     assert counts == {"high": 1, "medium": 1, "low": 1}
+
+
+def test_analyze_comment_sentiment_positive():
+    comments = ["Great job", "I love it"]
+    assert quality.analyze_comment_sentiment(comments) == "positive"
+
+
+def test_analyze_comment_sentiment_negative():
+    comments = ["terrible bug", "bad"]
+    assert quality.analyze_comment_sentiment(comments) == "negative"
+
+
+def test_classify_github_repo_with_maintenance():
+    repo = {
+        "stars": 2,
+        "open_issues": 1,
+        "commit_frequency": 5,
+        "issue_closure_rate": 0.9,
+    }
+    q, reason = quality.classify_github_repo(repo)
+    assert q == "high"
+    assert "maintenance" in reason

--- a/utils/quality.py
+++ b/utils/quality.py
@@ -3,6 +3,31 @@
 from __future__ import annotations
 
 from typing import Dict, List, Tuple
+import re
+from statistics import mean
+
+POSITIVE_WORDS = {
+    "good",
+    "great",
+    "excellent",
+    "awesome",
+    "nice",
+    "love",
+    "like",
+    "well",
+    "cool",
+}
+
+NEGATIVE_WORDS = {
+    "bad",
+    "terrible",
+    "awful",
+    "hate",
+    "bug",
+    "poor",
+    "worse",
+    "worst",
+}
 
 
 def classify_github_repo(repo: Dict) -> Tuple[str, str]:
@@ -23,6 +48,14 @@ def classify_github_repo(repo: Dict) -> Tuple[str, str]:
     score = repo.get("quality_score")
     if score is None:
         score = stars / (issues + 1)
+
+    commit_freq = repo.get("commit_frequency", 0.0)
+    closure_rate = repo.get("issue_closure_rate", 0.0)
+    maintenance = commit_freq * closure_rate
+
+    popularity = compute_popularity_metrics(repo) / 100.0
+    score += maintenance + popularity
+
     has_tests = repo.get("has_tests") or repo.get("tests")
 
     if score >= 5:
@@ -34,6 +67,14 @@ def classify_github_repo(repo: Dict) -> Tuple[str, str]:
     else:
         quality = "low"
         reason = "low star to issue ratio"
+
+    if maintenance > 1:
+        reason += " and active maintenance"
+    elif maintenance > 0:
+        reason += " and limited maintenance"
+
+    if popularity > 1:
+        reason += " popular project"
 
     if has_tests:
         reason += " with tests"
@@ -61,6 +102,38 @@ def classify_stackoverflow_answer(answer: Dict) -> Tuple[str, str]:
     if score >= 2:
         return "medium", "community upvoted"
     return "low", "low score"
+
+
+def comment_sentiment_score(comment: str) -> float:
+    """Return a simple sentiment polarity score for ``comment``."""
+
+    tokens = re.findall(r"\w+", comment.lower())
+    pos = sum(1 for t in tokens if t in POSITIVE_WORDS)
+    neg = sum(1 for t in tokens if t in NEGATIVE_WORDS)
+    if pos + neg == 0:
+        return 0.0
+    return (pos - neg) / (pos + neg)
+
+
+def analyze_comment_sentiment(comments: List[str]) -> str:
+    """Classify average sentiment of a list of comments."""
+
+    scores = [comment_sentiment_score(c) for c in comments if c]
+    avg = mean(scores) if scores else 0.0
+    if avg > 0.1:
+        return "positive"
+    if avg < -0.1:
+        return "negative"
+    return "neutral"
+
+
+def compute_popularity_metrics(repo: Dict) -> float:
+    """Return a popularity score using stars, forks and watchers."""
+
+    stars = repo.get("stars") or repo.get("stargazers_count", 0)
+    forks = repo.get("forks", 0)
+    watchers = repo.get("watchers", 0)
+    return stars + 0.5 * forks + 0.2 * watchers
 
 
 def balance_quality(records: List[Dict]) -> List[Dict]:


### PR DESCRIPTION
## Summary
- extend `utils.quality` with comment sentiment and popularity scoring helpers
- factor repository maintenance history into GitHub repo classification
- keep new quality level fields when generating dataset records
- verify classification and dataset building logic in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a06a3a8c8320b6c6d758a1f595d1