### PR TITLE
Enable Prometheus metrics loop and document scraping config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from pathlib import Path
 from typing import List, Optional
 
@@ -211,6 +212,10 @@ def queue(
     ),
 ):
     """Enfileira um job de scraping."""
+    from metrics import start_metrics_server, start_system_metrics_loop
+
+    start_metrics_server(int(os.environ.get("METRICS_PORT", "8001")))
+    start_system_metrics_loop()
     lang = lang or None
     category = category or None
     cats = (

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -21,3 +21,16 @@ This document provides high level recommendations for deploying Scraper Wiki in 
 ## Autoscaling
 
 Horizontal Pod Autoscaling can be enabled on the worker deployments using CPU utilization targets. Increase the node count in your Terraform modules to ensure sufficient capacity.
+
+## Metrics Scraping
+
+All components expose Prometheus metrics on port **8001**. To scrape these
+metrics configure Prometheus as follows:
+
+```yaml
+scrape_configs:
+  - job_name: 'scraper-wiki'
+    static_configs:
+      - targets: ['<service-host>:8001']
+    metrics_path: /
+```

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -2914,6 +2914,7 @@ def main(
     """Gera o dataset utilizando os parâmetros fornecidos."""
     start_time = time.perf_counter()
     metrics.start_metrics_server(int(os.environ.get("METRICS_PORT", "8001")))
+    metrics.start_system_metrics_loop()
     logger.info("🚀 Iniciando Wikipedia Scraper Ultra Pro Max - GodMode++")
 
     if rate_limit_delay is not None:
@@ -3037,6 +3038,7 @@ async def main_async(
     """Asynchronous version of :func:`main`."""
     start_time = time.perf_counter()
     metrics.start_metrics_server(int(os.environ.get("METRICS_PORT", "8001")))
+    metrics.start_system_metrics_loop()
     logger.info("🚀 Iniciando Wikipedia Scraper Ultra Pro Max - GodMode++ (async)")
 
     if rate_limit_delay is not None:


### PR DESCRIPTION
## Summary
- begin system metrics collection earlier in `scraper_wiki.main` and `main_async`
- collect metrics when using the `queue` CLI command
- document Prometheus scraping setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c8644885483208f00f24eefdcba31