### PR TITLE
Add robust URL normalization and navigation utilities

### DIFF
--- a/tests/test_utils_web.py
+++ b/tests/test_utils_web.py
@@ -1,0 +1,55 @@
+import random
+import numpy as np
+
+from utils.web import normalize_url, decide_navigation_action
+
+
+def test_normalize_url_basic():
+    url = "HTTP://www.Example.com:80/a/../b/?b=2&a=1#frag"
+    assert normalize_url(url) == "http://example.com/b?a=1&b=2"
+
+
+def test_normalize_url_tracking():
+    url = "https://example.com/page?utm_source=foo&x=1"
+    assert normalize_url(url) == "https://example.com/page?x=1"
+
+
+class DummyModel:
+    def predict(self, X):
+        return np.tile([[0.1, 0.7, 0.2]], (len(X), 1))
+
+
+def test_decide_navigation_action_basic():
+    link = {"url": "https://example.com/", "text": "next", "element": ["nav"]}
+    kb = {
+        "site_patterns": {
+            "example.com": {"navigation_elements": [{"classes": ["nav"]}]}
+        }
+    }
+    config = {
+        "priority_urls": [],
+        "content_keywords": [],
+        "navigation_keywords": ["next"],
+        "exploration_rate": 0.0,
+        "exploration_decay": 1.0,
+        "min_exploration_rate": 0.0,
+    }
+    action = decide_navigation_action(link, "example.com", kb, DummyModel(), config)
+    assert action == 1
+
+
+def test_decide_navigation_action_exploration():
+    random.seed(0)
+    link = {"url": "https://example.com/", "text": ""}
+    kb = {"site_patterns": {}}
+    config = {
+        "priority_urls": [],
+        "content_keywords": [],
+        "navigation_keywords": [],
+        "exploration_rate": 1.0,
+        "exploration_decay": 0.5,
+        "min_exploration_rate": 0.1,
+    }
+    action = decide_navigation_action(link, "example.com", kb, DummyModel(), config)
+    assert 0 <= action <= 2
+    assert config["exploration_rate"] == 0.5

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,6 +17,7 @@ from .code import (
 from .ast_tools import parse_code, get_functions_complexity
 from .code_sniffer import scan
 from .contextualizer import search_discussions
+from .web import normalize_url, decide_navigation_action
 
 __all__ = [
     "clean_text",
@@ -36,4 +37,6 @@ __all__ = [
     "get_functions_complexity",
     "scan",
     "search_discussions",
+    "normalize_url",
+    "decide_navigation_action",
 ]

--- a/utils/web.py
+++ b/utils/web.py
@@ -1,0 +1,150 @@
+"""Utilities for web crawling and navigation."""
+
+from __future__ import annotations
+
+import posixpath
+import random
+import re
+from typing import Any, Dict
+from urllib.parse import parse_qsl, urlparse, urlunparse, urlencode
+
+import numpy as np
+
+
+_TRACKING_PARAMS = {
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "fbclid",
+}
+
+
+def normalize_url(url: str) -> str:
+    """Return a normalized representation of ``url``.
+
+    The function performs several transformations to ensure URLs can be
+    compared reliably:
+
+    * lowercase scheme and domain;
+    * remove default ports (80 for HTTP, 443 for HTTPS);
+    * remove fragments;
+    * normalize path resolving ``."" and ``..`` segments;
+    * remove duplicate slashes and trailing slash;
+    * sort query parameters and drop common tracking keys;
+    * convert IDN domains to ASCII using ``idna``.
+    """
+
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = parsed.hostname.lower() if parsed.hostname else ""
+    if host.startswith("www."):
+        host = host[4:]
+    try:
+        host = host.encode("idna").decode("ascii")
+    except Exception:
+        pass
+    port = f":{parsed.port}" if parsed.port else ""
+    if (scheme == "http" and parsed.port == 80) or (
+        scheme == "https" and parsed.port == 443
+    ):
+        port = ""
+    netloc = host + port
+
+    path = posixpath.normpath(parsed.path)
+    path = re.sub(r"/+", "/", path)
+    if path == ".":
+        path = "/"
+
+    query_items = [
+        (k, v)
+        for k, v in parse_qsl(parsed.query, keep_blank_values=True)
+        if k not in _TRACKING_PARAMS
+    ]
+    query = urlencode(sorted(query_items))
+
+    normalized = urlunparse((scheme, netloc, path, "", query, ""))
+    if normalized.endswith("/") and path != "/":
+        normalized = normalized[:-1]
+    return normalized
+
+
+def _match_domain_pattern(patterns: list[dict[str, Any]], classes: list[str]) -> int:
+    return int(any(any(c in classes for c in p.get("classes", [])) for p in patterns))
+
+
+def decide_navigation_action(
+    link_info: Dict[str, Any],
+    domain: str,
+    knowledge_base: Dict[str, Any],
+    navigation_model: Any,
+    config: Dict[str, Any],
+) -> int:
+    """Choose how to handle ``link_info`` discovered while crawling.
+
+    The ``navigation_model`` is expected to expose a ``predict`` method taking
+    a ``numpy`` array of shape ``(n_samples, n_features)`` and returning
+    probabilities for three actions: skip, follow, or extract. ``knowledge_base``
+    may contain site specific patterns used to enrich feature vectors.
+    """
+
+    domain_patterns = knowledge_base.get("site_patterns", {}).get(domain, {})
+    classes = link_info.get("element", [])
+
+    features = [
+        len(link_info.get("url", "")),
+        len(link_info.get("text", "")),
+        int(
+            any(
+                k in link_info.get("url", "").lower()
+                for k in config.get("priority_urls", [])
+            )
+        ),
+        int(
+            any(
+                k in link_info.get("text", "").lower()
+                for k in config.get("content_keywords", [])
+            )
+        ),
+        int(
+            any(
+                k in link_info.get("text", "").lower()
+                for k in config.get("navigation_keywords", [])
+            )
+        ),
+        int("#" in link_info.get("url", "")),
+        int(link_info.get("url", "").endswith("/")),
+        link_info.get("url", "").count("/"),
+        int(re.search(r"\d", link_info.get("url", "")) is not None),
+        int(domain in link_info.get("url", "")),
+    ]
+
+    features.extend(
+        [
+            _match_domain_pattern(domain_patterns.get("content_elements", []), classes),
+            _match_domain_pattern(
+                domain_patterns.get("navigation_elements", []), classes
+            ),
+            _match_domain_pattern(domain_patterns.get("data_elements", []), classes),
+            _match_domain_pattern(domain_patterns.get("anti_patterns", []), classes),
+        ]
+    )
+
+    arr = np.array([features], dtype=float)
+    try:
+        action_probs = navigation_model.predict(arr)[0]
+        action = int(np.argmax(action_probs))
+    except Exception:
+        action = 1
+
+    if random.random() < config.get("exploration_rate", 0.0):
+        action = random.randint(0, 2)
+
+    rate = config.get("exploration_rate", 0.0) * config.get("exploration_decay", 1.0)
+    config["exploration_rate"] = max(rate, config.get("min_exploration_rate", 0.0))
+
+    return action
+
+
+__all__ = ["normalize_url", "decide_navigation_action"]


### PR DESCRIPTION
## Summary
- implement advanced `normalize_url` and `decide_navigation_action`
- expose new helpers from `utils` package
- test new utilities

## Testing
- `black utils/web.py utils/__init__.py tests/test_utils_web.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685a82027f9c83208a2e9fdba83f7684