### PR TITLE
Add distributed crawler benchmark and cloud plugin executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,14 @@ dataset = convert_records_to_dataset(records, "pt", "Programação")
 scraper.close()
 ```
 
+### Otimizando workers assíncronos
+
+Ao rodar o `AutoLearnerScraper` com Selenium é comum abrir diversos drivers em
+paralelo. Utilize o parâmetro `max_workers` de forma conservadora e sempre em
+modo *headless* para manter o consumo de memória baixo. Essa abordagem permite
+que múltiplas páginas sejam processadas sem picos de CPU, mesmo em ambientes com
+recursos limitados.
+
 Exemplo executando o plugin do StackOverflow:
 
 ```python

--- a/crawling/__init__.py
+++ b/crawling/__init__.py
@@ -1,1 +1,57 @@
-"""Crawling utilities."""
+"""Crawling utilities and rate limiting."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+class RateLimiter:
+    """Simple exponential backoff rate limiter."""
+
+    def __init__(self, min_delay: float, max_delay: float | None = None):
+        if max_delay is None:
+            max_delay = min_delay
+        self.base_min = min_delay
+        self.base_max = max_delay
+        self.min_delay = min_delay
+        self.max_delay = max_delay
+        self.consecutive_failures = 0
+
+    def _sample_delay(self) -> float:
+        import random
+
+        return random.uniform(self.min_delay, self.max_delay)
+
+    def wait(self) -> None:
+        import time
+
+        time.sleep(self._sample_delay())
+
+    def record_error(self) -> None:
+        self.consecutive_failures += 1
+        self.min_delay = min(self.max_delay, self.min_delay * 2)
+        self.max_delay = min(self.max_delay, self.max_delay * 2)
+
+    def record_success(self) -> None:
+        self.consecutive_failures = 0
+        self.min_delay = self.base_min
+        self.max_delay = self.base_max
+
+
+class DynamicRateLimiter:
+    """Manage per-host rate limiters with exponential backoff."""
+
+    def __init__(self, base_delay: float = 1.0, max_delay: float = 60.0) -> None:
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.limiters: Dict[str, RateLimiter] = {}
+
+    def get(self, host: str) -> RateLimiter:
+        if host not in self.limiters:
+            self.limiters[host] = RateLimiter(self.base_delay, self.max_delay)
+        return self.limiters[host]
+
+
+rate_limiter = DynamicRateLimiter()
+
+__all__ = ["rate_limiter", "DynamicRateLimiter"]

--- a/crawling/distributed.py
+++ b/crawling/distributed.py
@@ -11,6 +11,7 @@ from urllib.robotparser import RobotFileParser
 import requests
 
 from cluster import get_client, load_config
+from . import rate_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -57,14 +58,18 @@ class DistributedCrawler:
         if not self.can_fetch(url):
             logger.info("Blocked by robots.txt: %s", url)
             return None
-        time.sleep(self.crawl_delay)
+        host = urlparse(url).netloc
+        limiter = rate_limiter.get(host)
+        limiter.wait()
         try:
             resp = requests.get(
                 url, headers={"User-Agent": self.user_agent}, timeout=10
             )
             resp.raise_for_status()
+            limiter.record_success()
             return resp.text
         except Exception as exc:  # pragma: no cover - network errors
+            limiter.record_error()
             logger.error("Failed to fetch %s: %s", url, exc)
             return None
 
@@ -134,6 +139,61 @@ def start_crawler(config_path: str | None = None) -> None:
         max_pages=max_pages,
     )
     crawler.crawl()
+
+
+def benchmark_crawler(
+    start_urls: Iterable[str],
+    total_pages: int = 1000000,
+    client=None,
+    crawl_delay: float = 0.0,
+    user_agent: str = "ScraperWikiBot",
+) -> float:
+    """Benchmark crawling a large number of pages.
+
+    Args:
+        start_urls: Initial URLs used as seeds.
+        total_pages: Total number of pages to collect.
+        client: Optional distributed client.
+        crawl_delay: Base delay between requests.
+        user_agent: HTTP user agent string.
+
+    Returns:
+        Total time in seconds to fetch ``total_pages`` pages.
+    """
+    crawler = DistributedCrawler(
+        start_urls,
+        client=client,
+        crawl_delay=crawl_delay,
+        user_agent=user_agent,
+        max_pages=total_pages,
+    )
+    start = time.time()
+    crawler.crawl()
+    elapsed = time.time() - start
+    logger.info(
+        "Benchmark fetched %d pages in %.2fs (%.2f pages/s)",
+        total_pages,
+        elapsed,
+        total_pages / elapsed if elapsed else 0,
+    )
+    return elapsed
+
+
+def run_benchmark(config_path: str | None = None) -> None:
+    """Execute ``benchmark_crawler`` using ``cluster.yaml`` settings."""
+    cfg = load_config(config_path)
+    crawler_cfg = cfg.get("crawler", {})
+    client = get_client(cfg)
+    start_urls = crawler_cfg.get("start_urls", [])
+    pages = int(crawler_cfg.get("benchmark_pages", 1000000))
+    delay = float(crawler_cfg.get("crawl_delay", 0.0))
+    benchmark_crawler(
+        start_urls,
+        total_pages=pages,
+        client=client,
+        crawl_delay=delay,
+        user_agent=crawler_cfg.get("user_agent", "ScraperWikiBot"),
+    )
 
 
 def stop_crawler() -> None:

--- a/plugins/cloud_executor.py
+++ b/plugins/cloud_executor.py
@@ -1,0 +1,77 @@
+"""Execute plugin steps using AWS Lambda or Google Cloud Functions."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import requests
+
+
+def invoke_lambda(
+    function_name: str, payload: Dict[str, Any], region: str = "us-east-1"
+) -> Dict[str, Any]:
+    """Invoke an AWS Lambda function with ``payload``.
+
+    Parameters
+    ----------
+    function_name:
+        Name of the Lambda function.
+    payload:
+        Data sent as the invocation payload.
+    region:
+        AWS region where the function is deployed.
+
+    Returns
+    -------
+    dict
+        JSON response from the Lambda function.
+    """
+    try:  # pragma: no cover - optional dependency
+        import boto3  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise RuntimeError("boto3 required for AWS Lambda") from exc
+    client = boto3.client("lambda", region_name=region)
+    resp = client.invoke(
+        FunctionName=function_name, Payload=json.dumps(payload).encode()
+    )
+    data = resp.get("Payload")
+    if data:
+        return json.loads(data.read())
+    return {}
+
+
+def invoke_cloud_function(function_url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Call a Google Cloud Function via HTTP."""
+    resp = requests.post(function_url, json=payload, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def run_plugin_lambda(
+    plugin_name: str,
+    items: List[Dict[str, Any]],
+    function_name: str,
+    region: str = "us-east-1",
+) -> List[Dict[str, Any]]:
+    """Execute ``parse_item`` for ``items`` remotely via AWS Lambda."""
+    payload = {"plugin": plugin_name, "items": items}
+    result = invoke_lambda(function_name, payload, region=region)
+    return result.get("records", [])
+
+
+def run_plugin_gcf(
+    plugin_name: str, items: List[Dict[str, Any]], function_url: str
+) -> List[Dict[str, Any]]:
+    """Execute ``parse_item`` for ``items`` on Google Cloud Functions."""
+    payload = {"plugin": plugin_name, "items": items}
+    result = invoke_cloud_function(function_url, payload)
+    return result.get("records", [])
+
+
+__all__ = [
+    "invoke_lambda",
+    "invoke_cloud_function",
+    "run_plugin_lambda",
+    "run_plugin_gcf",
+]


### PR DESCRIPTION
## Summary
- implement `DynamicRateLimiter` and register in `crawling`
- use rate limiter in distributed crawler
- add benchmark helpers in `crawling.distributed`
- document async Selenium worker resource usage in README
- provide AWS Lambda and GCF helpers for plugins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab3dae2708320a17246383c0f5183