### PR TITLE
Add code enrichment utilities

### DIFF
--- a/enrichment/generator.py
+++ b/enrichment/generator.py
@@ -1,0 +1,94 @@
+"""Utilities for dataset enrichment."""
+
+from __future__ import annotations
+
+import ast
+import os
+import uuid
+from typing import Dict, List
+
+from graphviz import Digraph
+
+
+class _CallGraphVisitor(ast.NodeVisitor):
+    """AST visitor building a function call graph."""
+
+    def __init__(self) -> None:
+        self.current: str | None = None
+        self.calls: Dict[str, set[str]] = {}
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # type: ignore[override]
+        prev = self.current
+        self.current = node.name
+        self.calls.setdefault(node.name, set())
+        self.generic_visit(node)
+        self.current = prev
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore
+
+    def visit_Call(self, node: ast.Call) -> None:  # type: ignore[override]
+        if self.current and isinstance(node.func, ast.Name):
+            self.calls.setdefault(self.current, set()).add(node.func.id)
+        self.generic_visit(node)
+
+
+def generate_diagram(code: str, out_dir: str, name: str | None = None) -> str:
+    """Return path to a DOT file representing function calls in ``code``."""
+    os.makedirs(out_dir, exist_ok=True)
+    visitor = _CallGraphVisitor()
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        tree = ast.parse("")
+    visitor.visit(tree)
+
+    dot = Digraph(comment="Call Graph")
+    for func in visitor.calls:
+        dot.node(func)
+    for caller, callees in visitor.calls.items():
+        for callee in callees:
+            dot.edge(caller, callee)
+
+    filename = f"{name or uuid.uuid4().hex}.gv"
+    path = os.path.join(out_dir, filename)
+    dot.save(path)
+    return path
+
+
+def generate_explanations(text: str, lang: str = "en") -> Dict[str, str]:
+    """Return explanations at high, medium and low abstraction levels."""
+    sentences = [s.strip() for s in text.split(". ") if s.strip()]
+    joined = " ".join(sentences)
+    high = sentences[0] if sentences else joined[:80]
+    medium = " ".join(sentences[:3]) if sentences else joined[:200]
+    low = joined if len(joined) <= 500 else joined[:500] + "..."
+    return {"high": high, "medium": medium, "low": low}
+
+
+_THEORY_MAP = {
+    "sort": "Cormen et al., Introduction to Algorithms",
+    "graph": "Sedgewick and Wayne, Algorithms",
+    "neural": "Goodfellow et al., Deep Learning",
+    "database": "Silberschatz et al., Database System Concepts",
+    "compiler": "Aho et al., Compilers: Principles, Techniques, and Tools",
+}
+
+
+def link_theory(text: str) -> List[str]:
+    """Return academic references related to ``text`` keywords."""
+    matches: List[str] = []
+    lower = text.lower()
+    for key, ref in _THEORY_MAP.items():
+        if key in lower:
+            matches.append(ref)
+    # remove duplicates preserving order
+    seen = set()
+    result = []
+    for ref in matches:
+        if ref not in seen:
+            result.append(ref)
+            seen.add(ref)
+    return result
+
+
+__all__ = ["generate_diagram", "generate_explanations", "link_theory"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ PyPDF2>=3.0.1
 fpdf>=1.7.2
 pdfminer.six>=2024.0.0
 antlr4-python3-runtime>=4.13
+graphviz>=0.21

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -79,6 +79,11 @@ from utils.ast_tools import get_functions_complexity
 from utils.code_sniffer import scan as scan_code
 from utils.contextualizer import search_discussions
 from processing.pipeline import get_pipeline
+from enrichment.generator import (
+    generate_diagram,
+    generate_explanations,
+    link_theory,
+)
 
 
 # ============================
@@ -1812,8 +1817,20 @@ class DatasetBuilder:
         # Classificação avançada de tópicos
         topic, subtopic = self._classify_topic(title, content, lang)
 
+        rec_id = hashlib.md5(f"{title}_{lang}".encode("utf-8")).hexdigest()
+        diagram_path = ""
+        if code_lang != "unknown":
+            try:
+                diagram_path = generate_diagram(
+                    content, os.path.join(Config.LOG_DIR, "diagrams"), rec_id
+                )
+            except Exception:
+                diagram_path = ""
+        explanations = generate_explanations(content, lang)
+        theory_links = link_theory(content)
+
         record = {
-            "id": hashlib.md5(f"{title}_{lang}".encode("utf-8")).hexdigest(),
+            "id": rec_id,
             "title": title,
             "language": lang,
             "category": category,
@@ -1847,6 +1864,9 @@ class DatasetBuilder:
             "relations": relations,
             "tests": extra_metadata.get("tests", []) if extra_metadata else [],
             "docstring": docstring,
+            "diagram_path": diagram_path,
+            "theory_links": theory_links,
+            "explanations": explanations,
             "created_at": datetime.utcnow().isoformat(),
             "metadata": {
                 "length": len(content),

--- a/tests/test_code_extractors.py
+++ b/tests/test_code_extractors.py
@@ -122,6 +122,8 @@ def foo():
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
     assert result["metadata"]["code_language"] == "python"
     assert result["context"] == "Doc."
+    for f in ["diagram_path", "theory_links", "explanations"]:
+        assert f in result
 
 
 def test_parsers_javascript(monkeypatch):
@@ -130,6 +132,8 @@ def test_parsers_javascript(monkeypatch):
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
     assert result["metadata"]["code_language"] == "javascript"
     assert result["context"] == "comment"
+    for f in ["diagram_path", "theory_links", "explanations"]:
+        assert f in result
 
 
 def test_parsers_java(monkeypatch):
@@ -138,6 +142,8 @@ def test_parsers_java(monkeypatch):
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
     assert result["metadata"]["code_language"] == "java"
     assert result["context"] == "hi"
+    for f in ["diagram_path", "theory_links", "explanations"]:
+        assert f in result
 
 
 def test_gitlab_scraper_search(monkeypatch):

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -118,6 +118,9 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
         "origin_metrics",
         "challenge",
         "discussion_links",
+        "diagram_path",
+        "theory_links",
+        "explanations",
     ]:
         assert field in result
     assert result["discussion_links"] == ["d1"]
@@ -144,5 +147,7 @@ def foo(x):
     result = builder.generate_qa_pairs("T", code, "S", "en", "c")
     assert result["docstring"] == "Return x."
     assert result["signature"] == "foo(x)"
+    for field in ["diagram_path", "theory_links", "explanations"]:
+        assert field in result
     assert result["quality_level"] == "low"
     assert result["quality_reason"] == "quality score"

--- a/tests/test_enrichment_generator.py
+++ b/tests/test_enrichment_generator.py
@@ -1,0 +1,26 @@
+import importlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+sys.path.insert(0, str(ROOT))
+
+gen = importlib.import_module("enrichment.generator")
+
+
+def test_generate_diagram_creates_file(tmp_path):
+    code = """\ndef a():\n    b()\n\ndef b():\n    pass\n"""
+    path = gen.generate_diagram(code, tmp_path)
+    assert Path(path).exists()
+
+
+def test_generate_explanations_returns_levels():
+    text = "First. Second sentence. Third one."
+    ex = gen.generate_explanations(text)
+    assert set(ex.keys()) == {"high", "medium", "low"}
+
+
+def test_link_theory_matches_keywords():
+    refs = gen.link_theory("quick sort implementation")
+    assert any("Algorithms" in r or "Introduction" in r for r in refs)

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -166,6 +166,8 @@ def test_generate_qa_pairs_accepts_extra_metadata(monkeypatch):
     assert result["wikidata_id"] == "Q1"
     assert result["image_url"] == "img"
     assert result["tags"] == [{"tag": "python", "link": "url"}]
+    for field in ["diagram_path", "theory_links", "explanations"]:
+        assert field in result
 
 
 def test_generate_qa_pairs_extracts_tags(monkeypatch):
@@ -184,6 +186,8 @@ def test_generate_qa_pairs_extracts_tags(monkeypatch):
         category="c",
     )
     assert {"tag": "python", "link": None} in result["tags"]
+    for field in ["diagram_path", "theory_links", "explanations"]:
+        assert field in result
 
 
 def test_advanced_clean_text_removes_html():


### PR DESCRIPTION
## Summary
- generate UML call graphs with Graphviz
- compute multi-level code explanations and theory references
- enrich dataset records with diagrams, explanations and links
- test enrichment utilities and update dataset builder tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a3552b348320a6ffce9125755cc9