### PR TITLE
Enhance dataset builder with translation and Wikidata IDs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -117,6 +117,12 @@ def scrape(
         False, "--revisions", help="Inclui histórico de revisões", is_flag=True
     ),
     rev_limit: int = typer.Option(5, "--rev-limit", help="Número máximo de revisões"),
+    translate_to: str = typer.Option(
+        None,
+        "--translate",
+        help="Traduz conteúdo para o idioma fornecido",
+        show_default=False,
+    ),
     async_mode: bool = typer.Option(
         False, "--async", help="Usa scraping assíncrono", is_flag=True
     ),
@@ -163,6 +169,7 @@ def scrape(
                     depth=depth,
                     revisions=revisions,
                     rev_limit=rev_limit,
+                    translate_to=translate_to,
                 )
             )
         else:
@@ -175,6 +182,7 @@ def scrape(
                 depth=depth,
                 revisions=revisions,
                 rev_limit=rev_limit,
+                translate_to=translate_to,
                 client=client,
             )
         dataset_file = Path(scraper_wiki.Config.OUTPUT_DIR) / "wikipedia_qa.json"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,15 +22,21 @@ Example dataset entry:
         "title": "Title",
         "language": "en",
         "category": "History",
-   "quality_score": 0.0,
-   "tests": [],
-   "context": "Ada summary",
-   "docstring": "",
-   "raw_code": "",
-   "problems": [],
-   "fixed_version": "",
-   "lessons": "",
-   "origin_metrics": {},
-   "challenge": "",
-   "images": []
-   }
+        "quality_score": 0.0,
+        "tests": [],
+        "context": "Ada summary",
+        "docstring": "",
+        "raw_code": "",
+        "problems": [],
+        "fixed_version": "",
+        "lessons": "",
+        "origin_metrics": {},
+        "challenge": "",
+        "images": [],
+        "metadata": {
+            "length": 1000,
+            "source": "wikipedia",
+            "source_url": "https://en.wikipedia.org/wiki/Title",
+            "entity_ids": ["Q1"]
+        }
+    }

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -86,7 +86,7 @@ import dq
 import metrics
 from integrations import storage_sqlite
 from integrations.binary_storage import BinaryStorage
-from utils.text import clean_text, extract_entities
+from utils.text import clean_text, extract_entities, translate_text
 from utils.relation import extract_relations, extract_relations_regex
 from utils.quality import (
     classify_github_repo,
@@ -1877,9 +1877,12 @@ def cpu_process_page(
     videos: List[str] | None = None,
     revisions: List[dict] | None = None,
     rev_limit: int = 5,
+    translate_to: str | None = None,
 ) -> dict:
     """Executes CPU intensive operations for a page."""
-    builder = DatasetBuilder(include_revisions=revisions, rev_limit=rev_limit)
+    builder = DatasetBuilder(
+        include_revisions=revisions, rev_limit=rev_limit, translate_to=translate_to
+    )
     summary = summarize_text(content, lang)
     record = builder.generate_qa_pairs(
         title=title,
@@ -1918,6 +1921,7 @@ class DatasetBuilder:
         max_complexity: int | None = None,
         thread_executor: ThreadPoolExecutor | None = None,
         process_executor: ProcessPoolExecutor | None = None,
+        translate_to: str | None = None,
         **_,
     ):
         """Initialize the builder and optionally reuse executors.
@@ -1944,6 +1948,7 @@ class DatasetBuilder:
         self.min_complexity = min_complexity
         self.max_complexity = max_complexity
         self.last_scraped = load_last_scraped()
+        self.translate_to = translate_to
 
         self.thread_executor = thread_executor
         self.process_executor = process_executor
@@ -2086,6 +2091,7 @@ class DatasetBuilder:
                     videos,
                     revisions,
                     self.rev_limit,
+                    self.translate_to,
                 )
 
             # Sumariza o conteúdo
@@ -2099,6 +2105,18 @@ class DatasetBuilder:
                 lang=page_info["lang"],
                 category=page_info.get("category", ""),
             )
+            try:
+                from plugins import load_plugin
+
+                wikidata = load_plugin("wikidata")
+                items = wikidata.fetch_items(page_info["lang"], page_info["title"])
+                if items:
+                    parsed = wikidata.parse_item(items[0])
+                    qid = parsed.get("wikidata_id")
+                    if qid:
+                        qa_data.setdefault("metadata", {})["entity_ids"] = [qid]
+            except Exception:
+                pass
             qa_data["entities"] = extract_entities(clean_content)
             images = extract_images(getattr(page, "_html", ""))
             videos = extract_videos(getattr(page, "_html", ""))
@@ -2202,6 +2220,12 @@ class DatasetBuilder:
 
         tags = self._extract_tags(keywords, extra_metadata)
 
+        trans_content = content
+        trans_summary = summary
+        if self.translate_to:
+            trans_content = translate_text(content, self.translate_to)
+            trans_summary = translate_text(summary, self.translate_to)
+
         # Gera múltiplas perguntas baseadas no conteúdo
         questions = self._generate_questions(title, content, lang, keywords)
 
@@ -2215,9 +2239,14 @@ class DatasetBuilder:
 
         # Cria embeddings para busca semântica
         embeddings = self.embedding_model.encode(
-            [content, summary], show_progress_bar=False
+            [trans_content, trans_summary], show_progress_bar=False
         )
         content_embedding, summary_embedding = embeddings
+
+        if self.translate_to:
+            content = trans_content
+            summary = trans_summary
+            lang = self.translate_to
 
         # Classificação avançada de tópicos
         topic, subtopic = self._classify_topic(title, content, lang)
@@ -3022,6 +3051,7 @@ def main(
     depth: int = 1,
     revisions: bool = False,
     rev_limit: int = 5,
+    translate_to: str | None = None,
     client=None,
 ):
     """Gera o dataset utilizando os parâmetros fornecidos."""
@@ -3042,7 +3072,9 @@ def main(
         normalized = [normalize_category(c) or c for c in categories]
         cats = {c: Config.CATEGORIES.get(c, 1.0) for c in normalized}
 
-    builder = DatasetBuilder(include_revisions=revisions, rev_limit=rev_limit)
+    builder = DatasetBuilder(
+        include_revisions=revisions, rev_limit=rev_limit, translate_to=translate_to
+    )
 
     all_pages: List[dict] = []
     for lang in languages:
@@ -3147,6 +3179,7 @@ async def main_async(
     depth: int = 1,
     revisions: bool = False,
     rev_limit: int = 5,
+    translate_to: str | None = None,
 ) -> None:
     """Asynchronous version of :func:`main`."""
     start_time = time.perf_counter()
@@ -3166,7 +3199,9 @@ async def main_async(
         normalized = [normalize_category(c) or c for c in categories]
         cats = {c: Config.CATEGORIES.get(c, 1.0) for c in normalized}
 
-    builder = DatasetBuilder(include_revisions=revisions, rev_limit=rev_limit)
+    builder = DatasetBuilder(
+        include_revisions=revisions, rev_limit=rev_limit, translate_to=translate_to
+    )
 
     all_pages: List[dict] = []
     for lang in languages:

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -92,6 +92,18 @@ def tmp_log_dir(tmp_path, monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def stub_wikidata_plugin(monkeypatch):
+    import plugins
+
+    plugin = SimpleNamespace(
+        fetch_items=lambda l, c: [{"id": "Q1"}],
+        parse_item=lambda item: {"wikidata_id": item["id"]},
+    )
+    monkeypatch.setattr(plugins, "load_plugin", lambda name: plugin)
+    yield
+
+
 class DummyEmbed:
     def encode(self, *args, **kwargs):
         import numpy as np
@@ -188,6 +200,27 @@ def test_generate_qa_pairs_extracts_tags(monkeypatch):
     assert {"tag": "python", "link": None} in result["tags"]
     for field in ["diagram_path", "theory_links", "explanations"]:
         assert field in result
+
+
+def test_generate_qa_pairs_translates(monkeypatch):
+    qb = sw.DatasetBuilder(translate_to="es")
+    monkeypatch.setattr(qb, "_generate_questions", lambda *a, **k: [])
+    monkeypatch.setattr(qb, "_generate_answers", lambda *a, **k: [])
+    monkeypatch.setattr(sw, "extract_relations", lambda *a, **k: [])
+    captured = {}
+
+    def fake_encode(texts, show_progress_bar=False):
+        captured["texts"] = texts
+        import numpy as np
+
+        return np.zeros((2, 3))
+
+    monkeypatch.setattr(qb.embedding_model, "encode", fake_encode)
+    monkeypatch.setattr(sw, "translate_text", lambda text, lang: f"{text}-{lang}")
+    qb.generate_qa_pairs(
+        title="T", content="content", summary="sum", lang="en", category="c"
+    )
+    assert captured["texts"] == ["content-es", "sum-es"]
 
 
 def test_advanced_clean_text_removes_html():
@@ -582,7 +615,13 @@ def test_process_page_uses_clean_text(monkeypatch):
     builder = sw.DatasetBuilder()
     res = builder.process_page({"title": "T", "lang": "en"})
 
-    assert res == {"entities": [], "images": [], "image_paths": [], "video_urls": []}
+    assert res == {
+        "entities": [],
+        "images": [],
+        "image_paths": [],
+        "video_urls": [],
+        "metadata": {"entity_ids": ["Q1"]},
+    }
     assert called["clean"] == "raw text"
     assert called["adv"] == ("cleaned", "en", True)
 
@@ -638,6 +677,7 @@ def test_process_page_increments_counter(monkeypatch):
         "images": [],
         "image_paths": [],
         "video_urls": [],
+        "metadata": {"entity_ids": ["Q1"]},
     }
     assert counts["pages"] == 1
 
@@ -693,6 +733,7 @@ def test_process_page_records_histogram(monkeypatch):
         "images": [],
         "image_paths": [],
         "video_urls": [],
+        "metadata": {"entity_ids": ["Q1"]},
     }
     assert observed["count"] == 1
 
@@ -746,6 +787,39 @@ def test_process_page_downloads_assets(monkeypatch, tmp_path):
 
     assert res["image_paths"] == [str(tmp_path / "img.jpg")]
     assert res["video_urls"] == ["http://x/v.mp4"]
+
+
+def test_process_page_adds_entity_ids(monkeypatch):
+    class DummyPage:
+        text = "t" * 200
+
+        def exists(self):
+            return True
+
+    class DummyWiki:
+        def __init__(self, lang):
+            pass
+
+        def fetch_page(self, title):
+            return DummyPage()
+
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 10)
+    monkeypatch.setattr(sw, "WikipediaAdvanced", DummyWiki)
+    monkeypatch.setattr(sw, "clean_text", lambda t: t)
+    monkeypatch.setattr(
+        sw, "advanced_clean_text", lambda t, lang, remove_stopwords=False: t
+    )
+    monkeypatch.setattr(sw, "summarize_text", lambda *a, **k: "")
+    monkeypatch.setattr(
+        sw.DatasetBuilder, "generate_qa_pairs", lambda *a, **k: {"ok": True}
+    )
+    monkeypatch.setattr(sw, "extract_entities", lambda text: [])
+    monkeypatch.setattr(sw, "extract_images", lambda html: [])
+    monkeypatch.setattr(sw, "extract_videos", lambda html: [])
+    monkeypatch.setattr(sw.binary_storage, "save", lambda url: url)
+    builder = sw.DatasetBuilder()
+    res = builder.process_page({"title": "T", "lang": "en"})
+    assert res["metadata"]["entity_ids"] == ["Q1"]
 
 
 def test_save_dataset_json_csv(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- integrate optional page translation via `--translate` flag
- fetch Wikidata entity IDs during page processing
- document new `metadata.entity_ids` field
- add tests for translation and wikidata integration

## Testing
- `black cli.py scraper_wiki/__init__.py tests/test_scraper_wiki.py`
- `pytest tests/test_scraper_wiki.py -k generate_qa_pairs_translates -q`
- `pytest` *(fails: ModuleNotFoundError: No module named '...')*

------
https://chatgpt.com/codex/tasks/task_e_685d38a61780832092e5547413675672