### PR TITLE
Add active learning module

### DIFF
--- a/enrichment/active_learning.py
+++ b/enrichment/active_learning.py
@@ -1,0 +1,67 @@
+"""Active learning utilities for prioritizing scraping tasks."""
+
+from __future__ import annotations
+
+import heapq
+from typing import Iterable, List, Dict, Tuple
+
+import numpy as np
+
+from scraper_wiki import NLPProcessor
+from task_queue import publish
+
+
+class ActiveLearner:
+    """Score pages by diversity and publish high-value tasks first."""
+
+    def __init__(self) -> None:
+        self.embedding_model = NLPProcessor.get_embedding_model()
+        self.embeddings: List[np.ndarray] = []
+
+    def _compute_embedding(self, text: str) -> np.ndarray:
+        emb = self.embedding_model.encode(text, show_progress_bar=False)
+        arr = np.asarray(emb)
+        return arr[0] if arr.ndim > 1 else arr
+
+    def _diversity_score(self, emb: np.ndarray) -> float:
+        if not self.embeddings:
+            return 1.0
+        matrix = np.vstack(self.embeddings)
+        dots = matrix @ emb
+        norms = np.linalg.norm(matrix, axis=1) * np.linalg.norm(emb)
+        sim = (dots / (norms + 1e-9)).max()
+        return 1.0 - float(sim)
+
+    def update_from_record(self, record: Dict) -> None:
+        text = record.get("content")
+        emb = record.get("content_embedding")
+        if emb is None and text:
+            emb = self._compute_embedding(text)
+        else:
+            emb = np.asarray(emb, dtype=float)
+        if emb is not None:
+            self.embeddings.append(emb)
+
+    def score_pages(
+        self, pages: Iterable[Dict[str, str]]
+    ) -> List[Tuple[float, Dict[str, str]]]:
+        scored = []
+        for page in pages:
+            text = page.get("title") or page.get("url", "")
+            emb = self._compute_embedding(text)
+            score = self._diversity_score(emb)
+            scored.append((score, page))
+        return scored
+
+    def enqueue(
+        self, pages: Iterable[Dict[str, str]], queue: str = "scrape_tasks"
+    ) -> None:
+        scored = self.score_pages(pages)
+        heap = [(-score, page) for score, page in scored]
+        heapq.heapify(heap)
+        while heap:
+            _, page = heapq.heappop(heap)
+            publish(queue, page)
+
+
+__all__ = ["ActiveLearner"]

--- a/examples/active_learning.ipynb
+++ b/examples/active_learning.ipynb
@@ -1,0 +1,10 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": "# Active Learning Experiments"},
+  {"cell_type": "markdown", "metadata": {}, "source": "Demonstrates scoring pages and prioritizing scraping tasks using `ActiveLearner`."},
+  {"cell_type": "code", "execution_count": null, "metadata": {}, "outputs": [], "source": "from enrichment.active_learning import ActiveLearner\n\npages = [\n    {\"title\": \"Python (programming language)\"},\n    {\"title\": \"Artificial intelligence\"},\n    {\"title\": \"Monty Python\"},\n]\n\nlearner = ActiveLearner()\nlearner.enqueue(pages)"}
+ ],
+ "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python"}},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -1,0 +1,134 @@
+import sys
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy dependencies for scraper_wiki import
+placeholders = [
+    "sentence_transformers",
+    "datasets",
+    "spacy",
+    "unidecode",
+    "tqdm",
+    "html2text",
+    "bs4",
+    "aiohttp",
+    "backoff",
+    "sklearn",
+    "sklearn.cluster",
+    "sklearn.feature_extraction",
+    "sklearn.feature_extraction.text",
+    "sumy",
+    "sumy.parsers",
+    "sumy.parsers.plaintext",
+    "sumy.nlp",
+    "sumy.nlp.tokenizers",
+    "sumy.summarizers",
+    "sumy.summarizers.lsa",
+    "structlog",
+    "tenacity",
+    "networkx",
+    "mlflow",
+    "psutil",
+    "graphviz",
+]
+for name in placeholders:
+    sys.modules[name] = SimpleNamespace()
+sys.modules["spacy"] = SimpleNamespace(load=lambda *a, **k: SimpleNamespace())
+sys.modules["tqdm"] = SimpleNamespace(tqdm=lambda x, **k: x)
+sys.modules["unidecode"] = SimpleNamespace(unidecode=lambda x: x)
+sys.modules["bs4"] = SimpleNamespace(BeautifulSoup=lambda *a, **k: None)
+sys.modules["sklearn.cluster"] = SimpleNamespace(KMeans=object)
+sys.modules["sklearn.feature_extraction.text"] = SimpleNamespace(TfidfVectorizer=object)
+sys.modules["graphviz"] = SimpleNamespace(Digraph=object)
+sys.modules["psutil"] = SimpleNamespace(
+    cpu_percent=lambda interval=1: 0, virtual_memory=lambda: SimpleNamespace(percent=0)
+)
+sys.modules["structlog"] = SimpleNamespace(
+    configure=lambda *a, **k: None,
+    make_filtering_bound_logger=lambda level: SimpleNamespace(),
+    processors=SimpleNamespace(
+        add_log_level=None,
+        TimeStamper=lambda fmt=None: None,
+        JSONRenderer=lambda: None,
+        KeyValueRenderer=lambda: None,
+    ),
+    wrap_logger=lambda *a, **k: SimpleNamespace(),
+)
+sys.modules["backoff"] = SimpleNamespace(
+    on_exception=lambda *a, **k: (lambda f: f), expo=lambda *a, **k: None
+)
+sumy_mod = types.ModuleType("sumy")
+sumy_mod.__path__ = []
+parsers_mod = types.ModuleType("sumy.parsers")
+parsers_mod.__path__ = []
+plaintext_mod = types.ModuleType("sumy.parsers.plaintext")
+plaintext_mod.__path__ = []
+plaintext_mod.PlaintextParser = object
+parsers_mod.plaintext = plaintext_mod
+nlp_mod = types.ModuleType("sumy.nlp")
+nlp_mod.__path__ = []
+tokenizers_mod = types.ModuleType("sumy.nlp.tokenizers")
+tokenizers_mod.__path__ = []
+tokenizers_mod.Tokenizer = object
+nlp_mod.tokenizers = tokenizers_mod
+summarizers_mod = types.ModuleType("sumy.summarizers")
+summarizers_mod.__path__ = []
+lsa_mod = types.ModuleType("sumy.summarizers.lsa")
+lsa_mod.__path__ = []
+lsa_mod.LsaSummarizer = object
+summarizers_mod.lsa = lsa_mod
+sumy_mod.parsers = parsers_mod
+sumy_mod.nlp = nlp_mod
+sumy_mod.summarizers = summarizers_mod
+sys.modules["sumy"] = sumy_mod
+sys.modules["sumy.parsers"] = parsers_mod
+sys.modules["sumy.parsers.plaintext"] = plaintext_mod
+sys.modules["sumy.nlp"] = nlp_mod
+sys.modules["sumy.nlp.tokenizers"] = tokenizers_mod
+sys.modules["sumy.summarizers"] = summarizers_mod
+sys.modules["sumy.summarizers.lsa"] = lsa_mod
+
+wiki_stub = SimpleNamespace(
+    WikipediaException=Exception,
+    Namespace=SimpleNamespace(MAIN=0, CATEGORY=14),
+    ExtractFormat=SimpleNamespace(HTML=0),
+    Wikipedia=lambda *a, **k: SimpleNamespace(
+        page=lambda *a, **k: SimpleNamespace(exists=lambda: False),
+        api=SimpleNamespace(article_url=lambda x: ""),
+    ),
+    WikipediaPage=object,
+)
+sys.modules["wikipediaapi"] = wiki_stub
+
+
+class DummyEmbed:
+    def encode(self, texts, show_progress_bar=False):
+        import numpy as np
+
+        if isinstance(texts, str):
+            texts = [texts]
+        return np.array(
+            [[float(len(t)), float(sum(ord(c) for c in t) % 10)] for t in texts]
+        )
+
+
+def test_score_order(monkeypatch):
+    from scraper_wiki import NLPProcessor
+
+    monkeypatch.setattr(
+        NLPProcessor, "get_embedding_model", classmethod(lambda cls: DummyEmbed())
+    )
+
+    mod = importlib.import_module("enrichment.active_learning")
+    learner = mod.ActiveLearner()
+    learner.update_from_record({"content": "abc"})
+
+    pages = [{"title": "abcd"}, {"title": "efghij"}]
+    scored = learner.score_pages(pages)
+    assert scored[0][0] < scored[1][0]


### PR DESCRIPTION
## Summary
- introduce `ActiveLearner` for scoring and prioritizing pages
- add example usage notebook
- test active learning scoring logic

## Testing
- `pytest tests/test_active_learning.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'graphene', and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685bcc6954748320a8aadb7241560e2c