### PR TITLE
Add Airflow training pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,7 @@ antlr4-python3-runtime>=4.13
 graphviz>=0.21
 fake-useragent>=1.5.3
 selenium>=4.20.0  # optional
+# Machine learning workflow and experiment tracking
+mlflow>=2.12.1  # optional
+optuna>=3.6.1  # optional
+apache-airflow>=2.9.1  # optional

--- a/tests/test_airflow_pipeline.py
+++ b/tests/test_airflow_pipeline.py
@@ -1,0 +1,31 @@
+import importlib.util
+import sys
+from types import ModuleType
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Load the module without executing ``training.__init__``
+training_mod = ModuleType("training")
+training_mod.__path__ = [str(ROOT / "training")]
+sys.modules["training"] = training_mod
+spec = importlib.util.spec_from_file_location(
+    "training.airflow_pipeline", ROOT / "training" / "airflow_pipeline.py"
+)
+pipe = importlib.util.module_from_spec(spec)
+sys.modules["training.airflow_pipeline"] = pipe
+spec.loader.exec_module(pipe)
+
+
+def test_create_dag():
+    if pipe.DAG is None:
+        with pytest.raises(RuntimeError):
+            pipe.create_dag()
+    else:
+        dag = pipe.create_dag()
+        assert {
+            "collect_data",
+            "clean_data",
+            "fine_tune_model",
+        }.issubset(dag.task_dict)

--- a/training/airflow_pipeline.py
+++ b/training/airflow_pipeline.py
@@ -1,0 +1,72 @@
+"""Airflow pipeline orchestrating data collection and model fine-tuning."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from airflow import DAG
+    from airflow.operators.python import PythonOperator
+except Exception:  # pragma: no cover - optional dependency
+    DAG = None  # type: ignore
+    PythonOperator = None  # type: ignore
+
+
+def collect_data() -> None:
+    """Placeholder task to collect raw data."""
+    print("Collecting data...")
+
+
+def clean_data() -> None:
+    """Placeholder task to clean and preprocess the data."""
+    print("Cleaning data...")
+
+
+def fine_tune_model() -> None:
+    """Run a sample hyperparameter search and log results with MLflow."""
+    try:  # pragma: no cover - optional deps
+        import mlflow
+        import optuna
+    except Exception:
+        print("MLflow or Optuna not available")
+        return
+
+    def objective(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", 0.0, 1.0)
+        loss = (x - 0.5) ** 2
+        mlflow.log_params({"x": x})
+        mlflow.log_metric("loss", loss)
+        return loss
+
+    with mlflow.start_run():
+        study = optuna.create_study(direction="minimize")
+        study.optimize(objective, n_trials=1)
+
+
+def create_dag() -> Any:
+    """Create and return the Airflow DAG for the training pipeline."""
+    if DAG is None or PythonOperator is None:
+        raise RuntimeError("Airflow is not installed")
+
+    with DAG(
+        dag_id="training_pipeline",
+        start_date=datetime(2024, 1, 1),
+        schedule_interval=None,
+        catchup=False,
+    ) as dag:
+        collect = PythonOperator(task_id="collect_data", python_callable=collect_data)
+        clean = PythonOperator(task_id="clean_data", python_callable=clean_data)
+        tune = PythonOperator(
+            task_id="fine_tune_model", python_callable=fine_tune_model
+        )
+
+        collect >> clean >> tune
+
+    return dag
+
+
+try:  # pragma: no cover - optional dependency
+    dag = create_dag()
+except Exception:
+    dag = None


### PR DESCRIPTION
## Summary
- configure Airflow DAG in `training/` using MLflow and Optuna
- add optional dependencies for workflow orchestration
- test DAG creation logic without requiring Airflow runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae9f5efa083208aaa717d3ef846ca