### PR TITLE
Add social media scrapers

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -43,6 +43,10 @@ AVAILABLE_PLUGINS = {
     "bitbucket_scraper": "bitbucket_scraper",
     "sourceforge_scraper": "sourceforge_scraper",
     "notebooks": "notebooks",
+    "reddit": "reddit",
+    "twitter": "twitter",
+    "youtube_transcripts": "youtube_transcripts",
+    "python_docs": "python_docs",
 }
 
 

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,5 +1,11 @@
-"""Plugin interface definition."""
+"""Plugin interface definition and basic helpers."""
+
 from typing import List, Dict, Protocol, runtime_checkable
+
+import requests
+
+from scraper_wiki import Config, RateLimiter
+
 
 @runtime_checkable
 class Plugin(Protocol):
@@ -12,3 +18,29 @@ class Plugin(Protocol):
     def parse_item(self, item: Dict) -> Dict:
         """Convert a raw item into a dataset entry."""
         ...
+
+
+class BasePlugin:
+    """Base class implementing rate limiting and deduplication."""
+
+    def __init__(self) -> None:
+        self.rate_limiter = RateLimiter(Config.RATE_LIMIT_DELAY)
+        self._seen: set[str] = set()
+
+    def request(self, url: str, **kwargs) -> requests.Response:
+        """Perform a GET request respecting rate limits."""
+        self.rate_limiter.wait()
+        resp = requests.get(url, timeout=Config.TIMEOUT, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def deduplicate(self, items: List[Dict], key: str = "id") -> List[Dict]:
+        """Remove items with repeated identifiers."""
+        unique: List[Dict] = []
+        for it in items:
+            identifier = it.get(key)
+            if identifier is None or identifier not in self._seen:
+                if identifier is not None:
+                    self._seen.add(identifier)
+                unique.append(it)
+        return unique

--- a/plugins/python_docs.py
+++ b/plugins/python_docs.py
@@ -1,0 +1,48 @@
+"""Plugin for scraping Python official documentation."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import html2text
+
+from .base import BasePlugin
+
+
+class PythonDocsPlugin(BasePlugin):
+    """Fetch pages from docs.python.org."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        super().__init__()
+        self.base_url = base_url or "https://docs.python.org/3"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for a documentation page."""
+        url = f"{self.base_url}/{category}"
+        return [{"url": url, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and parse a documentation page."""
+        url = item.get("url")
+        if not url:
+            return {}
+        resp = self.request(url)
+        html = resp.text
+        text = html2text.html2text(html) if hasattr(html2text, "html2text") else html
+        record = {
+            "url": url,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": text,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = PythonDocsPlugin

--- a/plugins/reddit.py
+++ b/plugins/reddit.py
@@ -1,0 +1,67 @@
+"""Reddit scraping plugin using PRAW."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import praw
+
+from .base import BasePlugin
+
+
+class RedditPlugin(BasePlugin):
+    """Fetch posts from popular subreddits."""
+
+    def __init__(
+        self,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        user_agent: str | None = None,
+        subreddits: List[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.reddit = praw.Reddit(
+            client_id=client_id or "",
+            client_secret=client_secret or "",
+            user_agent=user_agent or "scraper-wiki",
+        )
+        self.subreddits = subreddits or ["programming", "learnpython"]
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return recent posts for configured subreddits."""
+        items: List[Dict] = []
+        for sub in self.subreddits:
+            for post in self.reddit.subreddit(sub).hot(limit=10):
+                it = {
+                    "id": post.id,
+                    "title": post.title,
+                    "selftext": getattr(post, "selftext", ""),
+                    "url": post.url,
+                    "subreddit": sub,
+                    "lang": lang,
+                    "category": category,
+                }
+                items.append(it)
+        return self.deduplicate(items)
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Convert a Reddit submission into a dataset record."""
+        record = {
+            "title": item.get("title", ""),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": item.get("selftext", ""),
+            "url": item.get("url", ""),
+            "subreddit": item.get("subreddit", ""),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = RedditPlugin

--- a/plugins/twitter.py
+++ b/plugins/twitter.py
@@ -1,0 +1,52 @@
+"""Twitter scraping plugin using the v2 API."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import requests
+
+from .base import BasePlugin
+
+
+class TwitterPlugin(BasePlugin):
+    """Fetch tweets matching a search query."""
+
+    def __init__(self, bearer_token: str | None = None) -> None:
+        super().__init__()
+        self.bearer_token = bearer_token or ""
+        self.api_url = "https://api.twitter.com/2/tweets/search/recent"
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return recent tweets for the given query."""
+        headers = {"Authorization": f"Bearer {self.bearer_token}"}
+        params = {"query": category, "max_results": 10}
+        resp = self.request(self.api_url, headers=headers, params=params)
+        data = resp.json()
+        items = data.get("data", [])
+        for it in items:
+            it["lang"] = lang
+            it["category"] = category
+        return self.deduplicate(items)
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Convert a tweet to a dataset record."""
+        record = {
+            "id": item.get("id"),
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": item.get("text", ""),
+            "author_id": item.get("author_id"),
+            "created_at": item.get("created_at"),
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = TwitterPlugin

--- a/plugins/youtube_transcripts.py
+++ b/plugins/youtube_transcripts.py
@@ -1,0 +1,43 @@
+"""Plugin fetching YouTube video transcripts."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from youtube_transcript_api import YouTubeTranscriptApi
+
+from .base import BasePlugin
+
+
+class YouTubeTranscriptPlugin(BasePlugin):
+    """Retrieve transcripts for YouTube videos."""
+
+    def fetch_items(self, lang: str, category: str) -> List[Dict]:
+        """Return descriptor for the given video ID or URL."""
+        video_id = category.split("v=")[-1].split("/")[-1]
+        return [{"video_id": video_id, "lang": lang, "category": category}]
+
+    def parse_item(self, item: Dict) -> Dict:
+        """Download and join transcript lines."""
+        vid = item.get("video_id")
+        if not vid:
+            return {}
+        transcript = YouTubeTranscriptApi.get_transcript(vid)
+        text = " ".join(seg.get("text", "") for seg in transcript)
+        record = {
+            "video_id": vid,
+            "language": item.get("lang", "en"),
+            "category": item.get("category", ""),
+            "content": text,
+        }
+        record.setdefault("raw_code", "")
+        record.setdefault("context", "")
+        record.setdefault("problems", [])
+        record.setdefault("fixed_version", "")
+        record.setdefault("lessons", "")
+        record.setdefault("origin_metrics", {})
+        record.setdefault("challenge", "")
+        return record
+
+
+Plugin = YouTubeTranscriptPlugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,5 @@ optuna>=3.6.1  # optional
 apache-airflow>=2.9.1  # optional
 dvc[s3]>=3.0
 structlog>=24.1.0
+praw>=7.7.1
+youtube-transcript-api>=0.6.2

--- a/tests/test_social_plugins.py
+++ b/tests/test_social_plugins.py
@@ -1,0 +1,136 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+scraper_stub = ModuleType("scraper_wiki")
+scraper_stub.Config = SimpleNamespace(TIMEOUT=5, RATE_LIMIT_DELAY=0)
+scraper_stub.RateLimiter = lambda delay: SimpleNamespace(wait=lambda: None)
+sys.modules.setdefault("scraper_wiki", scraper_stub)
+sys.modules.setdefault("html2text", SimpleNamespace(html2text=lambda x: x))
+
+
+def _check_defaults(record):
+    for field in [
+        "raw_code",
+        "context",
+        "problems",
+        "fixed_version",
+        "lessons",
+        "origin_metrics",
+        "challenge",
+    ]:
+        assert field in record
+
+
+class DummyResp:
+    def __init__(self, data=None, text=""):
+        self._data = data
+        self._text = text
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+    @property
+    def text(self):
+        return self._text
+
+
+def test_reddit_plugin(monkeypatch):
+    praw_mod = ModuleType("praw")
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    class DummyPost:
+        def __init__(self, id_):
+            self.id = id_
+            self.title = "T"
+            self.selftext = "C"
+            self.url = "u"
+
+    class DummySub:
+        def hot(self, limit=10):
+            return [DummyPost("1")]
+
+    praw_mod.Reddit = lambda *a, **k: SimpleNamespace(subreddit=lambda n: DummySub())
+    monkeypatch.setitem(sys.modules, "praw", praw_mod)
+
+    mod = importlib.import_module("plugins.reddit")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "x")
+    assert items[0]["subreddit"] == "programming"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["content"] == "C"
+    _check_defaults(parsed)
+
+
+def test_twitter_plugin(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        return DummyResp(
+            data={
+                "data": [{"id": "1", "text": "T", "author_id": "a", "created_at": "d"}]
+            }
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    mod = importlib.import_module("plugins.twitter")
+    plugin = mod.Plugin(bearer_token="t")
+    items = plugin.fetch_items("en", "dev")
+    assert items[0]["id"] == "1"
+    parsed = plugin.parse_item(items[0])
+    assert parsed["content"] == "T"
+    _check_defaults(parsed)
+
+
+def test_youtube_transcripts_plugin(monkeypatch):
+    yta_mod = ModuleType("youtube_transcript_api")
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+    yta_mod.YouTubeTranscriptApi = SimpleNamespace(
+        get_transcript=lambda vid: [{"text": "A"}, {"text": "B"}]
+    )
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api", yta_mod)
+
+    mod = importlib.import_module("plugins.youtube_transcripts")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "https://youtu.be/abc?v=abc")
+    parsed = plugin.parse_item(items[0])
+    assert "A" in parsed["content"]
+    _check_defaults(parsed)
+
+
+def test_python_docs_plugin(monkeypatch):
+    import requests
+
+    core_stub = ModuleType("core")
+    core_stub.builder = SimpleNamespace(DatasetBuilder=object)
+    monkeypatch.setitem(sys.modules, "core", core_stub)
+    monkeypatch.setitem(sys.modules, "core.builder", core_stub.builder)
+
+    monkeypatch.setattr(
+        requests, "get", lambda url, timeout=None: DummyResp(text="<h1>T</h1>Doc")
+    )
+    mod = importlib.import_module("plugins.python_docs")
+    plugin = mod.Plugin()
+    items = plugin.fetch_items("en", "library/functions.html")
+    assert items[0]["url"].endswith("functions.html")
+    parsed = plugin.parse_item(items[0])
+    assert "Doc" in parsed["content"]
+    _check_defaults(parsed)


### PR DESCRIPTION
## Summary
- implement BasePlugin with rate limiting and dedup helpers
- add scrapers for Reddit, Twitter, YouTube transcripts and Python docs
- register new plugins
- include dependencies praw and youtube-transcript-api
- test new plugins with mocked responses

## Testing
- `black plugins/base.py plugins/reddit.py plugins/twitter.py plugins/youtube_transcripts.py plugins/python_docs.py plugins/__init__.py tests/test_social_plugins.py`
- `pytest tests/test_social_plugins.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3c882a408320863e39ed0a664b76