### PR TITLE
Add Playwright backend for AutoLearnerScraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ plugins disponíveis são `api_docs`, `code_extractor`, `gist_scraper`,
 campo `plugin` na API para escolher qual utilizar.
 
 O módulo `crawling.auto_learner` inclui ainda o `AutoLearnerScraper`, um
-gerador de datasets que utiliza Selenium e `fake-useragent` para navegar por
-páginas dinâmicas. Ele pode ser executado de forma independente:
+gerador de datasets que utiliza Selenium ou Playwright, além de `fake-useragent`,
+para navegar por páginas dinâmicas. Ele pode ser executado de forma independente:
 
 ```python
 from core import AutoLearnerScraper
@@ -204,6 +204,10 @@ records = scraper.build_dataset(["python"])
 dataset = convert_records_to_dataset(records, "pt", "Programação")
 scraper.close()
 ```
+
+Defina `--scraper-backend playwright` ou a variável `SCRAPER_BACKEND=playwright`
+para usar Playwright. Após instalar o pacote com `pip install playwright`,
+execute `playwright install` para baixar os navegadores necessários.
 
 ### Otimizando workers assíncronos
 

--- a/cli.py
+++ b/cli.py
@@ -42,6 +42,12 @@ def main(
     storage_backend: str = typer.Option(
         None, "--storage-backend", help="Backend de armazenamento", show_default=False
     ),
+    scraper_backend: str = typer.Option(
+        None,
+        "--scraper-backend",
+        help="Backend do AutoLearnerScraper (selenium ou playwright)",
+        show_default=False,
+    ),
 ):
     if cache_backend is not None:
         scraper_wiki.Config.CACHE_BACKEND = cache_backend
@@ -64,6 +70,8 @@ def main(
         scraper_wiki.Config.MAX_PROCESSES = max_processes
     if storage_backend is not None:
         scraper_wiki.Config.STORAGE_BACKEND = storage_backend
+    if scraper_backend is not None:
+        scraper_wiki.Config.SCRAPER_BACKEND = scraper_backend
 
 
 QUEUE_FILE = Path("jobs_queue.jsonl")
@@ -273,7 +281,7 @@ def auto_scrape(
         base = f"{parsed.scheme}://{parsed.netloc}"
         sc = scrapers.get(base)
         if sc is None:
-            sc = AutoLearnerScraper(base)
+            sc = AutoLearnerScraper(base, backend=scraper_wiki.Config.SCRAPER_BACKEND)
             scrapers[base] = sc
         return sc
 

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -184,6 +184,7 @@ class Config:
     SQLITE_PATH = os.path.join(CACHE_DIR, "cache.sqlite")
     CACHE_TTL: Optional[int] = int(os.environ.get("CACHE_TTL", "0")) or None
     STORAGE_BACKEND = os.environ.get("STORAGE_BACKEND", "local")
+    SCRAPER_BACKEND = os.environ.get("SCRAPER_BACKEND", "selenium")
     LOG_SERVICE_URL = os.environ.get("LOG_SERVICE_URL")
     LOG_SERVICE_TYPE = os.environ.get("LOG_SERVICE_TYPE", "loki")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,43 @@ sys.modules.setdefault(
     "selenium.webdriver.common", ModuleType("selenium.webdriver.common")
 )
 sys.modules.setdefault("selenium.webdriver.common.by", by_stub)
+# Stub Playwright API
+playwright_sync_mod = ModuleType("playwright.sync_api")
+
+
+class _DummyPage:
+    def goto(self, url):
+        pass
+
+    def content(self):
+        return ""
+
+
+class _DummyBrowser:
+    def new_page(self):
+        return _DummyPage()
+
+
+class _DummyPlaywright:
+    def __init__(self):
+        self.chromium = SimpleNamespace(launch=lambda headless=True: _DummyBrowser())
+
+    def start(self):
+        return self
+
+    def stop(self):
+        pass
+
+
+def sync_playwright():
+    return _DummyPlaywright()
+
+
+playwright_sync_mod.sync_playwright = sync_playwright
+playwright_mod = ModuleType("playwright")
+playwright_mod.sync_api = playwright_sync_mod
+sys.modules.setdefault("playwright", playwright_mod)
+sys.modules.setdefault("playwright.sync_api", playwright_sync_mod)
 
 # Stub Selenium-based scraper to avoid heavy dependencies
 auto_stub = ModuleType("crawling.auto_learner")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -443,7 +443,9 @@ def test_auto_scrape_command(monkeypatch):
     records = []
 
     class DummyScraper:
-        def __init__(self, base_url, driver_path=None, headless=True):
+        def __init__(
+            self, base_url, driver_path=None, headless=True, backend="selenium"
+        ):
             self.base_url = base_url
             self.driver = SimpleNamespace(page_source="")
 
@@ -471,3 +473,45 @@ def test_auto_scrape_command(monkeypatch):
     assert result.exit_code == 0
     assert records == ["http://example.com/page"]
     assert json.loads(result.output) == [{"url": "http://example.com/page"}]
+
+
+def test_auto_scrape_backend_option(monkeypatch):
+    called = {}
+
+    class DummyScraper:
+        def __init__(
+            self, base_url, driver_path=None, headless=True, backend="selenium"
+        ):
+            called["backend"] = backend
+            self.base_url = base_url
+            self.driver = SimpleNamespace(page_source="")
+
+        def fetch_page(self, url):
+            return {"url": url}
+
+        def close(self):
+            pass
+
+    auto_mod = ModuleType("crawling.auto_learner")
+    auto_mod.AutoLearnerScraper = DummyScraper
+    sys.modules["crawling.auto_learner"] = auto_mod
+    import importlib
+
+    core = importlib.import_module("core")
+
+    monkeypatch.setattr(core, "AutoLearnerScraper", DummyScraper)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            "--scraper-backend",
+            "playwright",
+            "auto-scrape",
+            "http://example.com/page",
+            "--depth",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert called["backend"] == "playwright"


### PR DESCRIPTION
## Summary
- support Playwright in AutoLearnerScraper with selectable backend
- expose `SCRAPER_BACKEND` option via CLI and config
- mock Playwright in tests and cover CLI option
- document Playwright usage and install steps in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2bab77388320982546580885e2d9