### PR TITLE
Add Neo4j graph persistence and CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -344,6 +344,22 @@ def process_pipeline(
     typer.echo(f"Processados {len(result)} registros")
 
 
+@app.command("build-graph")
+def build_graph_cmd(
+    dataset: str = typer.Argument(..., help="Caminho para dataset de relações"),
+    persist: bool = typer.Option(False, "--persist", help="Salva o grafo no Neo4j"),
+):
+    """Converte um dataset de relações em grafo."""
+    from utils.compression import load_json_file
+    from utils.relation import relations_to_graph
+
+    data = load_json_file(dataset)
+    g = relations_to_graph(data, persist=persist)
+    typer.echo(
+        f"Graph construido com {g.number_of_nodes()} nós e {g.number_of_edges()} arestas"
+    )
+
+
 @app.command("start-crawler")
 def start_crawler_cmd(
     config: str = typer.Option(None, "--config", help="Path to cluster config")

--- a/docs/knowledge_graph.md
+++ b/docs/knowledge_graph.md
@@ -1,0 +1,35 @@
+# Knowledge Graph
+
+This project can transform scraped datasets into a graph stored in Neo4j.
+
+## Building the Graph
+
+Use the CLI to convert a JSON file of triples into a graph:
+
+```bash
+python cli.py build-graph path/to/dataset_triples.json --persist
+```
+
+The `--persist` flag sends all edges to the database using the connection
+information from the `NEO4J_URI`, `NEO4J_USER` and `NEO4J_PASSWORD`
+environment variables.
+
+## Example Queries
+
+In the Neo4j browser you can explore the data with Cypher:
+
+```cypher
+// List first relations
+MATCH (a:Entity)-[r:RELATED]->(b:Entity)
+RETURN a,b,r LIMIT 25;
+
+// Find everything related to Python
+MATCH (p:Entity {id:"Python"})<-[:RELATED]-(n)
+RETURN n;
+```
+
+## Visualization
+
+Neo4j Browser provides a simple visualization. After running a query, switch to
+*Graph* view to see nodes and edges. For larger exports consider tools like
+Neo4j Bloom or `networkx` drawing utilities.

--- a/integrations/neo4j_backend.py
+++ b/integrations/neo4j_backend.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import networkx as nx
+
+
+def save_graph(
+    graph: nx.DiGraph,
+    uri: Optional[str] = None,
+    user: Optional[str] = None,
+    password: Optional[str] = None,
+) -> None:
+    """Persist a NetworkX graph to Neo4j."""
+    if graph.number_of_edges() == 0:
+        return
+    try:  # pragma: no cover - optional dependency
+        from neo4j import GraphDatabase
+    except Exception as exc:  # pragma: no cover - missing deps
+        raise ImportError("neo4j is required for graph persistence") from exc
+
+    uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = user or os.getenv("NEO4J_USER", "neo4j")
+    password = password or os.getenv("NEO4J_PASSWORD", "test")
+
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    try:
+        with driver.session() as session:
+            for src, dst, data in graph.edges(data=True):
+                session.run(
+                    "MERGE (a:Entity {id:$from}) "
+                    "MERGE (b:Entity {id:$to}) "
+                    "MERGE (a)-[:RELATED {type:$rel}]->(b)",
+                    {"from": src, "to": dst, "rel": data.get("relation")},
+                )
+    finally:
+        driver.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -515,3 +515,19 @@ def test_auto_scrape_backend_option(monkeypatch):
 
     assert result.exit_code == 0
     assert called["backend"] == "playwright"
+
+
+def test_build_graph_command(tmp_path, monkeypatch):
+    triples = [{"subject": "Ada", "relation": "worked at", "object": "IBM"}]
+    data_file = tmp_path / "triples.json"
+    data_file.write_text(json.dumps(triples))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.neo4j_backend",
+        SimpleNamespace(save_graph=lambda g: None),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["build-graph", str(data_file), "--persist"])
+    assert result.exit_code == 0

--- a/tests/test_utils_relations.py
+++ b/tests/test_utils_relations.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+
 # Dummy NLP components
 class DummyToken:
     def __init__(self, text, dep, i=0, lemma=None):
@@ -15,6 +16,7 @@ class DummyToken:
         self.lemma_ = lemma or text
         self.children = []
 
+
 class DummyEnt:
     def __init__(self, text, start, end):
         self.text = text
@@ -22,8 +24,10 @@ class DummyEnt:
         self.end = end
         self.label_ = "PERSON"
 
+
 class DummySent(list):
     pass
+
 
 class DummyDoc:
     def __init__(self):
@@ -38,9 +42,11 @@ class DummyDoc:
     def __iter__(self):
         return iter(self.tokens)
 
+
 class DummyNLP:
     def __call__(self, text):
         return DummyDoc()
+
 
 class DummyProc:
     @classmethod
@@ -49,46 +55,94 @@ class DummyProc:
 
 
 def test_extract_relations_simple(monkeypatch):
-    monkeypatch.setitem(sys.modules, "sentence_transformers", SimpleNamespace(SentenceTransformer=lambda *a, **k: None))
-    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: DummyNLP()))
-    monkeypatch.setitem(sys.modules, "scraper_wiki", SimpleNamespace(NLPProcessor=DummyProc))
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        SimpleNamespace(SentenceTransformer=lambda *a, **k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: DummyNLP())
+    )
+    monkeypatch.setitem(
+        sys.modules, "scraper_wiki", SimpleNamespace(NLPProcessor=DummyProc)
+    )
 
     relations_mod = importlib.reload(importlib.import_module("utils.relation"))
     rels = relations_mod.extract_relations("Guido created Python", "en")
     assert rels == [{"subject": "Guido", "relation": "create", "object": "Python"}]
 
+
 def test_extract_relations_returns_empty_on_error(monkeypatch):
-    monkeypatch.setitem(sys.modules, 'sentence_transformers', SimpleNamespace(SentenceTransformer=lambda *a, **k: None))
-    monkeypatch.setitem(sys.modules, 'spacy', SimpleNamespace(load=lambda *a, **k: None))
-    monkeypatch.setitem(sys.modules, 'scraper_wiki', SimpleNamespace(NLPProcessor=SimpleNamespace(get_instance=lambda lang: (_ for _ in ()).throw(Exception()))))
-    relations_mod = importlib.reload(importlib.import_module('utils.relation'))
-    rels = relations_mod.extract_relations('text', 'en')
+    monkeypatch.setitem(
+        sys.modules,
+        "sentence_transformers",
+        SimpleNamespace(SentenceTransformer=lambda *a, **k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "scraper_wiki",
+        SimpleNamespace(
+            NLPProcessor=SimpleNamespace(
+                get_instance=lambda lang: (_ for _ in ()).throw(Exception())
+            )
+        ),
+    )
+    relations_mod = importlib.reload(importlib.import_module("utils.relation"))
+    rels = relations_mod.extract_relations("text", "en")
     assert rels == []
 
 
 def test_token_to_ent_text_fallback():
     import utils.relation as rel
-    token = DummyToken('Word', 'nsubj', i=0)
-    ent = DummyEnt('Other', 1, 2)
-    assert rel._token_to_ent_text(token, [ent]) == 'Word'
+
+    token = DummyToken("Word", "nsubj", i=0)
+    ent = DummyEnt("Other", 1, 2)
+    assert rel._token_to_ent_text(token, [ent]) == "Word"
 
 
 def test_extract_relations_regex_basic(monkeypatch):
-    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None)
+    )
     import utils.relation as rel
-    text = 'Ada worked at IBM. Bob studied at MIT.'
+
+    text = "Ada worked at IBM. Bob studied at MIT."
     res = rel.extract_relations_regex(text)
-    assert {'subject': 'Ada', 'relation': 'worked at', 'object': 'IBM'} in res
-    assert {'subject': 'Bob', 'relation': 'studied at', 'object': 'MIT'} in res
+    assert {"subject": "Ada", "relation": "worked at", "object": "IBM"} in res
+    assert {"subject": "Bob", "relation": "studied at", "object": "MIT"} in res
 
 
 def test_relations_to_graph_builds_edges(monkeypatch):
-    monkeypatch.setitem(sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None))
+    monkeypatch.setitem(
+        sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None)
+    )
     import utils.relation as rel
+
     relations = [
-        {'subject': 'Ada', 'relation': 'worked at', 'object': 'IBM'},
-        {'subject': 'Bob', 'relation': 'studied at', 'object': 'MIT'},
+        {"subject": "Ada", "relation": "worked at", "object": "IBM"},
+        {"subject": "Bob", "relation": "studied at", "object": "MIT"},
     ]
     g = rel.relations_to_graph(relations)
-    assert g.has_edge('Ada', 'IBM')
-    assert g['Ada']['IBM']['relation'] == 'worked at'
+    assert g.has_edge("Ada", "IBM")
+    assert g["Ada"]["IBM"]["relation"] == "worked at"
+
+
+def test_relations_to_graph_persists(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules, "spacy", SimpleNamespace(load=lambda *a, **k: None)
+    )
+    saved = {}
+    monkeypatch.setitem(
+        sys.modules,
+        "integrations.neo4j_backend",
+        SimpleNamespace(save_graph=lambda g: saved.update(nodes=g.number_of_nodes())),
+    )
+    import importlib
+
+    rel = importlib.reload(importlib.import_module("utils.relation"))
+    relations = [{"subject": "Ada", "relation": "worked at", "object": "IBM"}]
+    rel.relations_to_graph(relations, persist=True)
+    assert saved["nodes"] == 2

--- a/utils/relation.py
+++ b/utils/relation.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 from typing import List, Dict
+import os
 import re
 import networkx as nx
-
 
 
 def _token_to_ent_text(token, ents):
@@ -21,6 +21,7 @@ def extract_relations(text: str, lang: str = "en") -> List[Dict[str, str]]:
     """Extract basic subject-verb-object relations using spaCy."""
     try:
         from scraper_wiki import NLPProcessor
+
         nlp = NLPProcessor.get_instance(lang)
         doc = nlp(text)
     except Exception:
@@ -31,20 +32,29 @@ def extract_relations(text: str, lang: str = "en") -> List[Dict[str, str]]:
         root = next((t for t in sent if t.dep_ == "ROOT"), None)
         if not root:
             continue
-        subj = next((c for c in root.children if c.dep_ in {"nsubj", "nsubjpass"}), None)
-        obj = next((c for c in root.children if c.dep_ in {"dobj", "attr", "pobj", "obj"}), None)
+        subj = next(
+            (c for c in root.children if c.dep_ in {"nsubj", "nsubjpass"}), None
+        )
+        obj = next(
+            (c for c in root.children if c.dep_ in {"dobj", "attr", "pobj", "obj"}),
+            None,
+        )
         if subj and obj:
-            relations.append({
-                "subject": _token_to_ent_text(subj, doc.ents),
-                "relation": root.lemma_,
-                "object": _token_to_ent_text(obj, doc.ents),
-            })
+            relations.append(
+                {
+                    "subject": _token_to_ent_text(subj, doc.ents),
+                    "relation": root.lemma_,
+                    "object": _token_to_ent_text(obj, doc.ents),
+                }
+            )
     return relations
 
 
 def extract_relations_regex(text: str) -> List[Dict[str, str]]:
     """Extract simple relations based on a regex pattern."""
-    pattern = re.compile(r"([A-Z][a-zA-Z]*) (worked at|studied at|discovered) ([A-Z][a-zA-Z]*)")
+    pattern = re.compile(
+        r"([A-Z][a-zA-Z]*) (worked at|studied at|discovered) ([A-Z][a-zA-Z]*)"
+    )
     relations: List[Dict[str, str]] = []
     for match in pattern.finditer(text):
         subject, relation, obj = match.groups()
@@ -52,8 +62,19 @@ def extract_relations_regex(text: str) -> List[Dict[str, str]]:
     return relations
 
 
-def relations_to_graph(relations: List[Dict[str, str]]) -> nx.DiGraph:
-    """Convert a list of relations to a directed NetworkX graph."""
+def relations_to_graph(
+    relations: List[Dict[str, str]], persist: bool | None = None
+) -> nx.DiGraph:
+    """Convert a list of relations to a directed NetworkX graph.
+
+    Parameters
+    ----------
+    relations:
+        List of extracted relations with ``subject``, ``relation`` and ``object``.
+    persist:
+        If ``True`` the graph is also persisted to Neo4j. Defaults to ``False``
+        unless the ``PERSIST_GRAPH`` environment variable is set.
+    """
     graph = nx.DiGraph()
     for rel in relations:
         subj = rel.get("subject")
@@ -61,4 +82,14 @@ def relations_to_graph(relations: List[Dict[str, str]]) -> nx.DiGraph:
         graph.add_node(subj)
         graph.add_node(obj)
         graph.add_edge(subj, obj, relation=rel.get("relation"))
+
+    do_persist = persist if persist is not None else os.getenv("PERSIST_GRAPH") == "1"
+    if do_persist:
+        try:
+            from integrations.neo4j_backend import save_graph
+
+            save_graph(graph)
+        except Exception:  # pragma: no cover - optional backend
+            pass
+
     return graph


### PR DESCRIPTION
## Summary
- enable persisting graphs to Neo4j
- expose new `build-graph` command
- document knowledge graph usage
- test relation persistence and CLI

## Testing
- `black utils/relation.py integrations/neo4j_backend.py cli.py tests/test_utils_relations.py tests/test_cli.py`
- `pytest tests/test_utils_relations.py::test_relations_to_graph_persists -q`
- `pytest -q` *(fails: ModuleNotFoundError: httpx, typer, and others)*

------
https://chatgpt.com/codex/tasks/task_e_685c05c092148320b2fc101580e736e4