### PR TITLE
Add compliance checks and PII filtering

### DIFF
--- a/docs/ethics.md
+++ b/docs/ethics.md
@@ -1,0 +1,10 @@
+# Web Scraping Ethics
+
+This project respects the legal and ethical boundaries of data collection. When scraping any website you must:
+
+- **Check `robots.txt`** and comply with the site's crawling rules.
+- **Rate limit requests** to avoid overwhelming remote servers.
+- Identify yourself with a User-Agent header and provide contact information when possible.
+- Store only publicly available content and honor takedown requests.
+
+Failure to follow these practices can lead to legal issues or banned IPs. Always verify the licensing terms of the data source before distributing any dataset derived from it.

--- a/dq.py
+++ b/dq.py
@@ -200,6 +200,23 @@ def strip_credentials(code: str) -> str:
     return text
 
 
+_PII_PATTERNS = [
+    r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}",
+    r"\b(?:\d[ -]?){13,16}\b",  # credit card numbers
+    r"\b\d{3}-\d{2}-\d{4}\b",  # SSN format
+    r"\b\+?\d{1,3}[ -]?\(?\d{1,4}\)?[ -]?\d{1,4}[ -]?\d{1,9}\b",  # phone
+]
+
+
+def remove_pii(text: str) -> str:
+    """Return ``text`` with personal data redacted."""
+
+    cleaned = text
+    for pat in _PII_PATTERNS:
+        cleaned = re.sub(pat, "<PII>", cleaned)
+    return cleaned
+
+
 def detect_code_plagiarism(records: List[Dict], threshold: float = 0.95) -> List[Dict]:
     """Return records whose ``content`` is very similar to others."""
     plagiarized: List[Dict] = []

--- a/provenance/__init__.py
+++ b/provenance/__init__.py
@@ -1,0 +1,4 @@
+from .tracker import record_provenance, get_provenance, should_fetch
+from .compliance import check_license
+
+__all__ = ["record_provenance", "get_provenance", "should_fetch", "check_license"]

--- a/provenance/compliance.py
+++ b/provenance/compliance.py
@@ -1,0 +1,70 @@
+"""License compliance utilities."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+from urllib.parse import urlparse
+
+import requests
+
+ALLOWED_LICENSES = {
+    "CC BY-SA 3.0",
+    "CC BY-SA 4.0",
+    "MIT",
+    "Apache-2.0",
+}
+
+
+def _github_api_license(owner: str, repo: str) -> str:
+    """Return the license identifier for a GitHub repository."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/license"
+    try:
+        resp = requests.get(url, timeout=5)
+        if resp.ok:
+            data = resp.json()
+            lic = data.get("license", {}).get("spdx_id") or data.get("license", {}).get(
+                "name"
+            )
+            if lic:
+                return lic
+    except Exception:
+        pass
+    return "unknown"
+
+
+def check_license(url: str, allowed: Iterable[str] = ALLOWED_LICENSES) -> str:
+    """Check the license for ``url`` and ensure it is allowed.
+
+    Parameters
+    ----------
+    url:
+        Source URL.
+    allowed:
+        Iterable of accepted license identifiers.
+
+    Returns
+    -------
+    str
+        Detected license identifier or ``"unknown"``.
+
+    Raises
+    ------
+    ValueError
+        If a license is detected but not in ``allowed``.
+    """
+
+    domain = urlparse(url).netloc.lower()
+    license_id = "unknown"
+    if "wikipedia.org" in domain:
+        license_id = "CC BY-SA 3.0"
+    elif "github.com" in domain:
+        parts = urlparse(url).path.strip("/").split("/")
+        if len(parts) >= 2:
+            license_id = _github_api_license(parts[0], parts[1])
+    if license_id != "unknown" and allowed and license_id not in set(allowed):
+        raise ValueError(f"License {license_id} for {url} not allowed")
+    return license_id
+
+
+__all__ = ["check_license"]

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -1942,6 +1942,14 @@ class DatasetBuilder:
         except Exception:
             pass
 
+        try:
+            from provenance.compliance import check_license
+
+            lic = check_license(record["metadata"]["source_url"])
+            record["metadata"]["license"] = lic
+        except Exception:
+            record["metadata"]["license"] = "unknown"
+
         # Determine quality classification when possible
         if extra_metadata:
             if any(
@@ -2434,7 +2442,9 @@ class DatasetBuilder:
 
         for rec in self.dataset:
             if "content" in rec:
-                rec["content"] = dq.strip_credentials(rec["content"])
+                rec["content"] = dq.remove_pii(dq.strip_credentials(rec["content"]))
+            if "summary" in rec:
+                rec["summary"] = dq.remove_pii(rec["summary"])
 
         # Remove near-duplicates based on Simhash
         try:
@@ -2575,10 +2585,16 @@ class DatasetBuilder:
                 item.get("metadata", {}).get("source", "unknown")
                 for item in sorted_data
             }
+            licenses = {
+                item.get("metadata", {}).get("license", "unknown")
+                for item in sorted_data
+            }
             info = {
                 "source": list(sources)[0] if len(sources) == 1 else sorted(sources),
                 "collection_date": datetime.utcnow().date().isoformat(),
-                "license": "CC BY-SA 4.0",
+                "license": (
+                    list(licenses)[0] if len(licenses) == 1 else sorted(licenses)
+                ),
                 "version": new_version,
                 "size": len(sorted_data),
             }

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -58,6 +58,12 @@ def test_strip_credentials_replaces_tokens():
     assert "<REDACTED>" in sanitized
 
 
+def test_remove_pii_redacts_data():
+    text = "Contact me at user@example.com or call 555-123-4567"
+    cleaned = dq.remove_pii(text)
+    assert "<PII>" in cleaned
+
+
 def test_detect_code_plagiarism_flags_duplicates():
     recs = [
         {"content": "print('hi')"},

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -1926,3 +1926,33 @@ def test_save_dataset_strips_credentials(tmp_path, monkeypatch):
 
     data = json.loads((tmp_path / "wikipedia_qa.json").read_text(encoding="utf-8"))
     assert "<REDACTED>" in data[0]["content"]
+
+
+def test_save_dataset_removes_pii(tmp_path, monkeypatch):
+    builder = sw.DatasetBuilder()
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 5)
+    builder.dataset = [
+        {
+            "id": "1",
+            "title": "t",
+            "language": "en",
+            "category": "c",
+            "topic": "ai",
+            "subtopic": "nlp",
+            "keywords": [],
+            "content": "Contact me at user@example.com",
+            "summary": "s" * 20,
+            "content_embedding": [0.0],
+            "summary_embedding": [0.0],
+            "questions": ["q"],
+            "answers": ["a"],
+            "relations": [],
+            "created_at": "now",
+            "metadata": {},
+        }
+    ]
+
+    builder.save_dataset("json", output_dir=tmp_path)
+
+    data = json.loads((tmp_path / "wikipedia_qa.json").read_text(encoding="utf-8"))
+    assert "<PII>" in data[0]["content"]


### PR DESCRIPTION
## Summary
- add license compliance utilities and expose them
- store detected license in dataset records
- sanitize personal data before saving datasets
- document ethical scraping practices
- test new PII removal logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aefc9dde483209877133b0664e09e