### PR TITLE
Add dataset compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ python main.py --url "https://en.wikipedia.org/wiki/Python" --output csv
 python main.py --file urls.txt --output parquet
 ```
 
+Use `--compress gzip` ou `--compress zstd` para salvar arquivos compactados, economizando espaço em disco.
+
 ### Normalização de categorias e busca automática
 
 Os nomes de categoria passam por um processo de normalização que remove
@@ -146,6 +148,9 @@ Os valores suportados são `local` (padrão), `s3`/`minio`, `mongodb`, `postgres
 Para S3/MinIO defina `S3_BUCKET` e `S3_ENDPOINT` (ou `MINIO_ENDPOINT`).
 Para MongoDB use `MONGODB_URI`. Para PostgreSQL defina `POSTGRES_DSN`.
 Para Apache Iceberg/Delta Lake defina `DATALAKE_PATH`. Para Neo4j utilize `NEO4J_URI`, `NEO4J_USER` e `NEO4J_PASSWORD`. Para bancos vetoriais use `MILVUS_URI` e `MILVUS_COLLECTION` ou `WEAVIATE_URI`.
+
+Os arquivos podem ser comprimidos com `--compress gzip` ou `--compress zstd` ao salvar.
+Isso reduz o espaço ocupado em até 70% (zstd) com custo mínimo de CPU na escrita e leitura.
 
 O backend também pode ser escolhido definindo `STORAGE_BACKEND=<opção>`
 no ambiente (por exemplo `STORAGE_BACKEND=postgres`). Cada backend possui

--- a/api/api_app.py
+++ b/api/api_app.py
@@ -8,6 +8,7 @@ import json
 from datetime import datetime
 import graphene
 from utils.text import clean_text, extract_entities
+from utils.compression import load_json_file
 import asyncio
 from search import indexer
 
@@ -20,8 +21,7 @@ PROGRESS_FILE = os.path.join(sw.Config.LOG_DIR, "progress.json")
 def load_dataset() -> List[dict]:
     if not os.path.exists(DATA_FILE):
         return []
-    with open(DATA_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+    return load_json_file(DATA_FILE)
 
 
 def load_progress() -> dict:

--- a/cli.py
+++ b/cli.py
@@ -42,6 +42,12 @@ def main(
     storage_backend: str = typer.Option(
         None, "--storage-backend", help="Backend de armazenamento", show_default=False
     ),
+    compress: str = typer.Option(
+        None,
+        "--compress",
+        help="Compressão (none, gzip, zstd)",
+        show_default=False,
+    ),
     scraper_backend: str = typer.Option(
         None,
         "--scraper-backend",
@@ -70,6 +76,8 @@ def main(
         scraper_wiki.Config.MAX_PROCESSES = max_processes
     if storage_backend is not None:
         scraper_wiki.Config.STORAGE_BACKEND = storage_backend
+    if compress is not None:
+        scraper_wiki.Config.COMPRESSION = compress
     if scraper_backend is not None:
         scraper_wiki.Config.SCRAPER_BACKEND = scraper_backend
 

--- a/integrations/storage.py
+++ b/integrations/storage.py
@@ -1,6 +1,7 @@
 import os
 import json
 import csv
+from pathlib import Path
 from typing import List
 
 
@@ -35,7 +36,11 @@ class StorageBackend:
     """Interface for storage backends."""
 
     def save_dataset(
-        self, data: List[dict], fmt: str = "all", version: str | None = None
+        self,
+        data: List[dict],
+        fmt: str = "all",
+        version: str | None = None,
+        compression: str = "none",
     ) -> None:
         raise NotImplementedError
 
@@ -46,17 +51,41 @@ class LocalStorage(StorageBackend):
         os.makedirs(output_dir, exist_ok=True)
 
     def save_dataset(
-        self, data: List[dict], fmt: str = "all", version: str | None = None
+        self,
+        data: List[dict],
+        fmt: str = "all",
+        version: str | None = None,
+        compression: str = "none",
     ) -> None:
         if fmt in ["all", "json"]:
             json_file = os.path.join(self.output_dir, "wikipedia_qa.json")
             with open(json_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=4)
+            if compression != "none":
+                from utils.compression import compress_bytes
+
+                raw = Path(json_file).read_bytes()
+                comp = compress_bytes(raw, compression)
+                ext = ".zst" if compression == "zstd" else ".gz"
+                comp_path = json_file + ext
+                Path(comp_path).write_bytes(comp)
+                os.remove(json_file)
+                json_file = comp_path
         if fmt in ["all", "jsonl"]:
             jsonl_file = os.path.join(self.output_dir, "wikipedia_qa.jsonl")
             with open(jsonl_file, "w", encoding="utf-8") as f:
                 for row in data:
                     f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            if compression != "none":
+                from utils.compression import compress_bytes
+
+                raw = Path(jsonl_file).read_bytes()
+                comp = compress_bytes(raw, compression)
+                ext = ".zst" if compression == "zstd" else ".gz"
+                comp_path = jsonl_file + ext
+                Path(comp_path).write_bytes(comp)
+                os.remove(jsonl_file)
+                jsonl_file = comp_path
         if fmt in ["all", "csv"]:
             csv_file = os.path.join(self.output_dir, "wikipedia_qa.csv")
             with open(csv_file, "w", newline="", encoding="utf-8") as f:
@@ -74,6 +103,16 @@ class LocalStorage(StorageBackend):
                     }
                     rows.append(converted)
                 writer.writerows(rows)
+            if compression != "none":
+                from utils.compression import compress_bytes
+
+                raw = Path(csv_file).read_bytes()
+                comp = compress_bytes(raw, compression)
+                ext = ".zst" if compression == "zstd" else ".gz"
+                comp_path = csv_file + ext
+                Path(comp_path).write_bytes(comp)
+                os.remove(csv_file)
+                csv_file = comp_path
         if fmt in ["all", "parquet"]:
             try:
                 import pyarrow as pa
@@ -82,6 +121,16 @@ class LocalStorage(StorageBackend):
                 parquet_file = os.path.join(self.output_dir, "wikipedia_qa.parquet")
                 table = pa.Table.from_pylist(data)
                 pq.write_table(table, parquet_file)
+                if compression != "none":
+                    from utils.compression import compress_bytes
+
+                    raw = Path(parquet_file).read_bytes()
+                    comp = compress_bytes(raw, compression)
+                    ext = ".zst" if compression == "zstd" else ".gz"
+                    comp_path = parquet_file + ext
+                    Path(comp_path).write_bytes(comp)
+                    os.remove(parquet_file)
+                    parquet_file = comp_path
             except Exception:
                 pass
         if fmt in ["all", "tfrecord"]:
@@ -94,6 +143,16 @@ class LocalStorage(StorageBackend):
                         writer.write(
                             json.dumps(row, ensure_ascii=False).encode("utf-8")
                         )
+                if compression != "none":
+                    from utils.compression import compress_bytes
+
+                    raw = Path(tf_path).read_bytes()
+                    comp = compress_bytes(raw, compression)
+                    ext = ".zst" if compression == "zstd" else ".gz"
+                    comp_path = tf_path + ext
+                    Path(comp_path).write_bytes(comp)
+                    os.remove(tf_path)
+                    tf_path = comp_path
             except Exception:
                 pass
         _maybe_upload_large(data, "wikipedia_qa.json")
@@ -126,19 +185,39 @@ class S3Storage(StorageBackend):
         return f"{self.prefix}/{name}" if self.prefix else name
 
     def save_dataset(
-        self, data: List[dict], fmt: str = "all", version: str | None = None
+        self,
+        data: List[dict],
+        fmt: str = "all",
+        version: str | None = None,
+        compression: str = "none",
     ) -> None:
         if fmt in ["all", "json"]:
             body = json.dumps(data, ensure_ascii=False, indent=4).encode("utf-8")
+            from utils.compression import compress_bytes
+
+            body = compress_bytes(body, compression)
+            ext = (
+                ".zst"
+                if compression == "zstd"
+                else ".gz" if compression != "none" else ""
+            )
             self.s3.put_object(
-                Bucket=self.bucket, Key=self._key("wikipedia_qa.json"), Body=body
+                Bucket=self.bucket,
+                Key=self._key(f"wikipedia_qa.json{ext}"),
+                Body=body,
             )
         if fmt in ["all", "jsonl"]:
             lines = "\n".join(json.dumps(row, ensure_ascii=False) for row in data)
+            body = compress_bytes(lines.encode("utf-8"), compression)
+            ext = (
+                ".zst"
+                if compression == "zstd"
+                else ".gz" if compression != "none" else ""
+            )
             self.s3.put_object(
                 Bucket=self.bucket,
-                Key=self._key("wikipedia_qa.jsonl"),
-                Body=lines.encode("utf-8"),
+                Key=self._key(f"wikipedia_qa.jsonl{ext}"),
+                Body=body,
             )
         if fmt in ["all", "csv"]:
             import io
@@ -157,10 +236,16 @@ class S3Storage(StorageBackend):
                         for k, v in row.items()
                     }
                 )
+            body = compress_bytes(buffer.getvalue().encode("utf-8"), compression)
+            ext = (
+                ".zst"
+                if compression == "zstd"
+                else ".gz" if compression != "none" else ""
+            )
             self.s3.put_object(
                 Bucket=self.bucket,
-                Key=self._key("wikipedia_qa.csv"),
-                Body=buffer.getvalue().encode("utf-8"),
+                Key=self._key(f"wikipedia_qa.csv{ext}"),
+                Body=body,
             )
         if fmt in ["all", "parquet"]:
             try:
@@ -170,10 +255,16 @@ class S3Storage(StorageBackend):
                 table = pa.Table.from_pylist(data)
                 buf = pa.BufferOutputStream()
                 pq.write_table(table, buf)
+                body = compress_bytes(buf.getvalue().to_pybytes(), compression)
+                ext = (
+                    ".zst"
+                    if compression == "zstd"
+                    else ".gz" if compression != "none" else ""
+                )
                 self.s3.put_object(
                     Bucket=self.bucket,
-                    Key=self._key("wikipedia_qa.parquet"),
-                    Body=buf.getvalue().to_pybytes(),
+                    Key=self._key(f"wikipedia_qa.parquet{ext}"),
+                    Body=body,
                 )
             except Exception:
                 pass
@@ -192,9 +283,17 @@ class S3Storage(StorageBackend):
                     tmp.flush()
                     tmp.seek(0)
                     body = tmp.read()
+                from utils.compression import compress_bytes
+
+                body = compress_bytes(body, compression)
+                ext = (
+                    ".zst"
+                    if compression == "zstd"
+                    else ".gz" if compression != "none" else ""
+                )
                 self.s3.put_object(
                     Bucket=self.bucket,
-                    Key=self._key("wikipedia_qa.tfrecord"),
+                    Key=self._key(f"wikipedia_qa.tfrecord{ext}"),
                     Body=body,
                 )
             except Exception:

--- a/integrations/storage_datalake.py
+++ b/integrations/storage_datalake.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import List
 from integrations.storage import StorageBackend
 
@@ -11,7 +12,11 @@ class DatalakeStorage(StorageBackend):
         os.makedirs(path, exist_ok=True)
 
     def save_dataset(
-        self, data: List[dict], fmt: str = "all", version: str | None = None
+        self,
+        data: List[dict],
+        fmt: str = "all",
+        version: str | None = None,
+        compression: str = "none",
     ) -> None:
         try:
             import pyarrow as pa
@@ -29,3 +34,16 @@ class DatalakeStorage(StorageBackend):
             partitioning=["lang", "domain"],
             existing_data_behavior="overwrite_or_ignore",
         )
+        if compression != "none":
+            from utils.compression import compress_bytes
+            import glob
+
+            ext = ".zst" if compression == "zstd" else ".gz"
+            for file in glob.glob(
+                os.path.join(self.path, "**", "*.parquet"), recursive=True
+            ):
+                raw = Path(file).read_bytes()
+                comp = compress_bytes(raw, compression)
+                comp_path = file + ext
+                Path(comp_path).write_bytes(comp)
+                os.remove(file)

--- a/integrations/storage_sqlite.py
+++ b/integrations/storage_sqlite.py
@@ -5,7 +5,10 @@ from typing import Optional
 
 
 def save_to_db(
-    data: dict, table: str = "infoboxes", db_path: str = "infoboxes.sqlite"
+    data: dict,
+    table: str = "infoboxes",
+    db_path: str = "infoboxes.sqlite",
+    compression: str = "none",
 ) -> None:
     """Save a dictionary as a JSON blob in the given SQLite table."""
     dir_name = os.path.dirname(db_path)
@@ -13,12 +16,18 @@ def save_to_db(
         os.makedirs(dir_name, exist_ok=True)
     conn = sqlite3.connect(db_path)
     try:
+        dtype = "BLOB" if compression != "none" else "TEXT"
         conn.execute(
-            f"CREATE TABLE IF NOT EXISTS {table} (id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT)"
+            f"CREATE TABLE IF NOT EXISTS {table} (id INTEGER PRIMARY KEY AUTOINCREMENT, data {dtype})"
         )
+        payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        if compression != "none":
+            from utils.compression import compress_bytes
+
+            payload = compress_bytes(payload, compression)
         conn.execute(
             f"INSERT INTO {table} (data) VALUES (?)",
-            (json.dumps(data, ensure_ascii=False),),
+            (payload,),
         )
         conn.commit()
     finally:

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -192,6 +192,7 @@ class Config:
     SQLITE_PATH = os.path.join(CACHE_DIR, "cache.sqlite")
     CACHE_TTL: Optional[int] = int(os.environ.get("CACHE_TTL", "0")) or None
     STORAGE_BACKEND = os.environ.get("STORAGE_BACKEND", "local")
+    COMPRESSION = os.environ.get("COMPRESSION", "none")
     SCRAPER_BACKEND = os.environ.get("SCRAPER_BACKEND", "selenium")
     LOG_SERVICE_URL = os.environ.get("LOG_SERVICE_URL")
     LOG_SERVICE_TYPE = os.environ.get("LOG_SERVICE_TYPE", "loki")
@@ -2651,7 +2652,12 @@ class DatasetBuilder:
         old_size = old_info.get("size", 0)
         new_version = _bump(old_version)
 
-        backend.save_dataset(sorted_data, format, version=new_version)
+        backend.save_dataset(
+            sorted_data,
+            format,
+            version=new_version,
+            compression=Config.COMPRESSION,
+        )
         logger.info(f"Dataset salvo usando backend {Config.STORAGE_BACKEND}")
 
         if format == "qa":

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -67,3 +67,27 @@ def test_s3_save_tfrecord(monkeypatch):
         "Key": "pre/dataset_version.txt",
         "Body": b"2.0.0",
     }
+
+
+def test_s3_compression(monkeypatch):
+    class DummyClient:
+        def __init__(self):
+            self.kwargs = None
+
+        def put_object(self, Bucket, Key, Body):
+            self.kwargs = {"Bucket": Bucket, "Key": Key, "Body": Body}
+
+    dummy = DummyClient()
+    monkeypatch.setitem(
+        sys.modules, "boto3", SimpleNamespace(client=lambda *a, **k: dummy)
+    )
+    import importlib
+
+    storage_mod = importlib.reload(importlib.import_module("integrations.storage"))
+    s3 = storage_mod.S3Storage("b", prefix="p", client=dummy)
+    data = [{"z": 2}]
+    s3.save_dataset(data, fmt="json", compression="gzip")
+    assert dummy.kwargs["Key"].endswith("wikipedia_qa.json.gz")
+    import gzip, json as js
+
+    assert js.loads(gzip.decompress(dummy.kwargs["Body"]).decode()) == data

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -18,6 +18,18 @@ def test_save_to_db_creates_table_and_inserts(tmp_path):
     assert json.loads(row[0]) == data
 
 
+def test_save_to_db_compression(tmp_path):
+    db_file = tmp_path / "c.sqlite"
+    data = {"x": 5}
+    save_to_db(data, table="info", db_path=str(db_file), compression="gzip")
+    conn = sqlite3.connect(db_file)
+    row = conn.execute("SELECT data FROM info").fetchone()[0]
+    conn.close()
+    import gzip
+
+    assert json.loads(gzip.decompress(row).decode()) == data
+
+
 def test_metadata_functions(tmp_path):
     db_file = tmp_path / "meta.sqlite"
     assert get_last_processed("repo", db_path=str(db_file)) is None

--- a/training/pipeline.py
+++ b/training/pipeline.py
@@ -12,9 +12,10 @@ from .formats import (
 
 
 def load_dataset(path: str | Path) -> List[Dict]:
-    """Load dataset from JSON file."""
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+    """Load dataset from JSON file with optional compression."""
+    from utils.compression import load_json_file
+
+    return load_json_file(path)
 
 
 def save_json(data, path: str | Path) -> None:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,6 +7,7 @@ from .text import (
 )
 from .relation import extract_relations
 from .cleaner import clean_wiki_text, split_sentences
+from .compression import compress_bytes, decompress_bytes, load_json_file
 from .code import (
     normalize_indentation,
     remove_comments,
@@ -39,4 +40,7 @@ __all__ = [
     "search_discussions",
     "normalize_url",
     "decide_navigation_action",
+    "compress_bytes",
+    "decompress_bytes",
+    "load_json_file",
 ]

--- a/utils/compression.py
+++ b/utils/compression.py
@@ -1,0 +1,45 @@
+import gzip
+import io
+from pathlib import Path
+
+
+def compress_bytes(data: bytes, algorithm: str) -> bytes:
+    """Return ``data`` compressed with the given ``algorithm``."""
+    alg = algorithm.lower() if algorithm else "none"
+    if alg == "gzip":
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as fh:
+            fh.write(data)
+        return buf.getvalue()
+    if alg == "zstd":
+        import zstandard as zstd
+
+        return zstd.ZstdCompressor().compress(data)
+    return data
+
+
+def decompress_bytes(data: bytes, algorithm: str) -> bytes:
+    """Decompress ``data`` previously compressed with ``algorithm``."""
+    alg = algorithm.lower() if algorithm else "none"
+    if alg == "gzip":
+        return gzip.decompress(data)
+    if alg == "zstd":
+        import zstandard as zstd
+
+        return zstd.ZstdDecompressor().decompress(data)
+    return data
+
+
+def load_json_file(path: str | Path) -> list[dict]:
+    """Load JSON dataset possibly compressed by extension."""
+    p = Path(path)
+    data = p.read_bytes()
+    if p.suffix == ".gz":
+        data = gzip.decompress(data)
+    elif p.suffix == ".zst":
+        import zstandard as zstd
+
+        data = zstd.ZstdDecompressor().decompress(data)
+    import json
+
+    return json.loads(data.decode("utf-8"))


### PR DESCRIPTION
## Summary
- support optional compression in storage backends
- handle compressed JSON loading in the API and training pipeline
- add CLI flag `--compress`
- document compression usage in README
- add tests for S3 and SQLite compressed output

## Testing
- `black utils/compression.py utils/__init__.py scraper_wiki/__init__.py integrations/storage.py integrations/storage_datalake.py integrations/storage_sqlite.py cli.py training/pipeline.py api/api_app.py tests/test_storage.py tests/test_storage_sqlite.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*
- `pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685b3ef1d6448320811933d46f705fba