### PR TITLE
Add MLflow logging and tutorial

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,10 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
+  mlflow:
+    image: mlflow/mlflow:latest
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./mlruns:/mlflow
+    command: mlflow server --backend-store-uri /mlflow --default-artifact-root /mlflow --host 0.0.0.0

--- a/examples/mlflow_fine_tuning.ipynb
+++ b/examples/mlflow_fine_tuning.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Fine-tuning com MLflow"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Este notebook demonstra como treinar um modelo simples enquanto registra parametros e m\u00e9tricas no MLflow."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "!pip install -q transformers datasets mlflow"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from datasets import load_dataset\nfrom transformers import AutoTokenizer, AutoModelForSequenceClassification, TrainingArguments, Trainer\nimport mlflow\n\ndataset = load_dataset('imdb', split='train[:1%]')\ntokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')\ntokenized = dataset.map(lambda x: tokenizer(x['text'], truncation=True, padding='max_length'), batched=True)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "mlflow.set_tracking_uri('http://localhost:5000')\nwith mlflow.start_run():\n    mlflow.log_param('model', 'bert-base-uncased')\n    mlflow.log_param('dataset_size', len(tokenized))\n    model = AutoModelForSequenceClassification.from_pretrained('bert-base-uncased', num_labels=2)\n    args = TrainingArguments('out', num_train_epochs=1, per_device_train_batch_size=8)\n    trainer = Trainer(model=model, args=args, train_dataset=tokenized.select(range(32)), tokenizer=tokenizer)\n    trainer.train()\n    metrics = trainer.evaluate()\n    mlflow.log_metrics({k: float(v) for k, v in metrics.items()})"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_pretrained_utils.py
+++ b/tests/test_pretrained_utils.py
@@ -6,44 +6,66 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+
 # Stub torch and transformers before import
 class DummyTensor:
     def __init__(self, data):
         self.data = data
 
-sys.modules['torch'] = SimpleNamespace(Tensor=DummyTensor)
+
+sys.modules["torch"] = SimpleNamespace(Tensor=DummyTensor)
+
 
 class DummyTokenizer:
-    def __call__(self, texts, padding=True, truncation=True, return_tensors='pt'):
-        return {'input_ids': DummyTensor(texts)}
+    def __call__(self, texts, padding=True, truncation=True, return_tensors="pt"):
+        return {"input_ids": DummyTensor(texts)}
 
-sys.modules['transformers'] = SimpleNamespace(
+
+sys.modules["transformers"] = SimpleNamespace(
     BertTokenizer=SimpleNamespace(from_pretrained=lambda name: DummyTokenizer())
 )
 
-pretrained_utils = importlib.import_module('training.pretrained_utils')
+
+# Stub mlflow to avoid creating real runs
+class DummyRun:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+sys.modules["mlflow"] = SimpleNamespace(
+    start_run=lambda *a, **k: DummyRun(),
+    log_param=lambda *a, **k: None,
+    log_metric=lambda *a, **k: None,
+)
+
+pretrained_utils = importlib.import_module("training.pretrained_utils")
 
 
 def test_prepare_bert_inputs():
-    res = pretrained_utils.prepare_bert_inputs(['a', 'b'])
-    assert isinstance(res['input_ids'], DummyTensor)
-    assert res['input_ids'].data == ['a', 'b']
+    res = pretrained_utils.prepare_bert_inputs(["a", "b"])
+    assert isinstance(res["input_ids"], DummyTensor)
+    assert res["input_ids"].data == ["a", "b"]
 
 
 def test_extract_image_dataset(tmp_path, monkeypatch):
-    recs = [{'image_url': 'http://x/img.jpg', 'caption': 'cap'}]
+    recs = [{"image_url": "http://x/img.jpg", "caption": "cap"}]
 
     def fake_get(url, timeout=10):
         class Resp:
-            content = b'img'
+            content = b"img"
+
             def raise_for_status(self):
                 pass
-        assert url == 'http://x/img.jpg'
+
+        assert url == "http://x/img.jpg"
         return Resp()
 
-    monkeypatch.setattr(pretrained_utils.requests, 'get', fake_get)
+    monkeypatch.setattr(pretrained_utils.requests, "get", fake_get)
 
     pretrained_utils.extract_image_dataset(recs, tmp_path)
-    assert (tmp_path / '00000.jpg').exists()
-    text = (tmp_path / 'captions.txt').read_text(encoding='utf-8')
-    assert 'cap' in text
+    assert (tmp_path / "00000.jpg").exists()
+    text = (tmp_path / "captions.txt").read_text(encoding="utf-8")
+    assert "cap" in text

--- a/training/pipeline.py
+++ b/training/pipeline.py
@@ -1,6 +1,9 @@
 import json
+import hashlib
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional
+
+import mlflow
 
 from .formats import (
     save_arrow_dataset,
@@ -54,23 +57,45 @@ def convert_to_triples(records: List[Dict]) -> List[Dict]:
     return triples
 
 
-def run_pipeline(dataset_path: str | Path) -> None:
-    """Run full conversion pipeline for training."""
+def _hash_file(path: Path) -> str:
+    """Return MD5 hash of ``path`` for dataset versioning."""
+    h = hashlib.md5()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_pipeline(
+    dataset_path: str | Path, model_params: Optional[Dict] | None = None
+) -> None:
+    """Run full conversion pipeline for training and log results with MLflow."""
     dataset_path = Path(dataset_path)
     records = load_dataset(dataset_path)
     base = dataset_path.with_suffix("")
 
-    pairs = convert_to_conversation_pairs(records)
-    save_json(pairs, base.with_name(base.name + "_pairs.json"))
+    dataset_version = _hash_file(dataset_path)
 
-    emb = convert_to_embeddings(records)
-    save_json(emb, base.with_name(base.name + "_embeddings.json"))
+    with mlflow.start_run():
+        mlflow.log_param("dataset_path", str(dataset_path))
+        mlflow.log_param("dataset_version", dataset_version)
+        if model_params:
+            mlflow.log_params(model_params)
 
-    triples = convert_to_triples(records)
-    save_json(triples, base.with_name(base.name + "_triples.json"))
+        pairs = convert_to_conversation_pairs(records)
+        mlflow.log_metric("num_pairs", len(pairs))
+        save_json(pairs, base.with_name(base.name + "_pairs.json"))
 
-    save_hf_dataset(records, base.with_name(base.name + "_hf"))
-    save_tfrecord_dataset(records, base.with_suffix(".tfrecord"))
-    save_arrow_table(records, base.with_suffix(".arrow"))
-    save_arrow_dataset(records, base.with_name(base.name + "_arrow_dataset"))
-    save_delta_table(records, base.with_name(base.name + "_delta"))
+        emb = convert_to_embeddings(records)
+        mlflow.log_metric("num_embeddings", len(emb))
+        save_json(emb, base.with_name(base.name + "_embeddings.json"))
+
+        triples = convert_to_triples(records)
+        mlflow.log_metric("num_triples", len(triples))
+        save_json(triples, base.with_name(base.name + "_triples.json"))
+
+        save_hf_dataset(records, base.with_name(base.name + "_hf"))
+        save_tfrecord_dataset(records, base.with_suffix(".tfrecord"))
+        save_arrow_table(records, base.with_suffix(".arrow"))
+        save_arrow_dataset(records, base.with_name(base.name + "_arrow_dataset"))
+        save_delta_table(records, base.with_name(base.name + "_delta"))

--- a/training/pretrained_utils.py
+++ b/training/pretrained_utils.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict, List
+import hashlib
+import json
+
+import mlflow
 
 import requests
 import torch
@@ -42,8 +46,11 @@ def prepare_bert_inputs(texts: List[str]) -> Dict[str, torch.Tensor]:
     ['input_ids', 'token_type_ids', 'attention_mask']
     """
 
-    tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
-    return tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
+    with mlflow.start_run(nested=True):
+        mlflow.log_param("tokenizer_name", "bert-base-uncased")
+        mlflow.log_metric("num_texts", len(texts))
+        tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+        return tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
 
 
 def extract_image_dataset(records: List[dict], out_dir: Path) -> None:
@@ -61,17 +68,27 @@ def extract_image_dataset(records: List[dict], out_dir: Path) -> None:
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+    dataset_version = hashlib.md5(
+        json.dumps(records, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
     captions = out_dir / "captions.txt"
-    with captions.open("w", encoding="utf-8") as cf:
-        for idx, rec in enumerate(records):
-            url = rec.get("image_url")
-            if not url:
-                continue
-            caption = rec.get("caption") or rec.get("title", "")
-            resp = requests.get(url, timeout=10)
-            resp.raise_for_status()
-            ext = Path(url).suffix or ".jpg"
-            name = f"{idx:05d}{ext}"
-            with open(out_dir / name, "wb") as img_f:
-                img_f.write(resp.content)
-            cf.write(f"{name}\t{caption}\n")
+    downloaded = 0
+    with mlflow.start_run(nested=True):
+        mlflow.log_param("dataset_version", dataset_version)
+        mlflow.log_param("output_dir", str(out_dir))
+        mlflow.log_metric("num_records", len(records))
+        with captions.open("w", encoding="utf-8") as cf:
+            for idx, rec in enumerate(records):
+                url = rec.get("image_url")
+                if not url:
+                    continue
+                caption = rec.get("caption") or rec.get("title", "")
+                resp = requests.get(url, timeout=10)
+                resp.raise_for_status()
+                ext = Path(url).suffix or ".jpg"
+                name = f"{idx:05d}{ext}"
+                with open(out_dir / name, "wb") as img_f:
+                    img_f.write(resp.content)
+                cf.write(f"{name}\t{caption}\n")
+                downloaded += 1
+        mlflow.log_metric("images_downloaded", downloaded)


### PR DESCRIPTION
## Summary
- enable MLflow tracking in `training.pipeline` and `training.pretrained_utils`
- stub MLflow in tests
- spin up an MLflow server in `docker-compose.yml`
- add a sample MLflow fine‑tuning notebook

## Testing
- `pip install -q pytest mlflow requests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install -q beautifulsoup4 typer structlog httpx fpdf`
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b4233d59883208c22cf0f307d164d