### PR TITLE
Add Airflow DAG wrapper and docs

### DIFF
--- a/airflow/dags/scraper_pipeline.py
+++ b/airflow/dags/scraper_pipeline.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+
+try:  # Airflow is optional when running tests
+    from airflow.models import Variable
+except Exception:  # pragma: no cover - optional dependency
+    Variable = None  # type: ignore
+
+from training.airflow_pipeline import create_dag
+
+# Read configuration from Airflow Variables if available
+if Variable is not None:
+    langs = Variable.get("languages", default_var=None)
+    if langs:
+        os.environ["LANGUAGES"] = langs
+    cats = Variable.get("categories", default_var=None)
+    if cats:
+        os.environ["CATEGORIES"] = cats
+    storage = Variable.get("storage_backend", default_var=None)
+    if storage:
+        os.environ["STORAGE_BACKEND"] = storage
+
+dag = create_dag()

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -6,6 +6,25 @@ that collects pages, post-processes the dataset and publishes the results.
 Set the `AIRFLOW_SCHEDULE` environment variable with a cron expression and start
 Airflow using `docker-compose.airflow.yml`.
 
+The DAG defined in `airflow/dags/scraper_pipeline.py` reads the `languages`,
+`categories` and `storage_backend` Airflow Variables to control what gets
+scraped and where the dataset is stored. Create them through the Airflow UI or
+the CLI:
+
+```bash
+airflow variables set languages "pt,en"
+airflow variables set categories "Programação,Algoritmos"
+airflow variables set storage_backend s3
+```
+
+Trigger the job manually with:
+
+```bash
+airflow dags trigger dataset_pipeline
+```
+
+Progress can be monitored at `http://localhost:8080` in **Browse → DAG Runs**.
+
 For lightweight deployments a cron job can execute the CLI directly. The
 example below performs a weekly scrape every Monday at 02:00:
 


### PR DESCRIPTION
## Summary
- create `airflow/dags/scraper_pipeline.py` that loads Airflow Variables and calls `training.airflow_pipeline.create_dag`
- document how to trigger the DAG and monitor runs in `docs/scheduling.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_685d1439db5883209c7a299b72891001