### PR TITLE
Add competition plugins and notebook scraper

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -36,6 +36,13 @@ AVAILABLE_PLUGINS = {
     "cran_packages": "cran_packages",
     "jira_scraper": "jira_scraper",
     "bugzilla_scraper": "bugzilla_scraper",
+    "leetcode": "leetcode",
+    "hackerrank": "hackerrank",
+    "codeforces": "codeforces",
+    "kaggle": "kaggle",
+    "bitbucket_scraper": "bitbucket_scraper",
+    "sourceforge_scraper": "sourceforge_scraper",
+    "notebooks": "notebooks",
 }
 
 

--- a/plugins/bitbucket_scraper.py
+++ b/plugins/bitbucket_scraper.py
@@ -1,0 +1,61 @@
+"""Bitbucket repository scraping utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class BitbucketScraper:
+    """Minimal interface for the Bitbucket API."""
+
+    def __init__(self, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://api.bitbucket.org/2.0"
+
+    def _parse_repo(self, repo_url: str) -> Tuple[str, str]:
+        parts = repo_url.rstrip("/").split("/")[-2:]
+        if len(parts) != 2:
+            raise ValueError("Invalid Bitbucket repository URL")
+        return parts[0], parts[1]
+
+    def get_readme(self, repo_url: str) -> str:
+        owner, repo = self._parse_repo(repo_url)
+        url = f"{self.api_url}/repositories/{owner}/{repo}/src/HEAD/README.md"
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.text
+
+    def get_issues(self, repo_url: str) -> List[Dict]:
+        owner, repo = self._parse_repo(repo_url)
+        url = f"{self.api_url}/repositories/{owner}/{repo}/issues"
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, list):
+            return data
+        return data.get("values", [])
+
+    def build_dataset_record(self, repo_url: str) -> Dict:
+        readme = self.get_readme(repo_url)
+        issues = self.get_issues(repo_url)
+        record = {
+            "repository": repo_url,
+            "readme": readme,
+            "issues": issues,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+class Plugin(BitbucketScraper):
+    """Alias for plugin registry."""

--- a/plugins/codeforces.py
+++ b/plugins/codeforces.py
@@ -1,0 +1,62 @@
+"""Codeforces scraping plugin."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class CodeforcesPlugin(Plugin):  # type: ignore[misc]
+    """Fetch problems from Codeforces."""
+
+    def __init__(self, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://codeforces.com/api"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a Codeforces problem."""
+        return [{"slug": category, "lang": lang, "category": category}]
+
+    def _fetch_problem(self, slug: str) -> Dict:
+        resp = requests.get(
+            f"{self.api_url}/problemset/problem/{slug}", timeout=Config.TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch_discussion(self, slug: str) -> Dict:
+        resp = requests.get(
+            f"{self.api_url}/problemset/discussion/{slug}", timeout=Config.TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return problem statement, solution and discussion."""
+        slug = item.get("slug")
+        if not slug:
+            return {}
+        problem = self._fetch_problem(slug)
+        discussion = self._fetch_discussion(slug)
+        record = {
+            "title": problem.get("name", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "problem": problem.get("statement", ""),
+            "solution": problem.get("solution", ""),
+            "discussion": discussion.get("content", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = CodeforcesPlugin

--- a/plugins/hackerrank.py
+++ b/plugins/hackerrank.py
@@ -1,0 +1,62 @@
+"""HackerRank scraping plugin."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class HackerRankPlugin(Plugin):  # type: ignore[misc]
+    """Fetch challenges from HackerRank."""
+
+    def __init__(self, api_url: str | None = None) -> None:
+        self.api_url = (
+            api_url or "https://www.hackerrank.com/rest/contests/master/challenges"
+        )
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a challenge."""
+        return [{"slug": category, "lang": lang, "category": category}]
+
+    def _fetch_problem(self, slug: str) -> Dict:
+        resp = requests.get(f"{self.api_url}/{slug}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch_discussion(self, slug: str) -> Dict:
+        resp = requests.get(
+            f"{self.api_url}/{slug}/discussions", timeout=Config.TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return challenge statement, solution and discussions."""
+        slug = item.get("slug")
+        if not slug:
+            return {}
+        problem = self._fetch_problem(slug)
+        discussion = self._fetch_discussion(slug)
+        record = {
+            "title": problem.get("name", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "problem": problem.get("body", ""),
+            "solution": problem.get("solution", ""),
+            "discussion": discussion.get("content", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = HackerRankPlugin

--- a/plugins/kaggle.py
+++ b/plugins/kaggle.py
@@ -1,0 +1,58 @@
+"""Kaggle scraping plugin."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class KagglePlugin(Plugin):  # type: ignore[misc]
+    """Fetch competition descriptions from Kaggle."""
+
+    def __init__(self, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://www.kaggle.com/api/v1/competitions"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a Kaggle competition."""
+        return [{"slug": category, "lang": lang, "category": category}]
+
+    def _fetch_problem(self, slug: str) -> Dict:
+        resp = requests.get(f"{self.api_url}/{slug}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch_discussion(self, slug: str) -> Dict:
+        resp = requests.get(f"{self.api_url}/{slug}/topics", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return competition description, solution and discussions."""
+        slug = item.get("slug")
+        if not slug:
+            return {}
+        problem = self._fetch_problem(slug)
+        discussion = self._fetch_discussion(slug)
+        record = {
+            "title": problem.get("title", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "problem": problem.get("description", ""),
+            "solution": problem.get("solution", ""),
+            "discussion": discussion.get("content", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = KagglePlugin

--- a/plugins/leetcode.py
+++ b/plugins/leetcode.py
@@ -1,0 +1,58 @@
+"""LeetCode scraping plugin."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class LeetCodePlugin(Plugin):  # type: ignore[misc]
+    """Fetch problems and solutions from LeetCode."""
+
+    def __init__(self, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://leetcode.com/api"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return a descriptor for a LeetCode problem."""
+        return [{"slug": category, "lang": lang, "category": category}]
+
+    def _fetch_problem(self, slug: str) -> Dict:
+        resp = requests.get(f"{self.api_url}/problems/{slug}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch_discussion(self, slug: str) -> Dict:
+        resp = requests.get(f"{self.api_url}/discuss/{slug}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return problem statement, solution and discussion."""
+        slug = item.get("slug")
+        if not slug:
+            return {}
+        problem = self._fetch_problem(slug)
+        discussion = self._fetch_discussion(slug)
+        record = {
+            "title": problem.get("title", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "problem": problem.get("content", ""),
+            "solution": problem.get("solution", ""),
+            "discussion": discussion.get("content", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = LeetCodePlugin

--- a/plugins/notebooks.py
+++ b/plugins/notebooks.py
@@ -1,0 +1,47 @@
+"""Public notebook scraping plugin."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class NotebooksPlugin(Plugin):  # type: ignore[misc]
+    """Fetch raw notebook files from GitHub or Kaggle."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a notebook URL."""
+        return [{"url": category, "lang": lang, "category": category}]
+
+    def _fetch_notebook(self, url: str) -> str:
+        resp = requests.get(url, timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.text
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download the notebook content."""
+        url = item.get("url")
+        if not url:
+            return {}
+        content = self._fetch_notebook(url)
+        record = {
+            "url": url,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "notebook": content,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = NotebooksPlugin

--- a/plugins/sourceforge_scraper.py
+++ b/plugins/sourceforge_scraper.py
@@ -1,0 +1,51 @@
+"""SourceForge repository scraping utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from scraper_wiki import Config
+from .base import Plugin
+
+
+class SourceForgeScraper(Plugin):  # type: ignore[misc]
+    """Fetch project information from SourceForge."""
+
+    def __init__(self, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://sourceforge.net/rest/p"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a SourceForge project."""
+        return [{"name": category, "lang": lang, "category": category}]
+
+    def _fetch_project(self, name: str) -> Dict:
+        resp = requests.get(f"{self.api_url}/{name}", timeout=Config.TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return project metadata."""
+        name = item.get("name")
+        if not name:
+            return {}
+        data = self._fetch_project(name)
+        record = {
+            "name": data.get("name", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "summary": data.get("summary", ""),
+            "description": data.get("description", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = SourceForgeScraper

--- a/tests/test_new_plugins.py
+++ b/tests/test_new_plugins.py
@@ -1,0 +1,207 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Minimal configuration stub
+scraper_stub = ModuleType("scraper_wiki")
+scraper_stub.Config = SimpleNamespace(TIMEOUT=5)
+sys.modules.setdefault("scraper_wiki", scraper_stub)
+
+
+def _check_defaults(record):
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record
+
+
+class DummyResp:
+    def __init__(self, data=None, text=""):
+        self._data = data
+        self._text = text
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+    @property
+    def text(self):
+        return self._text
+
+
+def test_leetcode_plugin(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        if "problems" in url:
+            return DummyResp(data={"title": "Two Sum", "content": "P", "solution": "S"})
+        return DummyResp(data={"content": "D"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.leetcode")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "two-sum")
+    assert items[0]["slug"] == "two-sum"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["problem"] == "P"
+    assert parsed["solution"] == "S"
+    assert parsed["discussion"] == "D"
+    _check_defaults(parsed)
+
+
+def test_hackerrank_plugin(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        if url.endswith("/discussions"):
+            return DummyResp(data={"content": "D"})
+        return DummyResp(data={"name": "Ch", "body": "P", "solution": "S"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.hackerrank")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "challenge")
+    assert items[0]["slug"] == "challenge"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["problem"] == "P"
+    assert parsed["solution"] == "S"
+    assert parsed["discussion"] == "D"
+    _check_defaults(parsed)
+
+
+def test_codeforces_plugin(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        if "discussion" in url:
+            return DummyResp(data={"content": "D"})
+        return DummyResp(data={"name": "Prob", "statement": "P", "solution": "S"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.codeforces")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "1234/A")
+    assert items[0]["slug"] == "1234/A"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["problem"] == "P"
+    assert parsed["solution"] == "S"
+    assert parsed["discussion"] == "D"
+    _check_defaults(parsed)
+
+
+def test_kaggle_plugin(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        if url.endswith("/topics"):
+            return DummyResp(data={"content": "D"})
+        return DummyResp(data={"title": "Comp", "description": "P", "solution": "S"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.kaggle")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "competition")
+    assert items[0]["slug"] == "competition"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["problem"] == "P"
+    assert parsed["solution"] == "S"
+    assert parsed["discussion"] == "D"
+    _check_defaults(parsed)
+
+
+def test_bitbucket_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        if url.endswith("README.md"):
+            return DummyResp(text="readme")
+        if url.endswith("/issues"):
+            return DummyResp(data=[{"title": "bug"}])
+        return DummyResp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.bitbucket_scraper")
+    scraper = mod.Plugin()
+    record = scraper.build_dataset_record("https://bitbucket.org/u/repo")
+    assert record["readme"] == "readme"
+    assert record["issues"] == [{"title": "bug"}]
+    _check_defaults(record)
+
+
+def test_sourceforge_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(data={"name": "proj", "summary": "S", "description": "D"})
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.sourceforge_scraper")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "proj")
+    assert items[0]["name"] == "proj"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["summary"] == "S"
+    assert parsed["description"] == "D"
+    _check_defaults(parsed)
+
+
+def test_notebooks_plugin(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, timeout=None):
+        return DummyResp(text='{"nb":1}')
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.notebooks")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "http://example.com/nb.ipynb")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["notebook"] == '{"nb":1}'
+    _check_defaults(parsed)


### PR DESCRIPTION
## Summary
- add plugins for LeetCode, HackerRank, Codeforces and Kaggle
- add Bitbucket and SourceForge scrapers
- support public notebooks from GitHub/Kaggle
- register new plugins
- test new plugins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685aa91c9ce08320b44756a44362f397