### PR TITLE
Add test stubs for browser deps

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,31 @@ sys.modules.setdefault("weaviate", weaviate_stub)
 
 sys.modules.setdefault("yaml", SimpleNamespace(safe_load=lambda *a, **k: {}))
 
+# Stub optional browser dependencies
+ua_mod = ModuleType("fake_useragent")
+
+
+class _DummyUA:
+    def __init__(self, *a, **k):
+        self.random = "test-agent"
+
+
+ua_mod.UserAgent = _DummyUA
+sys.modules.setdefault("fake_useragent", ua_mod)
+
+selenium_stub = ModuleType("selenium")
+webdriver_stub = ModuleType("selenium.webdriver")
+webdriver_stub.Chrome = object
+webdriver_stub.ChromeOptions = object
+by_stub = ModuleType("selenium.webdriver.common.by")
+by_stub.By = SimpleNamespace(ID="id", CSS_SELECTOR="css")
+sys.modules.setdefault("selenium", selenium_stub)
+sys.modules.setdefault("selenium.webdriver", webdriver_stub)
+sys.modules.setdefault(
+    "selenium.webdriver.common", ModuleType("selenium.webdriver.common")
+)
+sys.modules.setdefault("selenium.webdriver.common.by", by_stub)
+
 # Stub Selenium-based scraper to avoid heavy dependencies
 auto_stub = ModuleType("crawling.auto_learner")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,29 @@ sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
 sys.modules.setdefault("unidecode", SimpleNamespace(unidecode=lambda x: x))
 sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
 sys.modules.setdefault("html2text", SimpleNamespace())
+ua_mod = ModuleType("fake_useragent")
+
+
+class _DummyUA:
+    def __init__(self, *a, **k):
+        self.random = "test-agent"
+
+
+ua_mod.UserAgent = _DummyUA
+sys.modules.setdefault("fake_useragent", ua_mod)
+
+selenium_stub = ModuleType("selenium")
+webdriver_stub = ModuleType("selenium.webdriver")
+webdriver_stub.Chrome = object
+webdriver_stub.ChromeOptions = object
+by_stub = ModuleType("selenium.webdriver.common.by")
+by_stub.By = SimpleNamespace(ID="id", CSS_SELECTOR="css")
+sys.modules.setdefault("selenium", selenium_stub)
+sys.modules.setdefault("selenium.webdriver", webdriver_stub)
+sys.modules.setdefault(
+    "selenium.webdriver.common", ModuleType("selenium.webdriver.common")
+)
+sys.modules.setdefault("selenium.webdriver.common.by", by_stub)
 wiki_mod = ModuleType("wikipediaapi")
 wiki_mod.WikipediaException = Exception
 wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)


### PR DESCRIPTION
## Summary
- stub fake_useragent and selenium in tests
- keep stubs available to all tests via conftest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9611b1488320b132c60287257de8