### PR TITLE
Add conversion helper for AutoLearner data

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,11 @@ páginas dinâmicas. Ele pode ser executado de forma independente:
 
 ```python
 from core import AutoLearnerScraper
+from crawling.auto_dataset import convert_records_to_dataset
 
 scraper = AutoLearnerScraper("https://exemplo.com")
 records = scraper.build_dataset(["python"])
+dataset = convert_records_to_dataset(records, "pt", "Programação")
 scraper.close()
 ```
 

--- a/crawling/auto_dataset.py
+++ b/crawling/auto_dataset.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from scraper_wiki import cpu_process_page
+
+
+def convert_records_to_dataset(
+    records: List[Dict[str, str]], lang: str, category: str
+) -> List[Dict]:
+    """Convert AutoLearnerScraper results to DatasetBuilder format.
+
+    Args:
+        records: Items returned by ``AutoLearnerScraper.build_dataset``.
+        lang: Language code for generated entries.
+        category: Category associated with the records.
+
+    Returns:
+        List of dataset records ready to be saved with ``DatasetBuilder``.
+    """
+
+    dataset = []
+    for rec in records:
+        data = cpu_process_page(
+            rec.get("title", rec.get("url", "")),
+            rec.get("content", ""),
+            lang,
+            category,
+        )
+        if rec.get("url"):
+            data.setdefault("metadata", {})["source_url"] = rec["url"]
+        dataset.append(data)
+    return dataset
+
+
+__all__ = ["convert_records_to_dataset"]

--- a/tests/test_auto_dataset.py
+++ b/tests/test_auto_dataset.py
@@ -1,0 +1,41 @@
+import sys
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_convert_records_to_dataset(monkeypatch):
+    """Records from AutoLearnerScraper are turned into dataset entries."""
+
+    stub = SimpleNamespace(cpu_process_page=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, "scraper_wiki", stub)
+
+    import crawling.auto_dataset as ad
+
+    importlib.reload(ad)
+
+    def fake_cpu_process(title, content, lang, category):
+        return {
+            "title": title,
+            "content": content,
+            "language": lang,
+            "category": category,
+        }
+
+    monkeypatch.setattr(ad, "cpu_process_page", fake_cpu_process)
+
+    records = [{"title": "T", "content": "C", "url": "u"}]
+    dataset = ad.convert_records_to_dataset(records, "en", "Test")
+
+    assert dataset == [
+        {
+            "title": "T",
+            "content": "C",
+            "language": "en",
+            "category": "Test",
+            "metadata": {"source_url": "u"},
+        }
+    ]


### PR DESCRIPTION
## Summary
- add new module `crawling.auto_dataset` to convert AutoLearnerScraper output to DatasetBuilder format
- document the helper in README usage example
- add unit test covering conversion logic

## Testing
- `pytest tests/test_auto_dataset.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9b0ee7f08320bf3940496478b810