### PR TITLE
Improve text cleaning

### DIFF
--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -118,6 +118,17 @@ from enrichment.generator import (
 from utils.sonarqube import analyze_code
 
 
+# Precompiled regex patterns for text cleaning
+_CLEAN_COMBINED_RE = re.compile(
+    r"\[\d+\]|\{\|.*?\|\}|\b(?:ver também|see also|véase também|voir aussi)\b.*",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_SECTION_RE = re.compile(
+    r"==\s*(?:referências|references|referencias|bibliografia|bibliography|bibliografía|ligações externas|external links|enlaces externos)\s*==.*",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
 # ============================
 # 🔧 Configurações Avançadas
 # ============================
@@ -871,32 +882,11 @@ def advanced_clean_text(
         if lang in ["en", "de"]:
             text = unidecode(text)
 
-        # Remove padrões específicos da Wikipedia
-        text = re.sub(r"\[\d+\]", "", text)  # Referências [1], [2], etc.
-        text = re.sub(
-            r"\b(ver também|see also|véase también|voir aussi)\b.*",
-            "",
-            text,
-            flags=re.IGNORECASE,
-        )
-        text = re.sub(r"\{\|.*?\|\}", "", text, flags=re.DOTALL)  # Remove tables
+        # Remove Wikipedia-specific markup in a single pass
+        text = _CLEAN_COMBINED_RE.sub("", text)
 
-        # Remove seções específicas
-        sections_to_remove = [
-            "referências",
-            "references",
-            "referencias",
-            "bibliografia",
-            "bibliography",
-            "bibliografía",
-            "ligações externas",
-            "external links",
-            "enlaces externos",
-        ]
-        for section in sections_to_remove:
-            text = re.sub(
-                rf"==\s*{section}\s*==.*", "", text, flags=re.IGNORECASE | re.DOTALL
-            )
+        # Remove specific sections
+        text = _SECTION_RE.sub("", text)
 
         if remove_stopwords or stem:
             removed = False

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,30 @@
+import sys
+from types import SimpleNamespace
+
+# Avoid loading heavy spaCy models during import
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: SimpleNamespace()))
+sys.modules.setdefault("sklearn.cluster", SimpleNamespace(KMeans=lambda *a, **k: None))
+sys.modules.setdefault(
+    "sklearn.feature_extraction.text",
+    SimpleNamespace(TfidfVectorizer=lambda *a, **k: None),
+)
+sys.modules.setdefault(
+    "sumy.parsers.plaintext",
+    SimpleNamespace(PlaintextParser=lambda *a, **k: None),
+)
+sys.modules.setdefault(
+    "sumy.nlp.tokenizers",
+    SimpleNamespace(Tokenizer=lambda *a, **k: None),
+)
+sys.modules.setdefault(
+    "sumy.summarizers.lsa",
+    SimpleNamespace(LsaSummarizer=lambda *a, **k: None),
+)
+
+import scraper_wiki as sw
+
+LARGE_TEXT = "Wiki text [[Link|display]] {\ntable\n|}\nSee also other" * 1000
+
+
+def test_advanced_clean_text_benchmark(benchmark):
+    benchmark(sw.advanced_clean_text, LARGE_TEXT, "en")

--- a/utils/cleaner.py
+++ b/utils/cleaner.py
@@ -1,13 +1,18 @@
 import re
 from bs4 import BeautifulSoup
 
+# Precompile common regex patterns
+_WIKI_LINK_RE = re.compile(r"\[\[(?:[^|\]]*\|)?([^\]]+)\]\]")
+_TEMPLATE_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
+_WHITESPACE_RE = re.compile(r"\s+")
+
 
 def clean_wiki_text(text: str) -> str:
     """Remove wiki markup and HTML from ``text``."""
-    text = re.sub(r"\[\[([^|\]]*\|)?([^\]]+)\]\]", r"\2", text)
-    text = re.sub(r"\{\{.*?\}\}", "", text, flags=re.DOTALL)
+    text = _WIKI_LINK_RE.sub(r"\1", text)
+    text = _TEMPLATE_RE.sub("", text)
     text = BeautifulSoup(text, "html.parser").get_text()
-    text = re.sub(r"\s+", " ", text)
+    text = _WHITESPACE_RE.sub(" ", text)
     return text.strip()
 
 
@@ -15,6 +20,7 @@ def split_sentences(text: str, lang: str = "en") -> list[str]:
     """Split ``text`` into sentences using spaCy or fallback to NLTK."""
     try:
         import spacy  # type: ignore
+
         try:
             nlp = spacy.load(f"{lang}_core_web_sm")
         except Exception:
@@ -25,6 +31,7 @@ def split_sentences(text: str, lang: str = "en") -> list[str]:
         try:
             import nltk
             from nltk.tokenize import sent_tokenize
+
             return [s.strip() for s in sent_tokenize(text, language=lang)]
         except Exception:
             return [s.strip() for s in re.split(r"[.!?]+", text) if s.strip()]

--- a/utils/text.py
+++ b/utils/text.py
@@ -8,6 +8,11 @@ from typing import Dict
 from bs4 import BeautifulSoup
 import spacy
 
+# Precompile regex patterns used across functions
+_WIKILINK_RE = re.compile(r"\[\[(?:[^|\]]*\|)?([^\]]+)\]\]")
+_CITATION_RE = re.compile(r"\[\d+\]")
+_WHITESPACE_RE = re.compile(r"\s+")
+
 try:
     from dateutil import parser as date_parser
 except Exception:  # pragma: no cover - optional dependency
@@ -25,15 +30,14 @@ def clean_text(text: str) -> str:
         sup.decompose()
     text = soup.get_text()
 
-    # Replace wiki style links [[Page|text]] -> text and [[Page]] -> Page
-    text = re.sub(r"\[\[([^|\]]+)\|([^\]]+)\]\]", r"\2", text)
-    text = re.sub(r"\[\[([^|\]]+)\]\]", r"\1", text)
+    # Handle wiki style links in a single pass
+    text = _WIKILINK_RE.sub(r"\1", text)
 
     # Normalize unicode characters
     text = unicodedata.normalize("NFKC", text)
 
-    text = re.sub(r"\[\d+\]", "", text)
-    text = re.sub(r"\s+", " ", text)
+    text = _CITATION_RE.sub("", text)
+    text = _WHITESPACE_RE.sub(" ", text)
     return text.strip()
 
 


### PR DESCRIPTION
## Summary
- precompile regex patterns for text cleaning modules
- consolidate multiple substitutions into single regex calls
- add benchmark test for large text cleaning

## Testing
- `pytest tests/test_benchmarks.py -q`
- `pytest tests/test_scraper_wiki.py::test_advanced_clean_text_removes_see_also_section -q`
- `pytest tests/test_utils_text.py::test_clean_text_removes_refs_and_spaces -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7920ca708320b0458f2d1eecf041