### PR TITLE
Add dataset/QA models validation

### DIFF
--- a/api/api_app.py
+++ b/api/api_app.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from fastapi import FastAPI, Query as FastQuery, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from scraper_wiki.models import DatasetRecord
 import scraper_wiki as sw
 import os
 import json
@@ -131,7 +132,7 @@ async def scrape(params: ScrapeParams):
     return {"status": "ok"}
 
 
-@app.get("/records")
+@app.get("/records", response_model=List[DatasetRecord])
 async def get_records(
     lang: List[str] | None = FastQuery(None),
     category: List[str] | None = FastQuery(None),
@@ -147,7 +148,8 @@ async def get_records(
     processed = await asyncio.gather(
         *(asyncio.to_thread(enrich_record, rec) for rec in filtered)
     )
-    return processed
+    validated = [DatasetRecord.parse_obj(rec).dict() for rec in processed]
+    return validated
 
 
 @app.get("/stats")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from core.builder import DatasetBuilder
 from .base import Plugin
+from scraper_wiki.models import DatasetRecord
+from pydantic import ValidationError
 from integrations import storage_sqlite
 
 # Mapping of available plugin names to module paths
@@ -79,7 +81,8 @@ def run_plugin(
             for item in items:
                 result = plugin.parse_item(item)
                 if result:
-                    builder.dataset.append(result)
+                    record = DatasetRecord.parse_obj(result)
+                    builder.dataset.append(record.dict())
                 ts = (
                     item.get("created_at")
                     or item.get("creation_date")

--- a/scraper_wiki/models/__init__.py
+++ b/scraper_wiki/models/__init__.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, Field, validator
+from typing import List, Optional, Dict, Any
+
+
+class DatasetRecord(BaseModel):
+    """Dataset record produced by scraping plugins."""
+
+    id: str
+    language: str
+    category: Optional[str] = None
+    content: str
+    created_at: str
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    content_embedding: Optional[List[float]] = None
+    summary_embedding: Optional[List[float]] = None
+    questions: Optional[List[Dict[str, Any]]] = None
+    answers: Optional[List[Dict[str, Any]]] = None
+    relations: Optional[List[Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"
+
+
+class QARecord(BaseModel):
+    """Simple question/answer pair."""
+
+    question: str
+    answer: str
+
+
+__all__ = ["DatasetRecord", "QARecord"]

--- a/tests/test_models_validation.py
+++ b/tests/test_models_validation.py
@@ -1,0 +1,74 @@
+import importlib.util
+from pathlib import Path
+import pytest
+from pydantic import ValidationError
+
+MODELS_PATH = (
+    Path(__file__).resolve().parents[1] / "scraper_wiki" / "models" / "__init__.py"
+)
+spec = importlib.util.spec_from_file_location("scraper_wiki.models", MODELS_PATH)
+models = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(models)
+DatasetRecord = models.DatasetRecord
+QARecord = models.QARecord
+
+
+def test_datasetrecord_valid():
+    rec = DatasetRecord.parse_obj(
+        {
+            "id": "1",
+            "language": "en",
+            "category": "c",
+            "content": "text",
+            "created_at": "now",
+        }
+    )
+    assert rec.id == "1"
+
+
+def test_datasetrecord_missing_field():
+    with pytest.raises(ValidationError):
+        DatasetRecord.parse_obj({"language": "en", "content": "x", "created_at": "now"})
+
+
+def test_datasetrecord_wrong_type():
+    with pytest.raises(ValidationError):
+        DatasetRecord.parse_obj(
+            {
+                "id": "1",
+                "language": "en",
+                "category": "c",
+                "content": "x",
+                "created_at": "now",
+                "content_embedding": "bad",
+            }
+        )
+
+
+def test_run_plugin_validation():
+    class DummyPlugin:
+        def fetch_items(self, lang, category, since=None):
+            return [{}]
+
+        def parse_item(self, item):
+            return {
+                "id": 1,
+                "language": "en",
+                "category": "c",
+                "content": "c",
+                "created_at": "now",
+            }
+
+    def run_plugin(plugin):
+        for item in plugin.fetch_items("en", "c"):
+            result = plugin.parse_item(item)
+            DatasetRecord.parse_obj(result)
+
+    with pytest.raises(ValidationError):
+        run_plugin(DummyPlugin())
+
+
+def test_qarecord():
+    qa = QARecord(question="q", answer="a")
+    assert qa.question == "q" and qa.answer == "a"


### PR DESCRIPTION
## Summary
- add `DatasetRecord` and `QARecord` Pydantic models
- validate plugin output with `DatasetRecord`
- validate `/records` API response using `DatasetRecord`
- add tests covering record validation and plugin output errors

## Testing
- `pytest tests/test_models_validation.py::test_datasetrecord_valid -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'graphene')*

------
https://chatgpt.com/codex/tasks/task_e_685bfcc312bc8320a2fa5a050f62eb4b