### PR TITLE
Add DVC for dataset versioning

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,5 @@
+[core]
+    remote = storage
+
+[remote "storage"]
+    url = s3://scraper-wiki-dvc

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,5 +19,11 @@ jobs:
           grep -vE '^(tensorflow|sentence-transformers|transformers|spacy|torch|tensorflow-gpu|apache-airflow|mlflow|optuna|selenium)' requirements.txt > req.txt
           pip install -r req.txt
           pip install pytest
+          pip install 'dvc[s3]'
+      - name: Pull DVC data
+        run: dvc pull
       - name: Run tests
         run: pytest
+      - name: Push DVC data
+        if: always()
+        run: dvc push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/datasets_wikipedia_pro

--- a/README.md
+++ b/README.md
@@ -433,6 +433,25 @@ from training.formats import publish_hf_dataset
 publish_hf_dataset(records, "usuario/meu-dataset", token="hf_xxx")
 ```
 
+## Versionamento de Dados com DVC
+
+Os datasets gerados em `datasets_wikipedia_pro/` são versionados com
+[DVC](https://dvc.org). Após clonar o repositório execute:
+
+```bash
+dvc pull
+```
+
+Esse comando baixa a última versão disponível no armazenamento remoto
+configurado. Para publicar novas versões após gerar dados, utilize:
+
+```bash
+dvc add datasets_wikipedia_pro
+git add datasets_wikipedia_pro.dvc .gitignore
+git commit -m "Atualiza dados"
+dvc push
+```
+
 ## Integração com frameworks de ML
 
 Os arquivos gerados em `training/` permitem treinar modelos de NLP de forma simples. A seguir alguns exemplos.

--- a/api/api_app.py
+++ b/api/api_app.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from fastapi import FastAPI, Query, Request
+from fastapi import FastAPI, Query as FastQuery, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import scraper_wiki as sw
@@ -105,8 +105,8 @@ async def scrape(params: ScrapeParams):
 
 @app.get("/records")
 async def get_records(
-    lang: Optional[List[str]] | Optional[str] = Query(None),
-    category: Optional[List[str]] | Optional[str] = Query(None),
+    lang: List[str] | None = FastQuery(None),
+    category: List[str] | None = FastQuery(None),
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
 ):

--- a/datasets_wikipedia_pro.dvc
+++ b/datasets_wikipedia_pro.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: d751713988987e9331980363e24189ce.dir
+  size: 0
+  nfiles: 0
+  hash: md5
+  path: datasets_wikipedia_pro

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ selenium>=4.20.0  # optional
 mlflow>=2.12.1  # optional
 optuna>=3.6.1  # optional
 apache-airflow>=2.9.1  # optional
+dvc[s3]>=3.0


### PR DESCRIPTION
## Summary
- initialize DVC repository and ignore output dataset folder
- track datasets_wikipedia_pro with DVC and configure S3 remote
- document how to pull/push dataset versions via DVC
- update CI workflow to pull and push DVC data
- fix FastAPI `Query` name clash in api_app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b275644c4832095505eaf30274026