### PR TITLE
Add pre-commit with linting and type checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3.11
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,24 @@ Run the command from the repository root. New features should include appropriat
 - Format all modified files with **black** (line length 88).
 - Write docstrings using the **Google** style.
 
+## Pre-commit hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run **black**,
+**flake8**, **isort** and **mypy** automatically. Install the hooks once after
+cloning the repository:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+After installation the checks will run on each commit. You can trigger them
+manually for all files with:
+
+```bash
+pre-commit run --all-files
+```
+
 You can format the entire repository by running:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.isort]
+profile = "black"
+line_length = 88
+known_first_party = ["scraper_wiki"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with black, flake8, isort and mypy
- configure formatting, linting and typing via `pyproject.toml` and `.flake8`
- document pre-commit usage in `CONTRIBUTING.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685b0d62e348832080008135e97b4f52