### PR TITLE
Implement raw data dumps and processing command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /datasets_wikipedia_pro
+datasets/raw
 dataset_metadata.json
 docs.tar.gz

--- a/cli.py
+++ b/cli.py
@@ -398,5 +398,44 @@ def update_parsers_cmd():
     typer.echo("Parsers updated")
 
 
+@app.command("process-raw")
+def process_raw_cmd(
+    raw_dir: str = typer.Option(
+        "datasets/raw", "--raw-dir", help="Diretório de dumps brutos"
+    ),
+    fmt: str = typer.Option("all", "--format", help="Formato de saída"),
+):
+    """Processa arquivos brutos gerados previamente."""
+    from tqdm import tqdm
+
+    builder = scraper_wiki.DatasetBuilder()
+    path = Path(raw_dir)
+    files = sorted(path.glob("*.json"))
+    for fp in tqdm(files, desc="Processando dumps"):
+        data = json.loads(fp.read_text(encoding="utf-8"))
+        title = data.get("title", "")
+        lang = data.get("lang", "")
+        category = data.get("category", "")
+        html = data.get("html", "")
+        text = data.get("text", "")
+        clean = scraper_wiki.advanced_clean_text(
+            text, lang, remove_stopwords=scraper_wiki.Config.REMOVE_STOPWORDS
+        )
+        record = scraper_wiki.cpu_process_page(
+            title,
+            clean,
+            lang,
+            category,
+            scraper_wiki.extract_images(html),
+            scraper_wiki.extract_videos(html),
+            None,
+            builder.rev_limit,
+        )
+        builder.dataset.append(record)
+
+    builder.enhance_with_clustering()
+    builder.save_dataset(format=fmt)
+
+
 if __name__ == "__main__":
     app()

--- a/datasets_raw.dvc
+++ b/datasets_raw.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 00000000000000000000000000000000.dir
+  size: 0
+  nfiles: 0
+  hash: md5
+  path: datasets/raw

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -150,6 +150,7 @@ class Config:
 
     # Diretórios de saída
     OUTPUT_DIR = "datasets_wikipedia_pro"
+    RAW_DIR = "datasets/raw"
     CACHE_DIR = ".wiki_cache"
     LOG_DIR = "logs"
     ASSETS_DIR = os.environ.get("ASSETS_DIR", "assets")
@@ -562,11 +563,14 @@ def log_failed_url(url: str) -> None:
 
 
 class CacheBackend(Protocol):
-    def get(self, key: str): ...
+    def get(self, key: str):
+        ...
 
-    def set(self, key: str, data, ttl: Optional[int] = None): ...
+    def set(self, key: str, data, ttl: Optional[int] = None):
+        ...
 
-    def stats(self) -> dict: ...
+    def stats(self) -> dict:
+        ...
 
 
 class FileCache(CacheBackend):
@@ -1113,6 +1117,34 @@ def extract_videos(html: str) -> List[str]:
     except Exception as e:
         logger.error(f"Erro ao extrair videos: {e}")
         return []
+
+
+def dump_raw_page(
+    title: str,
+    lang: str,
+    category: str,
+    html: str,
+    text: str,
+    output_dir: str = Config.RAW_DIR,
+) -> None:
+    """Persist raw page ``html`` and ``text`` to ``output_dir``."""
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+        safe = re.sub(r"[^a-zA-Z0-9_-]", "_", title)[:50]
+        path = Path(output_dir) / f"{lang}_{safe}.json"
+        data = {
+            "title": title,
+            "lang": lang,
+            "category": category,
+            "html": html,
+            "text": text,
+        }
+        tmp = str(path) + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+    except Exception as exc:  # pragma: no cover - filesystem errors
+        logger.error(f"Erro ao salvar RAW para {title}: {exc}")
 
 
 def is_captcha_page(html: str) -> bool:
@@ -1947,6 +1979,13 @@ class DatasetBuilder:
 
             # Extrai e limpa o texto
             raw_text = clean_text(page.text)
+            dump_raw_page(
+                page_info["title"],
+                page_info["lang"],
+                page_info.get("category", ""),
+                getattr(page, "_html", ""),
+                raw_text,
+            )
             clean_content = advanced_clean_text(
                 raw_text,
                 page_info["lang"],
@@ -2000,9 +2039,9 @@ class DatasetBuilder:
                 qa_data["videos"] = videos
                 qa_data["video_urls"] = videos
             if self.include_revisions:
-                qa_data.setdefault("metadata", {})["revisions"] = (
-                    wiki.get_revision_history(page_info["title"], self.rev_limit)
-                )
+                qa_data.setdefault("metadata", {})[
+                    "revisions"
+                ] = wiki.get_revision_history(page_info["title"], self.rev_limit)
             metrics.scrape_success.inc()
             metrics.pages_scraped_total.inc()
             ts = None
@@ -2826,6 +2865,7 @@ class DatasetBuilder:
         )
         logger.info(f"Dataset salvo usando backend {Config.STORAGE_BACKEND}")
         track_path(output_dir)
+        track_path(Config.RAW_DIR)
         save_last_scraped(self.last_scraped)
 
         if format == "qa":


### PR DESCRIPTION
## Summary
- persist raw HTML and text before generating QAs
- add CLI command `process-raw` to reprocess saved dumps
- track datasets/raw with DVC

## Testing
- `black scraper_wiki/__init__.py cli.py`
- `pytest -q` *(fails: ModuleNotFoundError and other errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b31586c83208b570277623921b2