### PR TITLE
Improve backoff for HTTP 429

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -19,6 +19,11 @@ pages_scraped_total = Counter("pages_scraped_total", "Pages successfully scraped
 # Falhas ao executar requisições HTTP
 requests_failed_total = Counter("requests_failed_total", "HTTP request failures")
 
+# HTTP 429 responses received
+requests_429_total = Counter(
+    "requests_429_total", "HTTP 429 responses from target servers"
+)
+
 # Total de tentativas extras ao fazer requisições
 request_retries_total = Counter("request_retries_total", "HTTP request retries")
 

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -1126,6 +1126,10 @@ class CaptchaDetected(Exception):
     """Raised when a CAPTCHA page is detected."""
 
 
+class TooManyRequests(CaptchaDetected):
+    """Raised when a HTTP 429 status is encountered."""
+
+
 async def fetch_with_retry(
     url: str,
     *,
@@ -1160,7 +1164,12 @@ async def fetch_with_retry(
                 async with session.get(
                     url, params=params, headers=headers, proxy=proxy
                 ) as resp:
-                    if resp.status in (429, 403):
+                    if resp.status == 429:
+                        metrics.scrape_block.inc()
+                        metrics.requests_429_total.inc()
+                        rate_limiter.record_error()
+                        raise TooManyRequests()
+                    if resp.status == 403:
                         metrics.scrape_block.inc()
                         rate_limiter.record_error()
                         raise CaptchaDetected()
@@ -1185,9 +1194,15 @@ async def fetch_with_retry(
             else:
                 fetch_semaphore.release()
 
+    def _wait_strategy(retry_state: tenacity.RetryCallState) -> float:
+        exc = retry_state.outcome.exception()
+        if isinstance(exc, TooManyRequests):
+            return tenacity.wait_random_exponential(multiplier=5, max=10)(retry_state)
+        return tenacity.wait_random_exponential(max=10)(retry_state)
+
     retryer = tenacity.AsyncRetrying(
         stop=tenacity.stop_after_attempt(retries),
-        wait=tenacity.wait_random_exponential(max=10),
+        wait=_wait_strategy,
         retry=tenacity.retry_if_exception_type(
             (aiohttp.ClientError, asyncio.TimeoutError, CaptchaDetected)
         ),

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -1592,12 +1592,15 @@ def test_fetch_with_retry_429_increases_delay(monkeypatch):
     rl = sw.RateLimiter(0.1)
     monkeypatch.setattr(sw, "rate_limiter", rl)
 
-    class DummyError(Exception):
-        def __init__(self, status):
-            super().__init__()
-            self.status = status
+    multipliers = []
 
-    monkeypatch.setattr(sw.aiohttp, "ClientResponseError", DummyError)
+    def fake_wait_random_exponential(multiplier=1, max=10):
+        multipliers.append(multiplier)
+        return lambda state: 0
+
+    monkeypatch.setattr(
+        sw.tenacity, "wait_random_exponential", fake_wait_random_exponential
+    )
 
     class DummyResp:
         status = 429
@@ -1614,7 +1617,7 @@ def test_fetch_with_retry_429_increases_delay(monkeypatch):
             return ""
 
         def raise_for_status(self):
-            raise sw.aiohttp.ClientResponseError(self.status)
+            pass
 
     class DummySession:
         async def __aenter__(self):
@@ -1628,23 +1631,30 @@ def test_fetch_with_retry_429_increases_delay(monkeypatch):
 
     monkeypatch.setattr(sw.aiohttp, "ClientSession", lambda *a, **k: DummySession())
     monkeypatch.setattr(sw.aiohttp, "ClientTimeout", lambda *a, **k: None)
+    monkeypatch.setattr(sw.tenacity.nap, "sleep", lambda t: None)
     monkeypatch.setattr(sw, "log_failed_url", lambda url: None)
+    metrics_calls = {"c": 0}
     monkeypatch.setattr(
         sw,
         "metrics",
         SimpleNamespace(
             scrape_block=SimpleNamespace(inc=lambda: None),
             requests_failed_total=SimpleNamespace(inc=lambda: None),
+            requests_429_total=SimpleNamespace(
+                inc=lambda: metrics_calls.__setitem__("c", metrics_calls["c"] + 1)
+            ),
         ),
     )
 
     import pytest
 
-    with pytest.raises(sw.aiohttp.ClientResponseError):
+    with pytest.raises(sw.TooManyRequests):
         asyncio.run(sw.fetch_with_retry("http://x", retries=1))
 
     assert rl.consecutive_failures == 1
     assert rl.min_delay == 0.2
+    assert multipliers[0] == 5
+    assert metrics_calls["c"] == 1
 
 
 def test_fetch_with_retry_uses_proxy(monkeypatch):


### PR DESCRIPTION
## Summary
- add `requests_429_total` Prometheus counter
- raise `TooManyRequests` for HTTP 429
- apply longer exponential backoff for 429 responses
- test new metric and backoff logic

## Testing
- `black scraper_wiki/__init__.py metrics.py tests/test_scraper_wiki.py`
- `pytest -q` *(fails: ModuleNotFoundError: 'httpx', 'requests', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685c81ee0ce88320b9a1c4caac29c246