### PR TITLE
Add Kubernetes and Terraform deployment resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ pdoc -o docs -d google integrations core plugins utils api
 ```
 
 See [docs/setup.md](docs/setup.md) for installation and configuration instructions and [docs/usage.md](docs/usage.md) for CLI and API examples.
+
+Additional deployment examples, including Kubernetes manifests and scaling guidance, are available in [docs/scaling.md](docs/scaling.md).

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,23 @@
+# Scaling Guidelines
+
+This document provides high level recommendations for deploying Scraper Wiki in a distributed environment.
+
+## Worker Sizing
+
+- **API**: Typically 1-2 replicas are sufficient. Each instance requires about **0.5 CPU** and **512Mi** of memory.
+- **Scraper Workers**: Start with the number of replicas defined in `cluster.yaml` (`workers: 4`). Each worker consumes roughly **1 CPU** and **1Gi** of memory.
+- **Dask/Ray Workers**: Match the value in `cluster.yaml`. A baseline of **1 CPU** and **2Gi** per worker is recommended.
+
+## Scheduler and Queue
+
+- The Dask scheduler is lightweight and can run with **0.5 CPU** and **512Mi** memory.
+- RabbitMQ should run with persistent storage (5–10Gi) and at least **0.5 CPU**.
+
+## Storage
+
+- Prometheus requires persistent volume of 10–20Gi for metrics retention.
+- Application logs and datasets can be stored on network volumes or object storage such as S3 or GCS.
+
+## Autoscaling
+
+Horizontal Pod Autoscaling can be enabled on the worker deployments using CPU utilization targets. Increase the node count in your Terraform modules to ensure sufficient capacity.

--- a/helm/scraper-wiki/Chart.yaml
+++ b/helm/scraper-wiki/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: scraper-wiki
+version: 0.1.0
+appVersion: "1.0"

--- a/helm/scraper-wiki/cluster.yaml
+++ b/helm/scraper-wiki/cluster.yaml
@@ -1,0 +1,9 @@
+cluster:
+  backend: dask  # or 'ray'
+  scheduler: tcp://scheduler:8786
+  workers: 4
+crawler:
+  crawl_delay: 1.0
+  max_pages: 100
+  start_urls: []
+  user_agent: ScraperWikiBot

--- a/helm/scraper-wiki/templates/api-deployment.yaml
+++ b/helm/scraper-wiki/templates/api-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scraper-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scraper-api
+  template:
+    metadata:
+      labels:
+        app: scraper-api
+    spec:
+      containers:
+      - name: api
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        command: ["uvicorn", "api.api_app:app", "--host", "0.0.0.0", "--port", "8000"]
+        env:
+        - name: QUEUE_URL
+          value: {{ .Values.queueUrl | quote }}
+        ports:
+        - containerPort: 8000

--- a/helm/scraper-wiki/templates/api-service.yaml
+++ b/helm/scraper-wiki/templates/api-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scraper-api
+spec:
+  selector:
+    app: scraper-api
+  ports:
+  - port: 8000
+    targetPort: 8000

--- a/helm/scraper-wiki/templates/cluster-configmap.yaml
+++ b/helm/scraper-wiki/templates/cluster-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-config
+binaryData:
+  cluster.yaml: |-
+    {{ (.Files.Get "cluster.yaml") | b64enc }}

--- a/helm/scraper-wiki/templates/worker-deployment.yaml
+++ b/helm/scraper-wiki/templates/worker-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scraper-worker
+spec:
+  replicas: {{ .Values.workers }}
+  selector:
+    matchLabels:
+      app: scraper-worker
+  template:
+    metadata:
+      labels:
+        app: scraper-worker
+    spec:
+      containers:
+      - name: worker
+        image: {{ .Values.workerImage.repository }}:{{ .Values.workerImage.tag }}
+        command: ["python", "worker.py"]
+        env:
+        - name: QUEUE_URL
+          value: {{ .Values.queueUrl | quote }}
+        - name: METRICS_PORT
+          value: "8001"
+        ports:
+        - containerPort: 8001

--- a/helm/scraper-wiki/templates/worker-service.yaml
+++ b/helm/scraper-wiki/templates/worker-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scraper-worker
+spec:
+  selector:
+    app: scraper-worker
+  ports:
+  - port: 8001
+    targetPort: 8001

--- a/helm/scraper-wiki/values.yaml
+++ b/helm/scraper-wiki/values.yaml
@@ -1,0 +1,8 @@
+image:
+  repository: myrepo/scraper-wiki
+  tag: latest
+workerImage:
+  repository: myrepo/scraper-wiki-worker
+  tag: latest
+queueUrl: amqp://guest:guest@rabbitmq:5672/
+workers: 1

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scraper-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scraper-api
+  template:
+    metadata:
+      labels:
+        app: scraper-api
+    spec:
+      containers:
+      - name: api
+        image: myrepo/scraper-wiki:latest
+        command: ["uvicorn", "api.api_app:app", "--host", "0.0.0.0", "--port", "8000"]
+        env:
+        - name: QUEUE_URL
+          value: amqp://guest:guest@rabbitmq:5672/
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - name: cluster-config
+          mountPath: /config
+      volumes:
+      - name: cluster-config
+        configMap:
+          name: cluster-config

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scraper-api
+spec:
+  selector:
+    app: scraper-api
+  ports:
+  - port: 8000
+    targetPort: 8000
+    name: http
+  type: ClusterIP

--- a/k8s/cluster-config.yaml
+++ b/k8s/cluster-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-config
+data:
+  cluster.yaml: |
+    cluster:
+      backend: dask
+      scheduler: tcp://scheduler:8786
+      workers: 4
+    crawler:
+      crawl_delay: 1.0
+      max_pages: 100
+      start_urls: []
+      user_agent: ScraperWikiBot

--- a/k8s/dask-worker-deployment.yaml
+++ b/k8s/dask-worker-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dask-worker
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: dask-worker
+  template:
+    metadata:
+      labels:
+        app: dask-worker
+    spec:
+      containers:
+      - name: worker
+        image: daskdev/dask:latest
+        args: ["dask-worker", "scheduler:8786"]
+        env:
+        - name: EXTRA_APT_PACKAGES
+          value: ""

--- a/k8s/grafana-deployment.yaml
+++ b/k8s/grafana-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana
+        ports:
+        - containerPort: 3000

--- a/k8s/grafana-service.yaml
+++ b/k8s/grafana-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+  - port: 3000
+    targetPort: 3000
+    name: http
+  type: ClusterIP

--- a/k8s/prometheus-configmap.yaml
+++ b/k8s/prometheus-configmap.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+    scrape_configs:
+      - job_name: 'scraper'
+        static_configs:
+          - targets: ['worker:8001']
+        metrics_path: /
+    rule_files:
+      - alerts.yaml
+  alerts.yaml: |
+    # Example Prometheus alert rules
+    # Alerta se a taxa de erros ultrapassar 20% nas últimas 5 minutos
+    - alert: HighScrapeErrorRate
+      expr: rate(scrape_error_total[5m]) / (rate(scrape_success_total[5m]) + rate(scrape_error_total[5m])) > 0.2
+      for: 10m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Taxa alta de erros de scraping"
+        description: "Mais de 20% das requisições resultaram em erro por 10 minutos"
+    
+    # Alerta se nenhum scraping bem sucedido for registrado
+    - alert: ScrapeStalled
+      expr: rate(scrape_success_total[10m]) == 0
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Scraping sem sucesso"
+        description: "Nenhuma página foi raspada com sucesso nas últimas 15 minutos"
+    
+    # Alerta se a cobertura de idiomas estiver baixa
+    - alert: MissingLanguages
+      expr: dataset_language_coverage < 0.5
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Cobertura de idiomas baixa"
+        description: "Menos de 50% dos idiomas definidos estão presentes no dataset"
+    
+    # Alerta se os parsers não forem atualizados há mais de 7 dias
+    - alert: OutdatedParsers
+      expr: time() - scraper_parser_update_timestamp > 7 * 24 * 3600
+      for: 10m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Parsers desatualizados"
+        description: "Faz mais de 7 dias desde a última atualização dos parsers"
+    
+    # Alerta de uso elevado de CPU
+    - alert: HighCPUUsage
+      expr: cpu_usage_percent > 90
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Uso de CPU elevado"
+        description: "O uso de CPU do worker está acima de 90% por 5 minutos"
+    
+    # Alerta de uso elevado de memória
+    - alert: HighMemoryUsage
+      expr: memory_usage_percent > 90
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Uso de memória elevado"
+        description: "O uso de memória do worker está acima de 90% por 5 minutos"

--- a/k8s/prometheus-deployment.yaml
+++ b/k8s/prometheus-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus
+        args:
+        - "--config.file=/etc/prometheus/prometheus.yml"
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus/
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config

--- a/k8s/prometheus-service.yaml
+++ b/k8s/prometheus-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090
+    name: http
+  type: ClusterIP

--- a/k8s/scheduler-deployment.yaml
+++ b/k8s/scheduler-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dask-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dask-scheduler
+  template:
+    metadata:
+      labels:
+        app: dask-scheduler
+    spec:
+      containers:
+      - name: scheduler
+        image: daskdev/dask:latest
+        args: ["dask-scheduler"]
+        ports:
+        - containerPort: 8786

--- a/k8s/scheduler-service.yaml
+++ b/k8s/scheduler-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scheduler
+spec:
+  selector:
+    app: dask-scheduler
+  ports:
+  - port: 8786
+    targetPort: 8786
+    name: scheduler

--- a/k8s/scraper-worker-deployment.yaml
+++ b/k8s/scraper-worker-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scraper-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scraper-worker
+  template:
+    metadata:
+      labels:
+        app: scraper-worker
+    spec:
+      containers:
+      - name: worker
+        image: myrepo/scraper-wiki-worker:latest
+        command: ["python", "worker.py"]
+        env:
+        - name: QUEUE_URL
+          value: amqp://guest:guest@rabbitmq:5672/
+        - name: METRICS_PORT
+          value: "8001"
+        ports:
+        - containerPort: 8001
+        volumeMounts:
+        - name: cluster-config
+          mountPath: /config
+      volumes:
+      - name: cluster-config
+        configMap:
+          name: cluster-config

--- a/k8s/scraper-worker-service.yaml
+++ b/k8s/scraper-worker-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scraper-worker
+spec:
+  selector:
+    app: scraper-worker
+  ports:
+  - port: 8001
+    targetPort: 8001
+    name: metrics
+  type: ClusterIP

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -1,0 +1,17 @@
+# AWS EKS Module
+
+This Terraform module provisions an EKS cluster suitable for running the Scraper Wiki stack with Dask or Ray.
+
+## Usage
+
+```hcl
+module "eks" {
+  source        = "./terraform/aws"
+  region        = "us-east-1"
+  cluster_name  = "scraper-wiki"
+  vpc_id        = "vpc-123456"
+  subnet_ids    = ["subnet-1", "subnet-2"]
+  worker_count  = 4
+  instance_type = "m5.large"
+}
+```

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = var.cluster_name
+  cluster_version = "1.29"
+  subnet_ids      = var.subnet_ids
+  vpc_id          = var.vpc_id
+
+  node_groups = {
+    default = {
+      desired_capacity = var.worker_count
+      instance_type    = var.instance_type
+    }
+  }
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_name" {
+  value = module.eks.cluster_name
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,31 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets for EKS"
+  type        = list(string)
+}
+
+variable "worker_count" {
+  description = "Number of worker nodes"
+  type        = number
+  default     = 3
+}
+
+variable "instance_type" {
+  description = "Worker node instance type"
+  type        = string
+  default     = "m5.large"
+}

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -1,0 +1,18 @@
+# GCP GKE Module
+
+This Terraform module provisions a GKE cluster for running the Scraper Wiki stack with Dask or Ray.
+
+## Usage
+
+```hcl
+module "gke" {
+  source       = "./terraform/gcp"
+  project      = "my-project"
+  region       = "us-central1"
+  cluster_name = "scraper-wiki"
+  network      = "default"
+  subnetwork   = "default"
+  worker_count = 4
+  machine_type = "n1-standard-4"
+}
+```

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+module "gke" {
+  source  = "terraform-google-modules/kubernetes-engine/google"
+  version = "~> 30.0"
+
+  project_id = var.project
+  name       = var.cluster_name
+  region     = var.region
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  node_pools = [
+    {
+      name       = "default"
+      node_count = var.worker_count
+      machine_type = var.machine_type
+    }
+  ]
+}

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_endpoint" {
+  value = module.gke.endpoint
+}
+
+output "cluster_name" {
+  value = module.gke.name
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,0 +1,36 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "GKE cluster name"
+  type        = string
+}
+
+variable "network" {
+  description = "VPC network name"
+  type        = string
+}
+
+variable "subnetwork" {
+  description = "Subnetwork name"
+  type        = string
+}
+
+variable "worker_count" {
+  description = "Number of worker nodes"
+  type        = number
+  default     = 3
+}
+
+variable "machine_type" {
+  description = "GCE machine type"
+  type        = string
+  default     = "n1-standard-4"
+}


### PR DESCRIPTION
## Summary
- provide Kubernetes manifests for API, workers, scheduler and monitoring
- add Helm chart for scraper-wiki
- include Terraform modules for AWS and GCP clusters
- document scaling guidelines
- mention new docs in README

## Testing
- `pip install $packages` *(fails: Getting requirements to build wheel did not run successfully)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_685b56b645ec83209335513e01ab157b