### PR TITLE
Add code analysis module with tests

### DIFF
--- a/processing/code_analysis.py
+++ b/processing/code_analysis.py
@@ -1,0 +1,137 @@
+"""Utilities for analyzing source code snippets."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from typing import Any, Dict, Iterable, List, Tuple
+
+try:
+    from tree_sitter import Parser  # type: ignore
+    from tree_sitter_languages import get_language  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Parser = None
+    get_language = None
+
+try:
+    from pygments import lex
+    from pygments.lexers import get_lexer_by_name, guess_lexer
+except Exception:  # pragma: no cover - optional dependency
+    lex = None
+    get_lexer_by_name = None
+    guess_lexer = None
+
+
+def _get_lexer(code: str, language: str | None = None):
+    lang = language or ""
+    if get_lexer_by_name:
+        try:
+            if lang:
+                return get_lexer_by_name(lang)
+        except Exception:
+            pass
+    if guess_lexer:
+        try:
+            return guess_lexer(code)
+        except Exception:
+            return None
+    return None
+
+
+def extract_ast(code: str, language: str | None = None) -> Any:
+    """Return an AST-like representation of ``code``.
+
+    The function attempts to use Tree-sitter if available, otherwise
+    falls back to Python's :mod:`ast` or Pygments tokens.
+    """
+
+    lang = (language or "python").lower()
+    if Parser and get_language:
+        try:
+            ts_lang = get_language(lang)
+            parser = Parser()
+            parser.set_language(ts_lang)
+            return parser.parse(code.encode("utf-8"))
+        except Exception:
+            pass
+    if lang in {"python", "py"}:
+        try:
+            return ast.parse(code)
+        except Exception:
+            return None
+    lexer = _get_lexer(code, lang)
+    if lexer and lex:
+        try:
+            return list(lex(code, lexer))
+        except Exception:
+            return None
+    return None
+
+
+def extract_metadata(code: str, language: str | None = None) -> Dict[str, Any]:
+    """Return simple metadata about ``code``.
+
+    Currently counts lines and tokens using Pygments when available.
+    """
+
+    lexer = _get_lexer(code, language)
+    tokens: Iterable[Any] = []
+    if lexer and lex:
+        try:
+            tokens = list(lex(code, lexer))
+        except Exception:
+            tokens = []
+    return {"lines": len(code.splitlines()), "tokens": len(list(tokens))}
+
+
+def check_execution(code: str, language: str = "python") -> Tuple[bool, str]:
+    """Compile and execute ``code`` returning success status and output."""
+
+    if language not in {"python", "py"}:
+        return False, "unsupported language"
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0, (result.stdout + result.stderr).strip()
+    except Exception as e:  # pragma: no cover - subprocess errors
+        return False, str(e)
+
+
+def validate_snippet(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Check compilation and execution of ``record['content']``.
+
+    Adds ``exec_ok`` and ``exec_output`` fields to the record.
+    """
+
+    code = record.get("content", "")
+    lang = record.get("metadata", {}).get("code_language", "python")
+    ok, output = check_execution(code, lang)
+    record["exec_ok"] = ok
+    record["exec_output"] = output
+    return record
+
+
+def generate_io_pairs(items: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Convert competition items to input/output pairs."""
+
+    pairs = []
+    for it in items:
+        inp = it.get("problem", "")
+        out = it.get("solution", "")
+        if inp and out:
+            pairs.append({"input": inp, "output": out})
+    return pairs
+
+
+__all__ = [
+    "extract_ast",
+    "extract_metadata",
+    "check_execution",
+    "validate_snippet",
+    "generate_io_pairs",
+]

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -2355,6 +2355,11 @@ class DatasetBuilder:
             self.dataset = pipe(self.dataset)
         return self.dataset
 
+    def add_io_pairs(self, pairs: List[dict]) -> None:
+        """Append input/output ``pairs`` to :attr:`qa_pairs`."""
+
+        self.qa_pairs.extend(pairs)
+
     def enhance_with_clustering(self):
         if not self.dataset:
             return

--- a/tests/test_code_analysis.py
+++ b/tests/test_code_analysis.py
@@ -1,0 +1,144 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub optional heavy libs if missing
+sys.modules.setdefault("tree_sitter", SimpleNamespace(Parser=object))
+sys.modules.setdefault(
+    "tree_sitter_languages", SimpleNamespace(get_language=lambda l: None)
+)
+# Heavy dependency stubs
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(SentenceTransformer=object)
+)
+sys.modules.setdefault(
+    "datasets",
+    SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None),
+)
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault("unidecode", SimpleNamespace(unidecode=lambda x: x))
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault("html2text", SimpleNamespace())
+sys.modules.setdefault("bs4", SimpleNamespace(BeautifulSoup=lambda *a, **k: None))
+numpy_stub = ModuleType("numpy")
+numpy_stub.array = lambda *a, **k: []
+numpy_stub.ndarray = list
+numpy_stub.all = lambda x: True
+numpy_stub.isfinite = lambda x: True
+sys.modules.setdefault("numpy", numpy_stub)
+sys.modules.setdefault(
+    "requests",
+    SimpleNamespace(
+        get=lambda *a, **k: None,
+        exceptions=SimpleNamespace(RequestException=Exception),
+    ),
+)
+sys.modules.setdefault("networkx", SimpleNamespace())
+sys.modules.setdefault("simhash", SimpleNamespace(Simhash=lambda *a, **k: None))
+sys.modules.setdefault("graphviz", SimpleNamespace(Digraph=object))
+wiki_mod = ModuleType("wikipediaapi")
+wiki_mod.WikipediaException = Exception
+wiki_mod.Namespace = SimpleNamespace(MAIN=0, CATEGORY=14)
+wiki_mod.ExtractFormat = SimpleNamespace(HTML=0)
+wiki_mod.WikipediaPage = object
+wiki_mod.Wikipedia = lambda *a, **k: SimpleNamespace(
+    page=lambda *a, **k: SimpleNamespace(exists=lambda: False),
+    api=SimpleNamespace(article_url=lambda x: ""),
+)
+sys.modules.setdefault("wikipediaapi", wiki_mod)
+sys.modules.setdefault(
+    "aiohttp",
+    SimpleNamespace(
+        ClientSession=object,
+        ClientTimeout=lambda *a, **k: None,
+        ClientError=Exception,
+        ClientResponseError=Exception,
+    ),
+)
+sys.modules.setdefault(
+    "backoff",
+    SimpleNamespace(
+        on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None
+    ),
+)
+sklearn_mod = ModuleType("sklearn")
+sklearn_mod.cluster = SimpleNamespace(KMeans=object)
+sklearn_mod.feature_extraction = SimpleNamespace(
+    text=SimpleNamespace(TfidfVectorizer=object)
+)
+sys.modules.setdefault("sklearn", sklearn_mod)
+sys.modules.setdefault("sklearn.cluster", sklearn_mod.cluster)
+sys.modules.setdefault("sklearn.feature_extraction", sklearn_mod.feature_extraction)
+sys.modules.setdefault(
+    "sklearn.feature_extraction.text", sklearn_mod.feature_extraction.text
+)
+sumy_mod = ModuleType("sumy")
+parsers_mod = ModuleType("sumy.parsers")
+plaintext_mod = ModuleType("sumy.parsers.plaintext")
+plaintext_mod.PlaintextParser = object
+parsers_mod.plaintext = plaintext_mod
+nlp_mod = ModuleType("sumy.nlp")
+tokenizers_mod = ModuleType("sumy.nlp.tokenizers")
+tokenizers_mod.Tokenizer = object
+nlp_mod.tokenizers = tokenizers_mod
+summarizers_mod = ModuleType("sumy.summarizers")
+lsa_mod = ModuleType("sumy.summarizers.lsa")
+lsa_mod.LsaSummarizer = object
+summarizers_mod.lsa = lsa_mod
+sumy_mod.parsers = parsers_mod
+sumy_mod.nlp = nlp_mod
+sumy_mod.summarizers = summarizers_mod
+sys.modules.setdefault("sumy", sumy_mod)
+sys.modules.setdefault("sumy.parsers", parsers_mod)
+sys.modules.setdefault("sumy.parsers.plaintext", plaintext_mod)
+sys.modules.setdefault("sumy.nlp", nlp_mod)
+sys.modules.setdefault("sumy.nlp.tokenizers", tokenizers_mod)
+sys.modules.setdefault("sumy.summarizers", summarizers_mod)
+sys.modules.setdefault("sumy.summarizers.lsa", lsa_mod)
+
+ca = importlib.import_module("processing.code_analysis")
+sw = importlib.import_module("scraper_wiki")
+
+
+class DummyEmbed:
+    def encode(self, *a, **k):
+        import numpy as np
+
+        return np.array([0.0])
+
+
+sw.NLPProcessor.get_embedding_model = classmethod(lambda cls: DummyEmbed())
+
+
+def test_extract_ast_returns_object():
+    code = "def foo(x):\n    return x * 2"
+    tree = ca.extract_ast(code, "python")
+    assert tree is not None
+
+
+def test_extract_metadata_counts_lines():
+    meta = ca.extract_metadata("a=1\nb=2")
+    assert meta["lines"] == 2
+    assert meta["tokens"] >= 1
+
+
+def test_check_execution_and_validation():
+    ok, out = ca.check_execution('print("hi")')
+    assert ok
+    assert "hi" in out
+    record = {"content": 'print("x")', "metadata": {"code_language": "python"}}
+    res = ca.validate_snippet(record)
+    assert res["exec_ok"]
+
+
+def test_generate_io_pairs_and_builder_integration():
+    items = [{"problem": "sum", "solution": "return a+b"}]
+    pairs = ca.generate_io_pairs(items)
+    builder = sw.DatasetBuilder()
+    builder.add_io_pairs(pairs)
+    assert builder.qa_pairs[0]["input"] == "sum"
+    assert builder.qa_pairs[0]["output"] == "return a+b"


### PR DESCRIPTION
## Summary
- implement `processing.code_analysis` using Tree-sitter/Pygments
- validate snippet execution and generate I/O pairs
- extend `DatasetBuilder` with `add_io_pairs`
- add tests for code analysis features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aad5fc9dc83209ab4b6ba6b59b641