### PR TITLE
Add synthetic QA generation

### DIFF
--- a/enrichment/generator.py
+++ b/enrichment/generator.py
@@ -92,3 +92,55 @@ def link_theory(text: str) -> List[str]:
 
 
 __all__ = ["generate_diagram", "generate_explanations", "link_theory"]
+
+
+def generate_synthetic_qa(topic: str, lang: str = "en", n: int = 1) -> List[dict]:
+    """Return ``n`` synthetic question/answer pairs for ``topic``.
+
+    The function attempts to use ``transformers`` text generation models if
+    available. When the dependency or model loading fails, simple heuristic
+    answers based on :func:`generate_explanations` are returned instead.
+
+    Parameters
+    ----------
+    topic : str
+        Topic used to craft the prompt for the language model.
+    lang : str
+        Language of the desired output.
+    n : int
+        Number of question/answer pairs to generate.
+
+    Returns
+    -------
+    List[dict]
+        List of dictionaries with ``question`` and ``answer`` keys.
+    """
+
+    try:  # pragma: no cover - optional dependency
+        from transformers import pipeline
+
+        generator = pipeline("text-generation", model="distilgpt2")
+    except Exception:  # pragma: no cover - fallback when transformers missing
+        generator = None
+
+    pairs: List[dict] = []
+    for _ in range(max(1, n)):
+        question = f"What is {topic}?"
+        if generator:
+            try:  # pragma: no cover - model inference
+                prompt = f"{question} Answer:"
+                res = generator(prompt, max_new_tokens=40, num_return_sequences=1)[0][
+                    "generated_text"
+                ]
+                answer = res.split("Answer:", 1)[-1].strip()
+            except Exception:  # pragma: no cover - inference failure
+                answer = generate_explanations(topic, lang)["medium"]
+        else:
+            answer = generate_explanations(topic, lang)["medium"]
+
+        pairs.append({"question": question, "answer": answer})
+
+    return pairs
+
+
+__all__.append("generate_synthetic_qa")

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -51,6 +51,7 @@ from pathlib import Path
 import hashlib
 import pickle
 import zlib
+import uuid
 from bs4 import BeautifulSoup
 import requests
 import aiohttp
@@ -114,8 +115,10 @@ from enrichment.generator import (
     generate_diagram,
     generate_explanations,
     link_theory,
+    generate_synthetic_qa,
 )
 from utils.sonarqube import analyze_code
+from utils.gap_analysis import identify_gaps
 
 
 HANDLED_EXCEPTIONS = (
@@ -1922,6 +1925,7 @@ class DatasetBuilder:
         thread_executor: ThreadPoolExecutor | None = None,
         process_executor: ProcessPoolExecutor | None = None,
         translate_to: str | None = None,
+        synthetic_pairs_per_gap: int = 0,
         **_,
     ):
         """Initialize the builder and optionally reuse executors.
@@ -1949,6 +1953,7 @@ class DatasetBuilder:
         self.max_complexity = max_complexity
         self.last_scraped = load_last_scraped()
         self.translate_to = translate_to
+        self.synthetic_pairs_per_gap = synthetic_pairs_per_gap
 
         self.thread_executor = thread_executor
         self.process_executor = process_executor
@@ -2825,8 +2830,43 @@ class DatasetBuilder:
             self.dataset, self.min_complexity, self.max_complexity
         )
 
+    def augment_with_synthetic_data(self, min_ratio: float = 0.1) -> None:
+        """Augment dataset generating synthetic question/answer pairs."""
+
+        if self.synthetic_pairs_per_gap <= 0 or not self.dataset:
+            return
+
+        gaps = identify_gaps(self.dataset, min_ratio=min_ratio)
+        languages = gaps.get("languages", []) or ["en"]
+        topics = gaps.get("topics", []) or ["general"]
+
+        for lang in languages:
+            for topic in topics:
+                pairs = generate_synthetic_qa(
+                    topic, lang, n=self.synthetic_pairs_per_gap
+                )
+                for q in pairs:
+                    self.dataset.append(
+                        {
+                            "id": uuid.uuid4().hex,
+                            "language": lang,
+                            "category": "synthetic",
+                            "topic": topic,
+                            "content": "",
+                            "summary": "",
+                            "questions": [q["question"]],
+                            "answers": [q["answer"]],
+                            "relations": [],
+                            "created_at": datetime.utcnow().isoformat(),
+                            "metadata": {"synthetic": True},
+                        }
+                    )
+
     def save_dataset(self, format: str = "all", output_dir: str = Config.OUTPUT_DIR):
         os.makedirs(output_dir, exist_ok=True)
+
+        # Optionally generate synthetic question/answer pairs
+        self.augment_with_synthetic_data()
 
         if not self.dataset:
             logger.warning("Nenhum dado para salvar")

--- a/tests/test_synthetic_generation.py
+++ b/tests/test_synthetic_generation.py
@@ -1,0 +1,36 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace, ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Stub heavy deps
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(SentenceTransformer=object)
+)
+sys.modules.setdefault(
+    "datasets",
+    SimpleNamespace(Dataset=object, concatenate_datasets=lambda *a, **k: None),
+)
+sys.modules.setdefault("spacy", SimpleNamespace(load=lambda *a, **k: None))
+sys.modules.setdefault("unidecode", SimpleNamespace(unidecode=lambda x: x))
+sys.modules.setdefault("tqdm", SimpleNamespace(tqdm=lambda x, **k: x))
+sys.modules.setdefault("html2text", SimpleNamespace())
+
+sw = importlib.import_module("scraper_wiki")
+
+gen = importlib.import_module("enrichment.generator")
+
+
+def test_augment_with_synthetic(monkeypatch):
+    builder = sw.DatasetBuilder(synthetic_pairs_per_gap=1)
+    builder.dataset = [{"language": "en", "topic": "a"}]
+
+    monkeypatch.setattr(
+        gen, "generate_synthetic_qa", lambda *a, **k: [{"question": "q", "answer": "a"}]
+    )
+
+    builder.augment_with_synthetic_data(min_ratio=0.6)
+    assert any(rec.get("metadata", {}).get("synthetic") for rec in builder.dataset)


### PR DESCRIPTION
## Summary
- create `generate_synthetic_qa` helper for LLM-based pair generation
- add synthetic augmentation support in `DatasetBuilder`
- allow configuring synthetic pairs in DatasetBuilder
- include new unit test for synthetic data generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_685d3e54762883209e33296f5d4735ea