### PR TITLE
Add proxy fallback and Playwright

### DIFF
--- a/crawling/__init__.py
+++ b/crawling/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Iterable, List
+
+import requests
 
 
 class RateLimiter:
@@ -54,4 +56,97 @@ class DynamicRateLimiter:
 
 rate_limiter = DynamicRateLimiter()
 
-__all__ = ["rate_limiter", "DynamicRateLimiter"]
+
+class BrightDataProxy:
+    """Simple wrapper for Bright Data proxy credentials."""
+
+    def __init__(self, user: str, password: str, host: str, port: int = 22225) -> None:
+        self.user = user
+        self.password = password
+        self.host = host
+        self.port = port
+
+    def as_dict(self) -> Dict[str, str]:
+        url = f"http://{self.user}:{self.password}@{self.host}:{self.port}"
+        return {"http": url, "https": url}
+
+
+class TwoCaptchaSolver:
+    """Minimal 2Captcha API client."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def solve_recaptcha(self, site_key: str, url: str) -> str:
+        """Return captcha solution for ``site_key`` on ``url``."""
+
+        resp = requests.post(
+            "http://2captcha.com/in.php",
+            data={
+                "key": self.api_key,
+                "method": "userrecaptcha",
+                "googlekey": site_key,
+                "pageurl": url,
+                "json": 1,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        captcha_id = resp.json().get("request")
+        for _ in range(20):
+            rate_limiter.wait()
+            res = requests.get(
+                "http://2captcha.com/res.php",
+                params={
+                    "key": self.api_key,
+                    "action": "get",
+                    "id": captcha_id,
+                    "json": 1,
+                },
+                timeout=10,
+            )
+            res.raise_for_status()
+            data = res.json()
+            if data.get("status") == 1:
+                return data["request"]
+            if data.get("request") != "CAPCHA_NOT_READY":
+                raise RuntimeError(data.get("request"))
+        raise RuntimeError("Captcha solving timed out")
+
+
+def fallback_request(
+    url: str, proxies: Iterable[str] | None, user_agents: Iterable[str] | None
+) -> str:
+    """Try multiple proxy/UA combinations until the request succeeds."""
+
+    proxy_cycle = list(proxies or [None])
+    ua_cycle = list(user_agents or [None])
+    attempts = max(len(proxy_cycle), 1) * max(len(ua_cycle), 1)
+    idx = 0
+    last_exc: Exception | None = None
+    for _ in range(attempts):
+        proxy = proxy_cycle[idx % len(proxy_cycle)]
+        ua = ua_cycle[idx % len(ua_cycle)]
+        idx += 1
+        headers = {"User-Agent": ua} if ua else {}
+        proxy_dict = {"http": proxy, "https": proxy} if proxy else None
+        try:
+            resp = requests.get(url, headers=headers, proxies=proxy_dict, timeout=10)
+            if resp.status_code in {403, 429}:
+                continue
+            resp.raise_for_status()
+            return resp.text
+        except Exception as exc:  # pragma: no cover - network errors
+            last_exc = exc
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("All attempts failed")
+
+
+__all__ = [
+    "rate_limiter",
+    "DynamicRateLimiter",
+    "BrightDataProxy",
+    "TwoCaptchaSolver",
+    "fallback_request",
+]

--- a/crawling/auto_learner.py
+++ b/crawling/auto_learner.py
@@ -9,15 +9,20 @@ from bs4 import BeautifulSoup
 from fake_useragent import UserAgent
 from selenium.webdriver import Chrome, ChromeOptions
 from selenium.webdriver.common.by import By
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
 class AutoLearnerScraper:
-    """Scraper that collects pages rendered dynamically with Selenium."""
+    """Scraper that collects pages rendered dynamically."""
 
     def __init__(
-        self, base_url: str, driver_path: str | None = None, headless: bool = True
+        self,
+        base_url: str,
+        driver_path: str | None = None,
+        headless: bool = True,
+        backend: str = "selenium",
     ) -> None:
         """Initialize the scraper.
 
@@ -25,19 +30,35 @@ class AutoLearnerScraper:
             base_url: Base website to crawl.
             driver_path: Optional path to the Chrome driver binary.
             headless: Run the browser without UI.
+            backend: ``"selenium"`` or ``"playwright"``.
         """
 
-        options = ChromeOptions()
-        if headless:
-            options.add_argument("--headless")
-        ua = UserAgent()
-        options.add_argument(f"user-agent={ua.random}")
-        self.driver = (
-            Chrome(driver_path, options=options)
-            if driver_path
-            else Chrome(options=options)
-        )
         self.base_url = base_url.rstrip("/")
+        self._pw: Optional[object] = None
+        if backend == "playwright":
+            from playwright.sync_api import sync_playwright
+
+            self._pw = sync_playwright().start()
+            browser = self._pw.chromium.launch(headless=headless)
+            self.driver = browser.new_page()
+        else:
+            options = ChromeOptions()
+            if headless:
+                options.add_argument("--headless")
+            ua = UserAgent()
+            options.add_argument(f"user-agent={ua.random}")
+            self.driver = (
+                Chrome(driver_path, options=options)
+                if driver_path
+                else Chrome(options=options)
+            )
+
+    def _get_page_source(self, url: str) -> str:
+        if self._pw is not None:
+            self.driver.goto(url)
+            return self.driver.content()
+        self.driver.get(url)
+        return self.driver.page_source
 
     def search(self, query: str) -> List[str]:
         """Search the site and return result links.
@@ -49,11 +70,17 @@ class AutoLearnerScraper:
             List of absolute URLs extracted from the results page.
         """
         url = f"{self.base_url}/search?q={query}"
-        self.driver.get(url)
-        elems = self.driver.find_elements(By.CSS_SELECTOR, "a")
+        html = self._get_page_source(url)
+        if self._pw is not None:
+            soup = BeautifulSoup(html, "html.parser")
+            elems = soup.select("a")
+            get_href = lambda el: el.get("href")
+        else:
+            elems = self.driver.find_elements(By.CSS_SELECTOR, "a")
+            get_href = lambda el: el.get_attribute("href")
         links = []
         for el in elems:
-            href = el.get_attribute("href")
+            href = get_href(el)
             if href and href.startswith(self.base_url):
                 links.append(href)
         return links
@@ -67,8 +94,7 @@ class AutoLearnerScraper:
         Returns:
             Record with ``title``, ``content`` and ``url`` keys.
         """
-        self.driver.get(url)
-        html = self.driver.page_source
+        html = self._get_page_source(url)
         soup = BeautifulSoup(html, "html.parser")
         text = soup.get_text(" ", strip=True)
         title = soup.title.string if soup.title else url
@@ -96,8 +122,11 @@ class AutoLearnerScraper:
         return records
 
     def close(self) -> None:
-        """Close the Selenium driver."""
-        self.driver.quit()
+        """Close the browser driver."""
+        if self._pw is not None:
+            self._pw.stop()
+        else:
+            self.driver.quit()
 
 
 __all__ = ["AutoLearnerScraper"]

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -992,6 +992,8 @@ async def fetch_with_retry(
 
     if proxy is None and Config.PROXIES:
         proxy = get_next_proxy()
+    if headers is None:
+        headers = {"User-Agent": Config.get_random_user_agent()}
 
     for attempt in range(1, retries + 1):
         try:
@@ -1013,8 +1015,9 @@ async def fetch_with_retry(
                     async with session.get(
                         url, params=params, headers=headers, proxy=proxy
                     ) as resp:
-                        if resp.status == 429:
+                        if resp.status in (429, 403):
                             metrics.scrape_block.inc()
+                            raise aiohttp.ClientResponseError(resp.status)
                         if 500 <= resp.status < 600:
                             raise aiohttp.ClientResponseError(
                                 resp.request_info,
@@ -1032,9 +1035,13 @@ async def fetch_with_retry(
                 else:
                     fetch_semaphore.release()
         except aiohttp.ClientResponseError as e:
-            if getattr(e, "status", None) == 429:
-                logger.warning(f"HTTP 429 for {url}, backing off")
+            status = getattr(e, "status", None)
+            if status in (429, 403):
+                logger.warning(f"HTTP {status} for {url}, rotating proxy/UA")
                 rate_limiter.record_error()
+                if Config.PROXIES:
+                    proxy = get_next_proxy()
+                headers["User-Agent"] = Config.get_random_user_agent()
             else:
                 logger.warning(f"Attempt {attempt} failed for {url}: {e}")
             exc = e

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import crawling
+import requests
+
+
+def test_fallback_request_switches_proxy_and_user_agent(monkeypatch):
+    calls = []
+
+    class Resp:
+        def __init__(self, status):
+            self.status_code = status
+            self.text = "ok"
+
+        def raise_for_status(self):
+            if self.status_code != 200:
+                raise requests.HTTPError()
+
+    def fake_get(url, headers=None, proxies=None, timeout=10):
+        calls.append((headers.get("User-Agent"), proxies.get("http") if proxies else None))
+        if len(calls) == 1:
+            return Resp(403)
+        return Resp(200)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    proxies = ["http://p1", "http://p2"]
+    uas = ["ua1", "ua2"]
+
+    text = crawling.fallback_request("http://x", proxies, uas)
+
+    assert text == "ok"
+    assert calls == [("ua1", "http://p1"), ("ua2", "http://p2")]


### PR DESCRIPTION
## Summary
- extend crawling utilities with Bright Data proxy and 2Captcha helper
- add request fallback helper cycling proxies and user agents
- rotate proxy and user-agent automatically on 403/429
- support Playwright backend in `AutoLearnerScraper`
- add regression test for proxy/user-agent fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685accd54d84832089ca79f5f4caf307