### PR TITLE
Add static quality metrics and expose via API

### DIFF
--- a/api/api_app.py
+++ b/api/api_app.py
@@ -193,6 +193,7 @@ class RecordType(graphene.ObjectType):
     subtopic = graphene.String()
     summary = graphene.String()
     created_at = graphene.String()
+    quality_score = graphene.Float()
 
 
 class Query(graphene.ObjectType):

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -22,7 +22,11 @@ import json
 import csv
 import random
 import logging
-import structlog
+
+try:
+    import structlog
+except Exception:  # pragma: no cover - optional dependency
+    structlog = None
 import asyncio
 import inspect
 from tqdm import tqdm
@@ -81,6 +85,7 @@ from utils.quality import (
     classify_stackoverflow_answer,
     balance_quality,
     generate_challenge_prompt,
+    evaluate_code_quality,
 )
 from utils.cleaner import clean_wiki_text, split_sentences
 from utils.code import (
@@ -154,6 +159,8 @@ class Config:
     MIN_TEXT_LENGTH = 150  # mínimo de caracteres para considerar uma página
     MAX_TEXT_LENGTH = 10000  # máximo de caracteres a extrair por página
     REMOVE_STOPWORDS = os.environ.get("REMOVE_STOPWORDS", "0") == "1"
+    MIN_CODE_QUALITY = float(os.environ.get("MIN_CODE_QUALITY", "1.0"))
+    MAX_LINT_ERRORS = int(os.environ.get("MAX_LINT_ERRORS", "10"))
 
     # Modelos de NLP
     NLP_MODELS = {
@@ -473,25 +480,27 @@ def setup_logger(name, log_file, level: int = logging.INFO, fmt: str = "text"):
         remote.setFormatter(formatter)
         logger.addHandler(remote)
 
-    structlog.configure(
-        wrapper_class=structlog.make_filtering_bound_logger(level),
-        processors=[
-            structlog.processors.add_log_level,
-            structlog.processors.TimeStamper(fmt="iso"),
-        ],
-    )
-    wrapped = structlog.wrap_logger(
-        logger,
-        processors=[
-            (
-                structlog.processors.JSONRenderer()
-                if fmt == "json"
-                else structlog.processors.KeyValueRenderer()
-            )
-        ],
-    )
+    if structlog:
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(level),
+            processors=[
+                structlog.processors.add_log_level,
+                structlog.processors.TimeStamper(fmt="iso"),
+            ],
+        )
+        wrapped = structlog.wrap_logger(
+            logger,
+            processors=[
+                (
+                    structlog.processors.JSONRenderer()
+                    if fmt == "json"
+                    else structlog.processors.KeyValueRenderer()
+                )
+            ],
+        )
+        return wrapped
 
-    return wrapped
+    return logger
 
 
 logger = setup_logger("wiki_scraper", "scraper.log")
@@ -1959,6 +1968,14 @@ class DatasetBuilder:
         else:
             problems, fixed_version = scan_code(content)
 
+        quality_metrics = evaluate_code_quality(raw_code, code_lang)
+        if (
+            quality_metrics["score"] < Config.MIN_CODE_QUALITY
+            or quality_metrics["lint_errors"] > Config.MAX_LINT_ERRORS
+            or any("eval" in p or "exec" in p for p in problems)
+        ):
+            return {}
+
         # Extrai keywords para gerar perguntas variadas
         keywords = extract_keywords(content, lang)
 
@@ -2023,7 +2040,8 @@ class DatasetBuilder:
             "summary_embedding": summary_embedding.tolist(),
             "quality_score": (
                 extra_metadata.get("quality_score", 0.0) if extra_metadata else 0.0
-            ),
+            )
+            + quality_metrics["score"],
             "quality": None,
             "reason": "",
             "quality_level": None,
@@ -2042,6 +2060,11 @@ class DatasetBuilder:
                 "source": "wikipedia",
                 "source_url": f"{get_base_url(lang)}/wiki/{title.replace(' ', '_')}",
             },
+        }
+
+        record.setdefault("origin_metrics", {})["code_quality"] = {
+            "cyclomatic_complexity": quality_metrics["complexity"],
+            "lint_errors": quality_metrics["lint_errors"],
         }
 
         metrics_sq = analyze_code(content)

--- a/tests/test_datasetbuilder_code.py
+++ b/tests/test_datasetbuilder_code.py
@@ -110,7 +110,7 @@ def test_generate_qa_pairs_processes_code(monkeypatch):
     assert result["metadata"].get("code_language") == "python"
     assert result["context"] == "S"
     assert result["tests"] == []
-    assert result["quality_score"] == 0.0
+    assert result["quality_score"] > 0
     for field in [
         "problems",
         "fixed_version",

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,6 +1,13 @@
 """Training utilities and preprocessing helpers."""
 
-from .pipeline import run_pipeline
+try:
+    from .pipeline import run_pipeline
+except Exception:  # pragma: no cover - optional dependency
+
+    def run_pipeline(*_a, **_k):  # type: ignore
+        raise RuntimeError("mlflow not available")
+
+
 from .preprocessing import chunk_text, tokenize_texts
 from .postprocessing import analyze_code_ast, filter_by_complexity
 

--- a/utils/quality.py
+++ b/utils/quality.py
@@ -5,6 +5,44 @@ from __future__ import annotations
 from typing import Dict, List, Tuple
 import re
 from statistics import mean
+from .code_sniffer import scan
+from .ast_tools import get_functions_complexity
+from .code import normalize_indentation, remove_comments, detect_programming_language
+from .sonarqube import analyze_code
+
+
+def evaluate_code_quality(code: str, language: str | None = None) -> Dict[str, float]:
+    """Return static analysis metrics and a quality score for ``code``.
+
+    Parameters
+    ----------
+    code: str
+        Source code snippet.
+    language: str | None
+        Optional language hint. If ``None`` the language is detected.
+
+    Returns
+    -------
+    Dict[str, float]
+        Mapping with ``complexity``, ``lint_errors`` and ``score`` fields.
+    """
+
+    lang = language or detect_programming_language(code)
+    cleaned = normalize_indentation(remove_comments(code, lang))
+    problems, _ = scan(cleaned)
+    complexities = get_functions_complexity(cleaned, lang)
+    max_complexity = max(complexities.values()) if complexities else 1
+    sonar_metrics = analyze_code(cleaned)
+    lint_errors = len(problems) + int(sonar_metrics.get("code_smells", 0))
+    score = max(0.0, 10.0 - max_complexity - lint_errors)
+    return {
+        "language": lang,
+        "complexity": float(max_complexity),
+        "lint_errors": float(lint_errors),
+        "score": float(score),
+        "sonarqube": sonar_metrics,
+    }
+
 
 POSITIVE_WORDS = {
     "good",


### PR DESCRIPTION
## Summary
- compute code quality with code_sniffer and SonarQube
- discard low-quality or vulnerable code
- expose quality score in API
- update dataset builder and tests
- handle optional mlflow dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simhash')*

------
https://chatgpt.com/codex/tasks/task_e_685bdfb507908320bd5c2a311a60cabe