### PR TITLE
Automated releases and dataset metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types:
+      - completed
+
+jobs:
+  release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pdoc huggingface_hub dvc
+
+      - name: Pull dataset
+        run: dvc pull || true
+
+      - name: Read version
+        id: version
+        run: echo "version=$(grep -m1 '^version =\"' pyproject.toml | cut -d '"' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate dataset metadata
+        run: |
+          VERSION=${{ steps.version.outputs.version }} scripts/generate_dataset_metadata.py datasets_wikipedia_pro dataset_metadata.json
+
+      - name: Generate docs
+        run: |
+          pdoc -o docs -d google integrations core plugins utils api
+          tar -czf docs.tar.gz docs
+
+      - name: Upload dataset to Hugging Face
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ secrets.HF_REPO }}
+        run: |
+          python - <<'PY'
+from pathlib import Path
+from training.formats import publish_hf_dataset
+import json, os
+records = []
+if Path('datasets_wikipedia_pro').exists():
+    for file in Path('datasets_wikipedia_pro').rglob('*.json'):
+        try:
+            records.extend(json.load(open(file)))
+        except Exception:
+            pass
+if records:
+    publish_hf_dataset(records, os.environ['HF_REPO'], token=os.environ.get('HF_TOKEN'))
+PY
+        continue-on-error: true
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          files: |
+            dataset_metadata.json
+            docs.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /datasets_wikipedia_pro
+dataset_metadata.json
+docs.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2024-06-13
+### Added
+- Initial release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,17 @@ pdoc -o docs -d google integrations core plugins utils api
 
 The output will appear inside the `docs/` directory.
 
+## Releases and Versioning
+
+Scraper Wiki follows [Semantic Versioning](https://semver.org/) for all
+releases. The current version is defined in `pyproject.toml` and tags are
+created as `vMAJOR.MINOR.PATCH`.
+
+- **MAJOR** version when you make incompatible API or dataset changes.
+- **MINOR** version when you add functionality in a backward compatible manner.
+- **PATCH** version when you make backward compatible bug fixes.
+
+
 ## Workflow
 
 1. Update docstrings and documentation when modifying code.

--- a/scripts/generate_dataset_metadata.py
+++ b/scripts/generate_dataset_metadata.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""Generate dataset metadata JSON."""
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def main(dataset_dir: str, output_file: str, version: str) -> None:
+    path = Path(dataset_dir)
+    size = 0
+    if path.exists():
+        for f in path.rglob("*"):
+            if f.is_file():
+                size += f.stat().st_size
+    metadata = {
+        "version": version,
+        "size_bytes": size,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+    }
+    with open(output_file, "w") as fh:
+        json.dump(metadata, fh)
+
+
+if __name__ == "__main__":
+    dataset_dir = sys.argv[1] if len(sys.argv) > 1 else "datasets_wikipedia_pro"
+    output_file = sys.argv[2] if len(sys.argv) > 2 else "dataset_metadata.json"
+    version = os.getenv("VERSION", "0.0.0")
+    main(dataset_dir, output_file, version)


### PR DESCRIPTION
## Summary
- document Semantic Versioning workflow
- start a `CHANGELOG.md`
- create release pipeline using GitHub Actions
- add script for dataset metadata generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx, bs4, structlog, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685b4c009b8c8320ab3fc89a081d8d07