### PR TITLE
Add binary asset storage and update dataset schema

### DIFF
--- a/integrations/binary_storage.py
+++ b/integrations/binary_storage.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import requests
+
+
+class BinaryStorage:
+    """Simple local storage for binary assets."""
+
+    def __init__(self, base_path: str) -> None:
+        self.base_path = base_path
+        os.makedirs(base_path, exist_ok=True)
+
+    def save(self, url: str) -> str:
+        """Download ``url`` and return local file path."""
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        ext = Path(url).suffix or ".bin"
+        name = hashlib.md5(url.encode("utf-8")).hexdigest() + ext
+        path = Path(self.base_path) / name
+        with open(path, "wb") as fh:
+            fh.write(resp.content)
+        return str(path)

--- a/plugins/youtube_transcripts.py
+++ b/plugins/youtube_transcripts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict, List
 
 from youtube_transcript_api import YouTubeTranscriptApi
+from scraper_wiki import binary_storage
 
 from .base import BasePlugin
 
@@ -29,7 +30,15 @@ class YouTubeTranscriptPlugin(BasePlugin):
             "language": item.get("lang", "en"),
             "category": item.get("category", ""),
             "content": text,
+            "video_urls": [f"https://www.youtube.com/watch?v={vid}"],
         }
+        thumb_url = f"https://img.youtube.com/vi/{vid}/hqdefault.jpg"
+        try:
+            path = binary_storage.save(thumb_url)
+            record["image_paths"] = [path]
+        except Exception:
+            record["image_paths"] = []
+        record["thumbnail_url"] = thumb_url
         record.setdefault("raw_code", "")
         record.setdefault("context", "")
         record.setdefault("problems", [])

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -73,6 +73,7 @@ from integrations import storage
 import dq
 import metrics
 from integrations import storage_sqlite
+from integrations.binary_storage import BinaryStorage
 from utils.text import clean_text, extract_entities
 from utils.relation import extract_relations, extract_relations_regex
 from utils.quality import (
@@ -114,6 +115,7 @@ class Config:
     OUTPUT_DIR = "datasets_wikipedia_pro"
     CACHE_DIR = ".wiki_cache"
     LOG_DIR = "logs"
+    ASSETS_DIR = os.environ.get("ASSETS_DIR", "assets")
 
     # Categorias avançadas com pesos
     CATEGORIES = {
@@ -225,6 +227,9 @@ class Config:
 
 
 _proxy_index = 0
+
+# Storage for downloaded images and other binary assets
+binary_storage = BinaryStorage(Config.ASSETS_DIR)
 
 
 def _fetch_premium_proxy() -> str | None:
@@ -1706,8 +1711,19 @@ def cpu_process_page(
     record["entities"] = extract_entities(content)
     if images is not None:
         record["images"] = images
+        paths: List[str] = []
+        for img in images:
+            url = img.get("image_url")
+            if not url:
+                continue
+            try:
+                paths.append(binary_storage.save(url))
+            except Exception:
+                continue
+        record["image_paths"] = paths
     if videos:
         record["videos"] = videos
+        record["video_urls"] = videos
     if revisions is not None:
         record.setdefault("metadata", {})["revisions"] = revisions
     return record
@@ -1863,8 +1879,14 @@ class DatasetBuilder:
             images = extract_images(getattr(page, "_html", ""))
             videos = extract_videos(getattr(page, "_html", ""))
             qa_data["images"] = images
+            qa_data["image_paths"] = [
+                binary_storage.save(img["image_url"])
+                for img in images
+                if img.get("image_url")
+            ]
             if videos:
                 qa_data["videos"] = videos
+                qa_data["video_urls"] = videos
             if self.include_revisions:
                 qa_data.setdefault("metadata", {})["revisions"] = (
                     wiki.get_revision_history(page_info["title"], self.rev_limit)

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -557,7 +557,7 @@ def test_process_page_uses_clean_text(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({"title": "T", "lang": "en"})
 
-    assert res == {"entities": [], "images": []}
+    assert res == {"entities": [], "images": [], "image_paths": [], "video_urls": []}
     assert called["clean"] == "raw text"
     assert called["adv"] == ("cleaned", "en", True)
 
@@ -607,7 +607,13 @@ def test_process_page_increments_counter(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({"title": "T", "lang": "en"})
 
-    assert res == {"ok": True, "entities": [], "images": []}
+    assert res == {
+        "ok": True,
+        "entities": [],
+        "images": [],
+        "image_paths": [],
+        "video_urls": [],
+    }
     assert counts["pages"] == 1
 
 
@@ -656,8 +662,65 @@ def test_process_page_records_histogram(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({"title": "T", "lang": "en"})
 
-    assert res == {"ok": True, "entities": [], "images": []}
+    assert res == {
+        "ok": True,
+        "entities": [],
+        "images": [],
+        "image_paths": [],
+        "video_urls": [],
+    }
     assert observed["count"] == 1
+
+
+def test_process_page_downloads_assets(monkeypatch, tmp_path):
+    class DummyPage:
+        text = "t" * 200
+        _html = (
+            "<div class='thumb'><img src='http://x/img.jpg'/></div>"
+            "<video src='http://x/v.mp4'></video>"
+        )
+
+        def exists(self):
+            return True
+
+    class DummyWiki:
+        def __init__(self, lang):
+            pass
+
+        def fetch_page(self, title):
+            return DummyPage()
+
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 10)
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "clean_text", lambda t: t)
+    monkeypatch.setattr(
+        sw, "advanced_clean_text", lambda t, lang, remove_stopwords=False: t
+    )
+    monkeypatch.setattr(sw, "summarize_text", lambda *a, **k: "")
+    monkeypatch.setattr(
+        sw.DatasetBuilder, "generate_qa_pairs", lambda *a, **k: {"ok": True}
+    )
+    monkeypatch.setattr(sw, "extract_entities", lambda text: [])
+    monkeypatch.setattr(
+        sw.binary_storage, "save", lambda url: str(tmp_path / "img.jpg")
+    )
+    monkeypatch.setattr(
+        sw,
+        "metrics",
+        SimpleNamespace(
+            scrape_success=SimpleNamespace(inc=lambda: None),
+            scrape_error=SimpleNamespace(inc=lambda: None),
+            pages_scraped_total=SimpleNamespace(inc=lambda: None),
+            requests_failed_total=SimpleNamespace(inc=lambda: None),
+            page_processing_seconds=SimpleNamespace(observe=lambda v: None),
+        ),
+    )
+
+    builder = sw.DatasetBuilder()
+    res = builder.process_page({"title": "T", "lang": "en"})
+
+    assert res["image_paths"] == [str(tmp_path / "img.jpg")]
+    assert res["video_urls"] == ["http://x/v.mp4"]
 
 
 def test_save_dataset_json_csv(tmp_path, monkeypatch):

--- a/tests/test_social_plugins.py
+++ b/tests/test_social_plugins.py
@@ -22,6 +22,8 @@ def _check_defaults(record):
         "lessons",
         "origin_metrics",
         "challenge",
+        "image_paths",
+        "video_urls",
     ]:
         assert field in record
 
@@ -111,8 +113,11 @@ def test_youtube_transcripts_plugin(monkeypatch):
     mod = importlib.import_module("plugins.youtube_transcripts")
     plugin = mod.Plugin()
     items = plugin.fetch_items("en", "https://youtu.be/abc?v=abc")
+    monkeypatch.setattr(mod.binary_storage, "save", lambda url: "/tmp/thumb.jpg")
     parsed = plugin.parse_item(items[0])
     assert "A" in parsed["content"]
+    assert parsed["image_paths"] == ["/tmp/thumb.jpg"]
+    assert parsed["video_urls"] == ["https://www.youtube.com/watch?v=abc"]
     _check_defaults(parsed)
 
 


### PR DESCRIPTION
## Summary
- implement BinaryStorage for saving images locally
- persist image paths and video URLs in dataset builder
- enhance YouTube plugin to store thumbnails
- adjust default config with ASSETS_DIR and expose BinaryStorage
- update tests for new schema fields and behaviors

## Testing
- `pip install typer rich` *(failed: Installation halted due to network restrictions)*
- `pytest -q` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bd59a4f7c8320a7d4682aecec70c0