### PR TITLE
Implement per-plugin rate limiter

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -22,6 +22,9 @@ requests_failed_total = Counter("requests_failed_total", "HTTP request failures"
 # Total de tentativas extras ao fazer requisições
 request_retries_total = Counter("request_retries_total", "HTTP request retries")
 
+# Number of times requests had to wait due to rate limiting
+rate_limited_total = Counter("rate_limited_total", "Number of rate limited events")
+
 # Histogram of processing time per page
 page_processing_seconds = Histogram(
     "page_processing_seconds", "Time spent processing a page in seconds"

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -4,7 +4,8 @@ from typing import List, Dict, Protocol, runtime_checkable
 
 import requests
 
-from scraper_wiki import Config, RateLimiter
+from scraper_wiki import Config, metrics
+from utils.rate_limiter import RateLimiter
 
 
 @runtime_checkable
@@ -23,8 +24,13 @@ class Plugin(Protocol):
 class BasePlugin:
     """Base class implementing rate limiting and deduplication."""
 
-    def __init__(self) -> None:
-        self.rate_limiter = RateLimiter(Config.RATE_LIMIT_DELAY)
+    def __init__(self, domain: str | None = None) -> None:
+        self.domain = domain or self.__class__.__name__.lower()
+        delay = Config.PLUGIN_RATE_LIMITS.get(
+            self.domain,
+            Config.PLUGIN_RATE_LIMITS.get("default", Config.RATE_LIMIT_DELAY),
+        )
+        self.rate_limiter = RateLimiter(delay, metrics=metrics)
         self._seen: set[str] = set()
 
     def request(self, url: str, **kwargs) -> requests.Response:

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -103,6 +103,7 @@ from utils.code import (
 from utils.ast_tools import get_functions_complexity
 from utils.code_sniffer import scan as scan_code
 from utils.contextualizer import search_discussions
+from utils.rate_limiter import RateLimiter
 from processing.pipeline import get_pipeline
 from enrichment.generator import (
     generate_diagram,
@@ -158,6 +159,17 @@ class Config:
     RETRIES = 5
     TIMEOUT = 10
     RATE_LIMIT_DELAY = float(os.environ.get("RATE_LIMIT_DELAY", 0.5))
+    PLUGIN_RATE_LIMITS: Dict[str, float] = {}
+    _raw_plugin_limits = os.environ.get("PLUGIN_RATE_LIMITS")
+    if _raw_plugin_limits:
+        for part in _raw_plugin_limits.split(","):
+            if "=" in part:
+                name, val = part.split("=", 1)
+                try:
+                    PLUGIN_RATE_LIMITS[name.strip()] = float(val)
+                except ValueError:
+                    pass
+    PLUGIN_RATE_LIMITS.setdefault("default", RATE_LIMIT_DELAY)
     MAX_PAGES_PER_CATEGORY = 1000
     MIN_TEXT_LENGTH = 150  # mínimo de caracteres para considerar uma página
     MAX_TEXT_LENGTH = 10000  # máximo de caracteres a extrair por página
@@ -282,41 +294,6 @@ BASE_URLS = {
 def get_base_url(lang: str) -> str:
     """Return base Wikipedia URL for a given language."""
     return BASE_URLS.get(lang, f"https://{lang}.wikipedia.org")
-
-
-class RateLimiter:
-    """Simple exponential backoff rate limiter with jitter."""
-
-    def __init__(self, min_delay: float, max_delay: float | None = None):
-        if max_delay is None:
-            max_delay = min_delay
-        self.base_min = min_delay
-        self.base_max = max_delay
-        self.min_delay = min_delay
-        self.max_delay = max_delay
-        self.consecutive_failures = 0
-
-    def _sample_delay(self) -> float:
-        return random.uniform(self.min_delay, self.max_delay)
-
-    def wait(self):
-        time.sleep(self._sample_delay())
-
-    async def async_wait(self):
-        await asyncio.sleep(self._sample_delay())
-
-    def record_error(self):
-        self.consecutive_failures += 1
-        self.min_delay *= 2
-        self.max_delay *= 2
-
-    def record_success(self):
-        self.reset()
-
-    def reset(self):
-        self.consecutive_failures = 0
-        self.min_delay = self.base_min
-        self.max_delay = self.base_max
 
 
 # ============================

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -1316,12 +1316,19 @@ def test_worker_concurrency_env(monkeypatch):
 
 def test_rate_limiter_backoff(monkeypatch):
     recorded = []
-    rl = sw.RateLimiter(0.1)
+    metrics_calls = []
+    rl = sw.RateLimiter(
+        0.1,
+        metrics=SimpleNamespace(
+            rate_limited_total=SimpleNamespace(inc=lambda: metrics_calls.append(True))
+        ),
+    )
     monkeypatch.setattr(sw.time, "sleep", lambda d: recorded.append(d))
     rl.wait()
     rl.record_error()
     rl.wait()
     assert recorded == [0.1, 0.2]
+    assert metrics_calls == [True, True]
 
 
 def test_rate_limiter_range_and_async(monkeypatch):
@@ -1334,7 +1341,6 @@ def test_rate_limiter_range_and_async(monkeypatch):
         recorded_async.append(d)
 
     monkeypatch.setattr(sw.asyncio, "sleep", fake_async_sleep)
-    monkeypatch.setattr(sw.random, "uniform", lambda a, b: b)
     rl.wait()
 
     async def run():
@@ -1344,8 +1350,8 @@ def test_rate_limiter_range_and_async(monkeypatch):
 
     aio.run(run())
 
-    assert recorded_sync == [0.2]
-    assert recorded_async == [0.2]
+    assert recorded_sync == [0.1]
+    assert recorded_async == [0.1]
 
 
 def test_fetch_with_retry_failure_increments_counter(monkeypatch):

--- a/tests/test_social_plugins.py
+++ b/tests/test_social_plugins.py
@@ -7,8 +7,12 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 scraper_stub = ModuleType("scraper_wiki")
-scraper_stub.Config = SimpleNamespace(TIMEOUT=5, RATE_LIMIT_DELAY=0)
-scraper_stub.RateLimiter = lambda delay: SimpleNamespace(wait=lambda: None)
+scraper_stub.Config = SimpleNamespace(
+    TIMEOUT=5, RATE_LIMIT_DELAY=0, PLUGIN_RATE_LIMITS={"default": 0}
+)
+scraper_stub.RateLimiter = lambda delay, *a, **k: SimpleNamespace(
+    wait=lambda: None, async_wait=lambda: None
+)
 sys.modules.setdefault("scraper_wiki", scraper_stub)
 sys.modules.setdefault("html2text", SimpleNamespace(html2text=lambda x: x))
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -6,6 +6,7 @@ from .text import (
     normalize_infobox,
 )
 from .relation import extract_relations
+from .rate_limiter import RateLimiter
 from .cleaner import clean_wiki_text, split_sentences
 from .compression import compress_bytes, decompress_bytes, load_json_file
 from .code import (
@@ -43,4 +44,5 @@ __all__ = [
     "compress_bytes",
     "decompress_bytes",
     "load_json_file",
+    "RateLimiter",
 ]

--- a/utils/rate_limiter.py
+++ b/utils/rate_limiter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Optional
+
+
+class RateLimiter:
+    """Leaky bucket rate limiter with exponential backoff."""
+
+    def __init__(
+        self,
+        min_delay: float,
+        max_delay: float | None = None,
+        *,
+        metrics: Optional[Any] = None,
+    ) -> None:
+        if max_delay is None:
+            max_delay = min_delay
+        self.base_min = min_delay
+        self.base_max = max_delay
+        self.min_delay = min_delay
+        self.max_delay = max_delay
+        self.metrics = metrics
+        self.consecutive_failures = 0
+        self.next_time = time.monotonic() + self.min_delay
+
+    def _record_wait(self, delay: float) -> None:
+        if delay > 0 and self.metrics is not None:
+            try:
+                self.metrics.rate_limited_total.inc()
+            except Exception:
+                pass
+
+    def wait(self) -> None:
+        now = time.monotonic()
+        if now < self.next_time:
+            delay = self.next_time - now
+            self._record_wait(delay)
+            time.sleep(delay)
+            now = time.monotonic()
+        self.next_time = max(now, self.next_time) + self.min_delay
+
+    async def async_wait(self) -> None:
+        now = time.monotonic()
+        if now < self.next_time:
+            delay = self.next_time - now
+            self._record_wait(delay)
+            await asyncio.sleep(delay)
+            now = time.monotonic()
+        self.next_time = max(now, self.next_time) + self.min_delay
+
+    def record_error(self) -> None:
+        self.consecutive_failures += 1
+        self.min_delay = min(self.max_delay, self.min_delay * 2)
+        self.next_time = time.monotonic() + self.min_delay
+
+    def record_success(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self.consecutive_failures = 0
+        self.min_delay = self.base_min
+        self.max_delay = self.base_max
+        self.next_time = time.monotonic() + self.min_delay


### PR DESCRIPTION
## Summary
- add new leaky bucket `RateLimiter` under utils
- expose new limiter in utils package
- track rate limited events with new Prometheus metric
- support per-plugin rate limit configuration in `Config`
- use new limiter inside `BasePlugin`
- update tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_685c02e65c648320893f5ea2e4874ea4