### PR TITLE
Add dataset aggregator and merge command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -365,6 +365,23 @@ def build_graph_cmd(
     )
 
 
+@app.command("merge-datasets")
+def merge_datasets_cmd(
+    datasets: List[str] = typer.Argument(..., help="Caminhos para arquivos JSON"),
+    output: str = typer.Option(
+        "merged_dataset.json", "--output", "-o", help="Arquivo de saída"
+    ),
+):
+    """Une múltiplos datasets em um único arquivo deduplicado."""
+    from processing.aggregator import merge_datasets
+
+    merged = merge_datasets(datasets)
+    Path(output).write_text(
+        json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    typer.echo(f"Salvo {len(merged)} registros em {output}")
+
+
 @app.command("start-crawler")
 def start_crawler_cmd(
     config: str = typer.Option(None, "--config", help="Path to cluster config")

--- a/processing/aggregator.py
+++ b/processing/aggregator.py
@@ -1,0 +1,34 @@
+"""Dataset aggregation utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+import dq
+
+
+def _load_file(path: str) -> List[Dict]:
+    """Load dataset records from ``path`` supporting JSON and JSONL."""
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    if p.suffix == ".jsonl":
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+    data = json.loads(text)
+    if isinstance(data, list):
+        return data
+    return data.get("data", []) if isinstance(data, dict) else []
+
+
+def merge_datasets(paths: List[str]) -> List[Dict]:
+    """Return deduplicated records from multiple dataset files."""
+    all_records: List[Dict] = []
+    for path in paths:
+        all_records.extend(_load_file(path))
+    records, _ = dq.deduplicate_by_simhash(all_records)
+    records, _ = dq.deduplicate_by_embedding(records)
+    return records
+
+
+__all__ = ["merge_datasets"]

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from typer.testing import CliRunner
+
+import cli
+from processing import aggregator
+
+
+def test_merge_datasets_deduplicates(tmp_path):
+    rec = {
+        "id": "1",
+        "language": "en",
+        "content": "print('hi')",
+        "created_at": "now",
+    }
+    file1 = tmp_path / "a.json"
+    file2 = tmp_path / "b.json"
+    file1.write_text(json.dumps([rec]), encoding="utf-8")
+    file2.write_text(json.dumps([rec.copy()]), encoding="utf-8")
+
+    merged = aggregator.merge_datasets([str(file1), str(file2)])
+    assert len(merged) == 1
+
+
+def test_cli_merge_datasets(tmp_path):
+    rec = {"id": "1", "language": "en", "content": "print('hi')", "created_at": "now"}
+    f1 = tmp_path / "a.json"
+    f2 = tmp_path / "b.json"
+    f1.write_text(json.dumps([rec]), encoding="utf-8")
+    f2.write_text(json.dumps([rec.copy()]), encoding="utf-8")
+    out = tmp_path / "out.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app, ["merge-datasets", str(f1), str(f2), "--output", str(out)]
+    )
+    assert result.exit_code == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert len(data) == 1


### PR DESCRIPTION
## Summary
- introduce processing/aggregator module for merging datasets
- implement `merge-datasets` command in CLI to combine JSON datasets
- add tests for new aggregator utilities

## Testing
- `black processing/aggregator.py cli.py tests/test_aggregator.py`
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d35bde76c8320865d30bd8c2cbf25