### PR TITLE
Add code review and tutorial plugins

### DIFF
--- a/plugins/code_review_scraper.py
+++ b/plugins/code_review_scraper.py
@@ -1,0 +1,99 @@
+"""GitHub pull request and issue collector for code review datasets."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Tuple
+
+import requests
+
+from .base import Plugin
+
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubReviewScraper(Plugin):  # type: ignore[misc]
+    """Fetch pull request diffs and comments from GitHub repositories."""
+
+    def __init__(self, token: str | None = None, api_url: str | None = None) -> None:
+        self.api_url = api_url or "https://api.github.com"
+        self.token = token
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        return headers
+
+    def _parse_repo(self, repo_url: str) -> Tuple[str, str]:
+        parts = repo_url.rstrip("/").split("/")[-2:]
+        if len(parts) != 2:
+            raise ValueError("Invalid GitHub repository URL")
+        return parts[0], parts[1]
+
+    def fetch_items(
+        self, lang: str, category: str, since: str | None = None
+    ) -> List[Dict]:
+        """Return pull requests with diffs and comments for ``category`` repo."""
+        owner, repo = self._parse_repo(category)
+        params = {"state": "closed"}
+        if since:
+            params["since"] = since
+        url = f"{self.api_url}/repos/{owner}/{repo}/pulls"
+        resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+        resp.raise_for_status()
+        pulls = resp.json()
+        items: List[Dict] = []
+        for pr in pulls:
+            number = pr.get("number")
+            if number is None:
+                continue
+            diff_resp = requests.get(
+                f"{self.api_url}/repos/{owner}/{repo}/pulls/{number}",
+                headers={**self._headers(), "Accept": "application/vnd.github.v3.diff"},
+                timeout=30,
+            )
+            diff_resp.raise_for_status()
+            diff = diff_resp.text
+            comments_resp = requests.get(
+                f"{self.api_url}/repos/{owner}/{repo}/issues/{number}/comments",
+                headers=self._headers(),
+                timeout=30,
+            )
+            comments_resp.raise_for_status()
+            comments = [c.get("body", "") for c in comments_resp.json()]
+            items.append(
+                {
+                    "lang": lang,
+                    "category": category,
+                    "title": pr.get("title", ""),
+                    "diff": diff,
+                    "comments": comments,
+                    "html_url": pr.get("html_url", ""),
+                }
+            )
+        return items
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Return record combining diff and comments."""
+        record = {
+            "title": item.get("title", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "diff": item.get("diff", ""),
+            "comments": item.get("comments", []),
+            "link": item.get("html_url", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+# Registry alias
+Plugin = GitHubReviewScraper

--- a/plugins/tutorials_scraper.py
+++ b/plugins/tutorials_scraper.py
@@ -1,0 +1,56 @@
+"""Fetch programming tutorials from Medium, Dev.to and freeCodeCamp."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+import requests
+from bs4 import BeautifulSoup
+import html2text
+
+from .base import Plugin
+
+logger = logging.getLogger(__name__)
+
+
+class TutorialsScraper(Plugin):  # type: ignore[misc]
+    """Retrieve tutorial articles for dataset generation."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return a single item with the tutorial HTML."""
+        resp = requests.get(category, timeout=30)
+        resp.raise_for_status()
+        return [
+            {
+                "lang": lang,
+                "category": category,
+                "url": category,
+                "html": resp.text,
+            }
+        ]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Extract plain text from tutorial HTML."""
+        html = item.get("html", "")
+        soup = BeautifulSoup(html, "html.parser")
+        title = soup.title.string if soup.title else item.get("url", "")
+        text = html2text.html2text(html) if hasattr(html2text, "html2text") else html
+        record = {
+            "title": title,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": text,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+# Alias for registry
+Plugin = TutorialsScraper

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -97,6 +97,7 @@ from enrichment.generator import (
     generate_explanations,
     link_theory,
 )
+from utils.sonarqube import analyze_code
 
 
 # ============================
@@ -1933,6 +1934,10 @@ class DatasetBuilder:
                 "source_url": f"{get_base_url(lang)}/wiki/{title.replace(' ', '_')}",
             },
         }
+
+        metrics_sq = analyze_code(content)
+        if metrics_sq:
+            record.setdefault("origin_metrics", {})["sonarqube"] = metrics_sq
 
         try:
             from provenance.tracker import record_provenance

--- a/tests/test_new_plugins.py
+++ b/tests/test_new_plugins.py
@@ -205,3 +205,51 @@ def test_notebooks_plugin(monkeypatch):
     parsed = plugin.parse_item(items[0])
     assert parsed["notebook"] == '{"nb":1}'
     _check_defaults(parsed)
+
+
+def test_tutorials_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *a, **k: DummyResp(text="<html><title>T</title><p>A</p></html>"),
+    )
+    mod = importlib.import_module("plugins.tutorials_scraper")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "https://example.com")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["title"] == "T"
+    _check_defaults(parsed)
+
+
+def test_code_review_scraper(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/pulls"):
+            return DummyResp(data=[{"number": 1, "title": "PR", "html_url": "u"}])
+        if url.endswith("/pulls/1"):
+            return DummyResp(text="diff")
+        if url.endswith("/issues/1/comments"):
+            return DummyResp(data=[{"body": "c"}])
+        return DummyResp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.code_review_scraper")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "https://github.com/u/r")
+    parsed = plugin.parse_item(items[0])
+    assert parsed["diff"] == "diff"
+    assert parsed["comments"] == ["c"]
+    _check_defaults(parsed)

--- a/utils/sonarqube.py
+++ b/utils/sonarqube.py
@@ -1,0 +1,32 @@
+"""Minimal SonarQube API integration for static analysis."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def analyze_code(code: str) -> Dict[str, float]:
+    """Analyze ``code`` using a SonarQube server if configured."""
+    url = os.getenv("SONARQUBE_URL")
+    token = os.getenv("SONARQUBE_TOKEN")
+    if not url or not token:
+        return {}
+    try:
+        resp = requests.post(
+            f"{url}/api/measure/analyze",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"code": code},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("measures", {})
+    except Exception as e:  # pragma: no cover - network issues
+        logger.error("SonarQube analysis failed: %s", e)
+        return {}


### PR DESCRIPTION
## Summary
- create `GitHubReviewScraper` for pull request diffs and comments
- create `TutorialsScraper` to fetch programming tutorials
- integrate SonarQube static analysis into dataset builder
- expose SonarQube helper utility
- test new plugins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fpdf')*

------
https://chatgpt.com/codex/tasks/task_e_685af91facac83208f83199e2c510f78