### PR TITLE
Add scheduled scraping and dataset tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ pdoc -o docs -d google integrations core plugins utils api
 See [docs/setup.md](docs/setup.md) for installation and configuration instructions and [docs/usage.md](docs/usage.md) for CLI and API examples.
 
 Additional deployment examples, including Kubernetes manifests and scaling guidance, are available in [docs/scaling.md](docs/scaling.md).
+Scheduling options using Airflow or cron are covered in [docs/scheduling.md](docs/scheduling.md).

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,19 @@
+# Scheduled Scraping
+
+Scraper Wiki can run on a fixed schedule using either **Airflow** or a simple
+cron job. The provided `training.airflow_pipeline` module builds an Airflow DAG
+that collects pages, post-processes the dataset and publishes the results.
+Set the `AIRFLOW_SCHEDULE` environment variable with a cron expression and start
+Airflow using `docker-compose.airflow.yml`.
+
+For lightweight deployments a cron job can execute the CLI directly. The
+example below performs a weekly scrape every Monday at 02:00:
+
+```cron
+0 2 * * 1 python cli.py scrape --lang en --category "Programação" --format json
+```
+
+Both approaches track the last scraped timestamp of each page to avoid
+redundant downloads and leverage DVC to store only the differences between
+runs.
+

--- a/integrations/alerts.py
+++ b/integrations/alerts.py
@@ -1,0 +1,26 @@
+"""Utility to send alerts to maintainers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+logger = logging.getLogger("wiki_scraper")
+
+
+def send_alert(message: str) -> None:
+    """Send a notification using the configured webhook."""
+    from scraper_wiki import Config
+
+    if not Config.ALERT_WEBHOOK_URL:
+        return
+    try:
+        requests.post(
+            Config.ALERT_WEBHOOK_URL,
+            json={"text": message},
+            timeout=10,
+        )
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error(f"Failed to send alert: {exc}")

--- a/integrations/dvc_utils.py
+++ b/integrations/dvc_utils.py
@@ -1,0 +1,20 @@
+"""Helper to track dataset changes with DVC."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger("wiki_scraper")
+
+
+def track_path(path: str) -> None:
+    """Add ``path`` to DVC and push updates."""
+    if not Path(path).exists():
+        return
+    try:
+        subprocess.run(["dvc", "add", path], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["dvc", "push"], check=True, stdout=subprocess.DEVNULL)
+    except Exception as exc:  # pragma: no cover - dvc missing
+        logger.error(f"Failed to push dataset to DVC: {exc}")

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -58,6 +58,9 @@ from typing import List, Dict, Tuple, Optional, Set, Protocol
 from datetime import datetime
 import multiprocessing
 import signal
+from scraper_wiki.state import load_last_scraped, save_last_scraped
+from integrations.alerts import send_alert
+from integrations.dvc_utils import track_path
 import backoff
 import tenacity
 import numpy as np
@@ -206,6 +209,7 @@ class Config:
     SCRAPER_BACKEND = os.environ.get("SCRAPER_BACKEND", "selenium")
     LOG_SERVICE_URL = os.environ.get("LOG_SERVICE_URL")
     LOG_SERVICE_TYPE = os.environ.get("LOG_SERVICE_TYPE", "loki")
+    ALERT_WEBHOOK_URL = os.environ.get("ALERT_WEBHOOK_URL")
 
     # API endpoints and keys for optional plugins
     STACKOVERFLOW_API_KEY = os.environ.get("STACKOVERFLOW_API_KEY")
@@ -1757,6 +1761,7 @@ class DatasetBuilder:
         self.rev_limit = rev_limit
         self.min_complexity = min_complexity
         self.max_complexity = max_complexity
+        self.last_scraped = load_last_scraped()
 
         # Load checkpoints if available
         pages_path = os.path.join(Config.LOG_DIR, "checkpoint_pages.json")
@@ -1837,6 +1842,22 @@ class DatasetBuilder:
         start_time = time.perf_counter()
         try:
             wiki = WikipediaAdvanced(page_info["lang"])
+            key = f"{page_info['lang']}:{page_info['title']}"
+            last_ts = self.last_scraped.get(key)
+            revs = []
+            if last_ts:
+                revs = wiki.get_revision_history(page_info["title"], 1)
+                if revs:
+                    try:
+                        last_dt = datetime.fromisoformat(last_ts)
+                        rev_dt = datetime.fromisoformat(
+                            revs[0]["timestamp"].replace("Z", "+00:00")
+                        )
+                        if rev_dt <= last_dt:
+                            return None
+                    except Exception:
+                        pass
+
             page = wiki.fetch_page(page_info["title"])
 
             if not page or not page.exists():
@@ -1902,6 +1923,12 @@ class DatasetBuilder:
                 )
             metrics.scrape_success.inc()
             metrics.pages_scraped_total.inc()
+            ts = None
+            if revs:
+                ts = revs[0].get("timestamp")
+            if not ts:
+                ts = datetime.utcnow().isoformat()
+            self.last_scraped[key] = ts
             return qa_data
         except Exception as e:
             metrics.scrape_error.inc()
@@ -2709,6 +2736,8 @@ class DatasetBuilder:
             compression=Config.COMPRESSION,
         )
         logger.info(f"Dataset salvo usando backend {Config.STORAGE_BACKEND}")
+        track_path(output_dir)
+        save_last_scraped(self.last_scraped)
 
         if format == "qa":
             save_qa_dataset(sorted_data, Path(output_dir) / "qa_pairs.json")
@@ -2759,8 +2788,13 @@ class DatasetBuilder:
                     cf.write(
                         f"{datetime.utcnow().isoformat()} - v{new_version} size changed {old_size}->{len(sorted_data)}\n"
                     )
+            if diff_ratio > 0.5:
+                send_alert(
+                    f"Dataset size changed significantly: {old_size} -> {len(sorted_data)}"
+                )
         except Exception as e:  # pragma: no cover - unexpected I/O errors
             logger.error(f"Erro ao salvar dataset_info.json: {e}")
+            send_alert(f"Failed to save dataset info: {e}")
 
 
 # ============================

--- a/scraper_wiki/state.py
+++ b/scraper_wiki/state.py
@@ -1,0 +1,36 @@
+import json
+import os
+from typing import Dict
+
+
+def _file() -> str:
+    from . import Config
+
+    return os.path.join(Config.LOG_DIR, "last_scraped.json")
+
+
+def load_last_scraped() -> Dict[str, str]:
+    """Load last scraped timestamps from disk."""
+    path = _file()
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_last_scraped(data: Dict[str, str]) -> None:
+    """Persist last scraped timestamps to disk."""
+    try:
+        from . import Config
+
+        path = _file()
+        os.makedirs(Config.LOG_DIR, exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- allow scheduled runs with Airflow or cron in new docs
- add alert webhook integration
- persist last-scraped timestamps
- track datasets in DVC after each run

## Testing
- `black scraper_wiki/state.py integrations/alerts.py integrations/dvc_utils.py scraper_wiki/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685bf095c5c8832089088fcbac1ed105