### PR TITLE
Add Streamlit dashboard management features

### DIFF
--- a/api/api_app.py
+++ b/api/api_app.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import graphene
 from utils.text import clean_text, extract_entities
 from utils.compression import load_json_file
+from task_queue import publish, clear as clear_queue
 import asyncio
 from search import indexer
 
@@ -16,12 +17,23 @@ app = FastAPI()
 
 DATA_FILE = os.path.join(sw.Config.OUTPUT_DIR, "wikipedia_qa.json")
 PROGRESS_FILE = os.path.join(sw.Config.LOG_DIR, "progress.json")
+INFO_FILE = os.path.join(sw.Config.OUTPUT_DIR, "dataset_info.json")
 
 
 def load_dataset() -> List[dict]:
     if not os.path.exists(DATA_FILE):
         return []
     return load_json_file(DATA_FILE)
+
+
+def load_dataset_info() -> dict:
+    if not os.path.exists(INFO_FILE):
+        return {}
+    try:
+        with open(INFO_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
 
 
 def load_progress() -> dict:
@@ -75,6 +87,12 @@ class ScrapeParams(BaseModel):
     category: Optional[List[str]] | Optional[str] = None
     format: str = "all"
     plugin: str = "wikipedia"  # e.g. "infobox_parser" or "table_parser"
+
+
+class QueueItem(BaseModel):
+    url: Optional[str] = None
+    title: Optional[str] = None
+    lang: Optional[str] = None
 
 
 @app.post("/scrape")
@@ -132,6 +150,28 @@ async def search_endpoint(q: str):
     """Return records matching ``q`` from Elasticsearch."""
     results = await asyncio.to_thread(indexer.query_index, q)
     return results
+
+
+@app.get("/dataset/summary")
+async def dataset_summary():
+    """Return metadata about the generated dataset."""
+    return load_dataset_info()
+
+
+@app.post("/queue/add")
+async def queue_add(items: List[QueueItem]):
+    """Add scraping tasks to the queue."""
+    for item in items:
+        publish("scrape_tasks", item.model_dump(exclude_none=True))
+    return {"status": "ok", "queued": len(items)}
+
+
+@app.post("/queue/clear")
+async def queue_clear():
+    """Remove all pending scraping tasks and results."""
+    clear_queue("scrape_tasks")
+    clear_queue("scrape_results")
+    return {"status": "cleared"}
 
 
 class RecordType(graphene.ObjectType):

--- a/dashboard.py
+++ b/dashboard.py
@@ -11,6 +11,7 @@ import requests
 PROGRESS_FILE = Path("logs/progress.json")
 API_BASE = os.environ.get("API_BASE", "http://localhost:8000")
 PROM_URL = os.environ.get("PROMETHEUS_URL", "http://localhost:9090")
+LOG_FILE = Path(os.environ.get("LOG_FILE", "logs/scraper.log"))
 
 
 def load_progress():
@@ -26,6 +27,38 @@ def load_progress():
             except json.JSONDecodeError:
                 return {}
     return {}
+
+
+def load_dataset_info():
+    try:
+        resp = requests.get(f"{API_BASE}/dataset/summary", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        return {}
+
+
+def tail_logs(lines: int = 20) -> str:
+    if LOG_FILE.exists():
+        data = LOG_FILE.read_text(encoding="utf-8").splitlines()
+        return "\n".join(data[-lines:])
+    return ""
+
+
+def enqueue_tasks(tasks: list[dict]) -> bool:
+    try:
+        resp = requests.post(f"{API_BASE}/queue/add", json=tasks, timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def clear_tasks() -> bool:
+    try:
+        resp = requests.post(f"{API_BASE}/queue/clear", timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
 
 
 def load_metrics():
@@ -153,6 +186,28 @@ def detect_bias(langs: list[str], categories: list[str]) -> list[str]:
 def main():
     st.title("Scraper Progress Dashboard")
 
+    st.sidebar.header("Queue Management")
+    task_input = st.sidebar.text_area("URLs or titles", height=100)
+    if st.sidebar.button("Start/Enqueue"):
+        tasks = []
+        for line in task_input.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("http"):
+                tasks.append({"url": line})
+            else:
+                tasks.append({"title": line, "lang": "en"})
+        if tasks and enqueue_tasks(tasks):
+            st.sidebar.success("Tasks queued")
+        elif tasks:
+            st.sidebar.error("Failed to enqueue tasks")
+    if st.sidebar.button("Stop/Clear Queue"):
+        if clear_tasks():
+            st.sidebar.success("Queue cleared")
+        else:
+            st.sidebar.error("Failed to clear queue")
+
     progress = load_progress()
     metrics = load_metrics()
     pages_processed = progress.get("pages_processed", 0)
@@ -195,6 +250,14 @@ def main():
     st.write(languages)
     if bias_alerts:
         st.warning(" | ".join(bias_alerts))
+
+    info = load_dataset_info()
+    if info:
+        st.subheader("Dataset Summary")
+        st.json(info)
+
+    st.subheader("Recent Logs")
+    st.text(tail_logs(20))
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,17 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
+  dashboard:
+    build: .
+    command: streamlit run dashboard.py --server.port 8501 --server.address 0.0.0.0
+    environment:
+      - API_BASE=http://api:8000
+      - PROMETHEUS_URL=http://prometheus:9090
+    ports:
+      - "8501:8501"
+    depends_on:
+      - api
+      - prometheus
   mlflow:
     image: mlflow/mlflow:latest
     ports:

--- a/task_queue.py
+++ b/task_queue.py
@@ -22,6 +22,10 @@ class BaseQueue:
     def consume(self, queue: str):
         raise NotImplementedError
 
+    def clear(self, queue: str):
+        """Remove all pending messages from ``queue``."""
+        raise NotImplementedError
+
 
 class InMemoryQueue(BaseQueue):
     def __init__(self):
@@ -39,6 +43,9 @@ class InMemoryQueue(BaseQueue):
             msg = q.get()
             yield json.loads(msg)
             q.task_done()
+
+    def clear(self, queue: str):
+        self._get_queue(queue).queue.clear()
 
 
 class RabbitMQQueue(BaseQueue):
@@ -60,6 +67,9 @@ class RabbitMQQueue(BaseQueue):
                 self.channel.basic_ack(method.delivery_tag)
                 yield json.loads(body.decode())
 
+    def clear(self, queue: str):
+        self.channel.queue_purge(queue)
+
 
 class RedisQueue(BaseQueue):
     """Queue backend using Redis lists."""
@@ -77,6 +87,9 @@ class RedisQueue(BaseQueue):
             item = self.client.blpop(queue, timeout=1)
             if item:
                 yield json.loads(item[1])
+
+    def clear(self, queue: str):
+        self.client.delete(queue)
 
 
 _BACKEND = None
@@ -105,3 +118,8 @@ def publish(queue_name: str, message: dict):
 
 def consume(queue_name: str):
     yield from get_backend().consume(queue_name)
+
+
+def clear(queue_name: str) -> None:
+    """Clear all messages from ``queue_name``."""
+    get_backend().clear(queue_name)

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -98,6 +98,9 @@ def create_client(monkeypatch):
     monkeypatch.setattr(api_app.sw, "main", lambda *a, **k: None)
     monkeypatch.setattr(api_app.indexer, "query_index", lambda q: [{"id": 1}])
     monkeypatch.setattr(api_app, "extract_entities", lambda text: [])
+    monkeypatch.setattr(api_app, "load_dataset_info", lambda: {"source": "w"})
+    monkeypatch.setattr(api_app, "publish", lambda q, m: None)
+    monkeypatch.setattr(api_app, "clear_queue", lambda q: None)
     return TestClient(api_app.app)
 
 
@@ -134,3 +137,27 @@ def test_search_endpoint(monkeypatch):
     resp = client.get("/search", params={"q": "py"})
     assert resp.status_code == 200
     assert resp.json() == [{"id": 1}]
+
+
+def test_dataset_summary_endpoint(monkeypatch):
+    client = create_client(monkeypatch)
+    resp = client.get("/dataset/summary")
+    assert resp.status_code == 200
+    assert resp.json() == {"source": "w"}
+
+
+def test_queue_management(monkeypatch):
+    queued = []
+    cleared = []
+
+    monkeypatch.setattr(api_app, "publish", lambda q, m: queued.append((q, m)))
+    monkeypatch.setattr(api_app, "clear_queue", lambda q: cleared.append(q))
+
+    client = create_client(monkeypatch)
+    resp = client.post("/queue/add", json=[{"url": "http://x"}])
+    assert resp.status_code == 200
+    assert queued == [("scrape_tasks", {"url": "http://x"})]
+
+    resp = client.post("/queue/clear")
+    assert resp.status_code == 200
+    assert "scrape_tasks" in cleared


### PR DESCRIPTION
## Summary
- extend task queue module with queue clearing support
- expose dataset summary and queue management endpoints in API
- enhance Streamlit dashboard with queue controls, dataset view, logs
- add dashboard service to docker-compose
- test dataset summary and queue endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685b45a26e588320902444798a3779e2