### PR TITLE
Add dataset export & HF integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,17 @@ informações básicas sobre o conjunto criado:
 - `collection_date`: data da coleta no formato `AAAA-MM-DD`;
 - `license`: licença aplicável, padrão `"CC BY-SA 4.0"`.
 
+### Publicação no Hugging Face
+
+Utilize a função `publish_hf_dataset` em `training.formats` para enviar o
+dataset diretamente para o Hub. Basta informar o repositório de destino e um
+token válido:
+
+```python
+from training.formats import publish_hf_dataset
+publish_hf_dataset(records, "usuario/meu-dataset", token="hf_xxx")
+```
+
 ## Integração com frameworks de ML
 
 Os arquivos gerados em `training/` permitem treinar modelos de NLP de forma simples. A seguir alguns exemplos.
@@ -577,4 +588,6 @@ um treinamento rápido de NER com Transformers. Outros notebooks disponíveis
 incluem `qa_training.ipynb`, que mostra como filtrar por tópico e idioma para
 fazer fine-tuning de um modelo de Perguntas e Respostas, e `filtering.ipynb`,
 que demonstra como selecionar artigos por categoria ou linguagem e exportar
-subconjuntos do dataset.
+subconjuntos do dataset. Novos notebooks `jax_fine_tuning.ipynb` e
+`lightning_fine_tuning.ipynb` apresentam exemplos de treino usando JAX/Flax e
+PyTorch Lightning.

--- a/examples/jax_fine_tuning.ipynb
+++ b/examples/jax_fine_tuning.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Fine-tuning com JAX/Flax"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Exemplo simples usando transformers e Flax."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "!pip install -q transformers datasets flax optax"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "from datasets import load_dataset\nfrom transformers import FlaxAutoModelForSequenceClassification, AutoTokenizer\nimport optax\n\ntrain_ds = load_dataset('imdb', split='train[:1%]')\ntokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')\ntrain_ds = train_ds.map(lambda x: tokenizer(x['text'], truncation=True, padding='max_length'), batched=True)\n\nmodel = FlaxAutoModelForSequenceClassification.from_pretrained('bert-base-uncased', num_labels=2)\noptimizer = optax.adam(5e-5)\nstate = model.create_train_state(optimizer=optimizer)\nfor batch in train_ds.shuffle(seed=0).batch(8):\n    state, metrics = model.train_step(state, batch)"
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/lightning_fine_tuning.ipynb
+++ b/examples/lightning_fine_tuning.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Fine-tuning com PyTorch Lightning"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Demonstra treino r\u00e1pido usando Lightning."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "!pip install -q pytorch-lightning transformers datasets"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "from datasets import load_dataset\nfrom transformers import AutoTokenizer, AutoModelForSequenceClassification\nimport pytorch_lightning as pl\nimport torch\n\ntrain_ds = load_dataset('imdb', split='train[:1%]')\ntokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')\n\ndef collate(batch):\n    enc = tokenizer([x['text'] for x in batch], padding=True, truncation=True, return_tensors='pt')\n    labels = torch.tensor([x['label'] for x in batch])\n    return {**enc, 'labels': labels}\n\nloader = torch.utils.data.DataLoader(train_ds, batch_size=8, collate_fn=collate)\nmodel = AutoModelForSequenceClassification.from_pretrained('bert-base-uncased', num_labels=2)\nclass LitModel(pl.LightningModule):\n    def __init__(self):\n        super().__init__()\n        self.model = model\n    def forward(self, **x):\n        return self.model(**x)\n    def training_step(self, batch, batch_idx):\n        out = self(**batch)\n        loss = out.loss\n        self.log('train_loss', loss)\n        return loss\n    def configure_optimizers(self):\n        return torch.optim.AdamW(self.parameters(), lr=5e-5)\n\ntrainer = pl.Trainer(max_epochs=1, logger=False, enable_checkpointing=False)\ntrainer.fit(LitModel(), loader)"
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _reload(monkeypatch, modules=None):
+    if modules:
+        for name, mod in modules.items():
+            monkeypatch.setitem(sys.modules, name, mod)
+    if "training" in sys.modules and not hasattr(sys.modules["training"], "__path__"):
+        sys.modules.pop("training")
+    sys.modules.pop("training.formats", None)
+    return importlib.import_module("training.formats")
+
+
+def test_save_arrow_dataset(tmp_path, monkeypatch):
+    written = {}
+
+    def dummy_write_dataset(
+        table,
+        base_dir,
+        format="parquet",
+        partitioning=None,
+        existing_data_behavior=None,
+    ):
+        written["dir"] = base_dir
+
+    pa_mod = ModuleType("pyarrow")
+    pa_mod.Table = SimpleNamespace(from_pylist=lambda recs: "table")
+    ds_mod = ModuleType("pyarrow.dataset")
+    ds_mod.write_dataset = dummy_write_dataset
+    pa_mod.dataset = ds_mod
+    formats = _reload(monkeypatch, {"pyarrow": pa_mod, "pyarrow.dataset": ds_mod})
+
+    formats.save_arrow_dataset([{"a": 1}], tmp_path)
+    assert written["dir"] == str(tmp_path)
+
+
+def test_save_delta_table(tmp_path, monkeypatch):
+    written = {}
+
+    def dummy_write_deltalake(path, table, mode="error"):
+        written["path"] = path
+
+    pa_mod = ModuleType("pyarrow")
+    pa_mod.Table = SimpleNamespace(from_pylist=lambda recs: "table")
+    delta_mod = ModuleType("deltalake")
+    delta_mod.write_deltalake = dummy_write_deltalake
+    formats = _reload(monkeypatch, {"pyarrow": pa_mod, "deltalake": delta_mod})
+
+    formats.save_delta_table([{"x": 1}], tmp_path)
+    assert written["path"] == str(tmp_path)

--- a/training/formats.py
+++ b/training/formats.py
@@ -53,6 +53,39 @@ def save_arrow_table(records: List[Dict], path: Path) -> None:
         return
 
 
+def save_arrow_dataset(
+    records: List[Dict], directory: Path, partitioning: List[str] | None = None
+) -> None:
+    """Write ``records`` to an Apache Arrow dataset.
+
+    Parameters
+    ----------
+    records : list[dict]
+        Dataset records.
+    directory : pathlib.Path
+        Target directory to store the dataset.
+    partitioning : list[str] | None
+        Optional columns used to partition the dataset.
+    """
+    try:  # pragma: no cover - optional deps
+        import pyarrow as pa
+        import pyarrow.dataset as ds
+
+        if not records:
+            return
+        table = pa.Table.from_pylist(records)
+        directory.mkdir(parents=True, exist_ok=True)
+        ds.write_dataset(
+            table,
+            base_dir=str(directory),
+            format="parquet",
+            partitioning=partitioning,
+            existing_data_behavior="overwrite_or_ignore",
+        )
+    except Exception:  # pragma: no cover - optional deps
+        return
+
+
 def save_qa_dataset(records: List[Dict], path: Path) -> None:
     """Save question/answer pairs in a simple JSON list."""
     pairs = []
@@ -76,3 +109,49 @@ def save_text_corpus(records: List[Dict], directory: Path) -> None:
         name = rec.get("id") or rec.get("title", "record")
         file_path = directory / f"{name}.txt"
         file_path.write_text(text, encoding="utf-8")
+
+
+def save_delta_table(records: List[Dict], directory: Path) -> None:
+    """Export ``records`` to a Delta Lake table directory.
+
+    Parameters
+    ----------
+    records : list[dict]
+        Dataset records.
+    directory : pathlib.Path
+        Target Delta Lake directory.
+    """
+    try:  # pragma: no cover - optional deps
+        import pyarrow as pa
+        from deltalake import write_deltalake
+
+        if not records:
+            return
+        table = pa.Table.from_pylist(records)
+        directory.mkdir(parents=True, exist_ok=True)
+        write_deltalake(str(directory), table, mode="overwrite")
+    except Exception:  # pragma: no cover - optional deps
+        return
+
+
+def publish_hf_dataset(
+    records: List[Dict], repo: str, token: str | None = None
+) -> None:
+    """Publish ``records`` to the Hugging Face Hub.
+
+    Parameters
+    ----------
+    records : list[dict]
+        Dataset records.
+    repo : str
+        Repository name in the form ``username/dataset``.
+    token : str | None
+        Authentication token for the Hub.
+    """
+    try:  # pragma: no cover - optional deps
+        from datasets import Dataset
+
+        ds = Dataset.from_list(records)
+        ds.push_to_hub(repo_id=repo, token=token)
+    except Exception:  # pragma: no cover - optional deps
+        return

--- a/training/pipeline.py
+++ b/training/pipeline.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from typing import List, Dict
 
 from .formats import (
+    save_arrow_dataset,
     save_arrow_table,
+    save_delta_table,
     save_hf_dataset,
     save_tfrecord_dataset,
 )
@@ -69,3 +71,5 @@ def run_pipeline(dataset_path: str | Path) -> None:
     save_hf_dataset(records, base.with_name(base.name + "_hf"))
     save_tfrecord_dataset(records, base.with_suffix(".tfrecord"))
     save_arrow_table(records, base.with_suffix(".arrow"))
+    save_arrow_dataset(records, base.with_name(base.name + "_arrow_dataset"))
+    save_delta_table(records, base.with_name(base.name + "_delta"))


### PR DESCRIPTION
## Summary
- extend data export utilities to support Arrow datasets, Delta Lake and publishing to Hugging Face Hub
- update pipeline to generate new dataset formats
- document Hugging Face publication and new example notebooks
- add notebooks showing fine-tuning with JAX/Flax and PyTorch Lightning
- test new exporters

## Testing
- `black training/formats.py training/pipeline.py tests/test_formats.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac1cbd82483208c0c7fea45565bf5