### PR TITLE
Add manual ack support for queue and worker

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -34,3 +34,29 @@ scrape_configs:
       - targets: ['<service-host>:8001']
     metrics_path: /
 ```
+
+## Worker Restarts
+
+Scraper workers are stateless and can be restarted at any time. When deploying
+with **systemd**, define a service similar to:
+
+```ini
+[Service]
+ExecStart=/usr/bin/python /opt/scraper-wiki/worker.py
+Restart=always
+```
+
+On **Kubernetes**, use a Deployment with `restartPolicy: Always` and scale the
+`worker` pod replicas as needed:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scraper-worker
+spec:
+  replicas: 4
+  template:
+    spec:
+      restartPolicy: Always
+```

--- a/task_queue.py
+++ b/task_queue.py
@@ -19,7 +19,7 @@ class BaseQueue:
     def publish(self, queue: str, message: dict):
         raise NotImplementedError
 
-    def consume(self, queue: str):
+    def consume(self, queue: str, manual_ack: bool = False):
         raise NotImplementedError
 
     def clear(self, queue: str):
@@ -37,12 +37,16 @@ class InMemoryQueue(BaseQueue):
     def publish(self, queue: str, message: dict):
         self._get_queue(queue).put(json.dumps(message))
 
-    def consume(self, queue: str):
+    def consume(self, queue: str, manual_ack: bool = False):
         q = self._get_queue(queue)
         while True:
             msg = q.get()
-            yield json.loads(msg)
-            q.task_done()
+            data = json.loads(msg)
+            if manual_ack:
+                yield data, q.task_done
+            else:
+                yield data
+                q.task_done()
 
     def clear(self, queue: str):
         self._get_queue(queue).queue.clear()
@@ -60,12 +64,18 @@ class RabbitMQQueue(BaseQueue):
         body = json.dumps(message).encode()
         self.channel.basic_publish(exchange="", routing_key=queue, body=body)
 
-    def consume(self, queue: str):
+    def consume(self, queue: str, manual_ack: bool = False):
         self.channel.queue_declare(queue=queue, durable=True)
         for method, _, body in self.channel.consume(queue, inactivity_timeout=1):
             if body:
-                self.channel.basic_ack(method.delivery_tag)
-                yield json.loads(body.decode())
+                data = json.loads(body.decode())
+                if manual_ack:
+                    yield data, lambda tag=method.delivery_tag: self.channel.basic_ack(
+                        tag
+                    )
+                else:
+                    self.channel.basic_ack(method.delivery_tag)
+                    yield data
 
     def clear(self, queue: str):
         self.channel.queue_purge(queue)
@@ -82,11 +92,19 @@ class RedisQueue(BaseQueue):
     def publish(self, queue: str, message: dict):
         self.client.rpush(queue, json.dumps(message))
 
-    def consume(self, queue: str):
+    def consume(self, queue: str, manual_ack: bool = False):
         while True:
-            item = self.client.blpop(queue, timeout=1)
-            if item:
-                yield json.loads(item[1])
+            if manual_ack:
+                item = self.client.brpoplpush(queue, f"{queue}:processing", timeout=1)
+                if item:
+                    data = json.loads(item)
+                    yield data, lambda val=item: self.client.lrem(
+                        f"{queue}:processing", 1, val
+                    )
+            else:
+                item = self.client.blpop(queue, timeout=1)
+                if item:
+                    yield json.loads(item[1])
 
     def clear(self, queue: str):
         self.client.delete(queue)
@@ -116,8 +134,8 @@ def publish(queue_name: str, message: dict):
     get_backend().publish(queue_name, message)
 
 
-def consume(queue_name: str):
-    yield from get_backend().consume(queue_name)
+def consume(queue_name: str, manual_ack: bool = False):
+    yield from get_backend().consume(queue_name, manual_ack=manual_ack)
 
 
 def clear(queue_name: str) -> None:

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -1,0 +1,15 @@
+import importlib
+from task_queue import InMemoryQueue, consume, publish, _BACKEND
+
+
+def test_manual_ack(monkeypatch):
+    q = InMemoryQueue()
+    monkeypatch.setattr("task_queue.get_backend", lambda: q)
+    publish("q", {"a": 1})
+    it = consume("q", manual_ack=True)
+    msg, ack = next(it)
+    assert msg == {"a": 1}
+    # not calling ack should keep internal unfinished count
+    assert q._get_queue("q").unfinished_tasks == 1
+    ack()
+    assert q._get_queue("q").unfinished_tasks == 0

--- a/worker.py
+++ b/worker.py
@@ -17,7 +17,7 @@ def main_sync() -> None:
     start_metrics_server(int(os.environ.get("METRICS_PORT", "8001")))
     start_system_metrics_loop()
     builder = DatasetBuilder()
-    for task in consume("scrape_tasks"):
+    for task, ack in consume("scrape_tasks", manual_ack=True):
         url = task.get("url")
         if not url and {"title", "lang"} <= task.keys():
             url = f"{get_base_url(task['lang'])}/wiki/{task['title'].replace(' ', '_')}"
@@ -28,10 +28,11 @@ def main_sync() -> None:
         result = builder.process_page(task)
         if result:
             publish("scrape_results", result)
+        ack()
 
 
 async def _handle_task(
-    task: dict, builder: DatasetBuilder, sem: asyncio.Semaphore
+    task: dict, ack_fn, builder: DatasetBuilder, sem: asyncio.Semaphore
 ) -> None:
     async with sem:
         url = task.get("url")
@@ -44,6 +45,7 @@ async def _handle_task(
         result = await builder.process_page_async(task)
         if result:
             await asyncio.to_thread(publish, "scrape_results", result)
+        ack_fn()
 
 
 async def main_async() -> None:
@@ -52,10 +54,10 @@ async def main_async() -> None:
     start_system_metrics_loop()
     builder = DatasetBuilder()
     sem = asyncio.Semaphore(Config.WORKER_CONCURRENCY)
-    iterator = consume("scrape_tasks")
+    iterator = consume("scrape_tasks", manual_ack=True)
     while True:
-        task = await asyncio.to_thread(next, iterator)
-        asyncio.create_task(_handle_task(task, builder, sem))
+        task, ack = await asyncio.to_thread(next, iterator)
+        asyncio.create_task(_handle_task(task, ack, builder, sem))
 
 
 def main(async_mode: bool = False) -> None:


### PR DESCRIPTION
## Summary
- implement manual acknowledgement logic for task_queue backends
- publish results before acking tasks in worker
- add worker restart guidance to scaling docs
- test manual ack behaviour

## Testing
- `pytest tests/test_task_queue.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_685d10430f1483209ef1c5937bdf36b8