### PR TITLE
Add topic entropy and gap analysis utilities

### DIFF
--- a/processing/pipeline.py
+++ b/processing/pipeline.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import math
 import subprocess
 import re
+from collections import Counter
 from typing import Callable, Dict, List
 
 import dq
@@ -61,6 +63,34 @@ def analyze_complexity(code: str, language: str | None = None) -> Dict[str, int]
     return analysis.get("complexities", {})
 
 
+def compute_topic_entropy(records: List[Dict]) -> float:
+    """Return Shannon entropy of ``records`` topics."""
+    counts = Counter(rec.get("topic", "unknown") for rec in records)
+    total = sum(counts.values())
+    if total == 0:
+        return 0.0
+    entropy = 0.0
+    for c in counts.values():
+        p = c / total
+        entropy -= p * math.log2(p)
+    return entropy
+
+
+def balance_languages(records: List[Dict]) -> List[Dict]:
+    """Return ``records`` balanced across code languages."""
+    groups: Dict[str, List[Dict]] = {}
+    for rec in records:
+        lang = rec.get("metadata", {}).get("code_language", "unknown")
+        groups.setdefault(lang, []).append(rec)
+    if not groups:
+        return records
+    min_count = min(len(v) for v in groups.values())
+    balanced: List[Dict] = []
+    for lang in sorted(groups):
+        balanced.extend(groups[lang][:min_count])
+    return balanced
+
+
 def process_record(record: Dict) -> Dict:
     """Process a single dataset record through all stages."""
     content = record.get("content", "")
@@ -95,6 +125,8 @@ __all__ = [
     "lint_code",
     "scan_vulnerabilities",
     "analyze_complexity",
+    "compute_topic_entropy",
+    "balance_languages",
     "process_record",
     "run_pipeline",
     "get_pipeline",

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -953,6 +953,33 @@ def extract_images(html: str) -> List[Dict[str, str]]:
         return []
 
 
+def extract_videos(html: str) -> List[str]:
+    """Return video URLs from ``html`` content."""
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+        videos: List[str] = []
+        for vid in soup.find_all("video"):
+            src = vid.get("src") or ""
+            if not src:
+                source = vid.find("source")
+                if source and source.get("src"):
+                    src = source["src"]
+            if src:
+                if src.startswith("//"):
+                    src = "https:" + src
+                videos.append(src)
+        for iframe in soup.find_all("iframe"):
+            src = iframe.get("src") or ""
+            if any(domain in src for domain in ["youtube.com", "vimeo.com"]):
+                if src.startswith("//"):
+                    src = "https:" + src
+                videos.append(src)
+        return videos
+    except Exception as e:
+        logger.error(f"Erro ao extrair videos: {e}")
+        return []
+
+
 async def fetch_with_retry(
     url: str,
     *,
@@ -1567,6 +1594,7 @@ def cpu_process_page(
     lang: str,
     category: str,
     images: List[Dict[str, str]] | None = None,
+    videos: List[str] | None = None,
     revisions: List[dict] | None = None,
     rev_limit: int = 5,
 ) -> dict:
@@ -1583,6 +1611,8 @@ def cpu_process_page(
     record["entities"] = extract_entities(content)
     if images is not None:
         record["images"] = images
+    if videos:
+        record["videos"] = videos
     if revisions is not None:
         record.setdefault("metadata", {})["revisions"] = revisions
     return record
@@ -1705,6 +1735,7 @@ class DatasetBuilder:
 
             if proc_executor:
                 images = extract_images(getattr(page, "_html", ""))
+                videos = extract_videos(getattr(page, "_html", ""))
                 revisions = None
                 if self.include_revisions:
                     revisions = wiki.get_revision_history(
@@ -1717,6 +1748,7 @@ class DatasetBuilder:
                     page_info["lang"],
                     page_info.get("category", ""),
                     images,
+                    videos,
                     revisions,
                     self.rev_limit,
                 )
@@ -1734,7 +1766,10 @@ class DatasetBuilder:
             )
             qa_data["entities"] = extract_entities(clean_content)
             images = extract_images(getattr(page, "_html", ""))
+            videos = extract_videos(getattr(page, "_html", ""))
             qa_data["images"] = images
+            if videos:
+                qa_data["videos"] = videos
             if self.include_revisions:
                 qa_data.setdefault("metadata", {})["revisions"] = (
                     wiki.get_revision_history(page_info["title"], self.rev_limit)

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -1,0 +1,38 @@
+import importlib
+import math
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+pipeline = importlib.import_module("processing.pipeline")
+analysis = importlib.import_module("utils.gap_analysis")
+
+
+def test_topic_entropy():
+    recs = [{"topic": "a"}, {"topic": "a"}, {"topic": "b"}]
+    ent = pipeline.compute_topic_entropy(recs)
+    expected = -(2 / 3 * math.log2(2 / 3) + 1 / 3 * math.log2(1 / 3))
+    assert round(ent, 4) == round(expected, 4)
+
+
+def test_balance_languages():
+    recs = [
+        {"metadata": {"code_language": "py"}},
+        {"metadata": {"code_language": "py"}},
+        {"metadata": {"code_language": "js"}},
+    ]
+    balanced = pipeline.balance_languages(recs)
+    langs = [r["metadata"]["code_language"] for r in balanced]
+    assert langs.count("py") == langs.count("js") == 1
+
+
+def test_identify_gaps():
+    recs = [
+        {"language": "en", "topic": "a"},
+        {"language": "en", "topic": "b"},
+        {"language": "pt", "topic": "a"},
+    ]
+    gaps = analysis.identify_gaps(recs, min_ratio=0.4)
+    assert gaps == {"languages": ["pt"], "topics": ["b"]}

--- a/utils/gap_analysis.py
+++ b/utils/gap_analysis.py
@@ -1,0 +1,23 @@
+"""Dataset gap analysis utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def identify_gaps(records: List[Dict], min_ratio: float = 0.1) -> Dict[str, List[str]]:
+    """Return underrepresented languages and topics."""
+    total = len(records)
+    lang_counts: Dict[str, int] = {}
+    topic_counts: Dict[str, int] = {}
+    for rec in records:
+        lang = rec.get("language", "unknown")
+        lang_counts[lang] = lang_counts.get(lang, 0) + 1
+        topic = rec.get("topic", "unknown")
+        topic_counts[topic] = topic_counts.get(topic, 0) + 1
+    under_langs = [l for l, c in lang_counts.items() if c / total < min_ratio]
+    under_topics = [t for t, c in topic_counts.items() if c / total < min_ratio]
+    return {"languages": under_langs, "topics": under_topics}
+
+
+__all__ = ["identify_gaps"]


### PR DESCRIPTION
## Summary
- calculate topic entropy and balance code languages in `processing/pipeline.py`
- extend dataset builder to handle optional video links
- add `utils/gap_analysis.py` for finding underrepresented languages and topics
- test new gap analysis utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abb018a1883208dcb1ec092dc0c4f