### PR TITLE
Implement incremental dedup via provenance

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -170,6 +170,7 @@ def scrape(
                     revisions=revisions,
                     rev_limit=rev_limit,
                     translate_to=translate_to,
+                    incremental=incremental,
                 )
             )
         else:
@@ -184,6 +185,7 @@ def scrape(
                 rev_limit=rev_limit,
                 translate_to=translate_to,
                 client=client,
+                incremental=incremental,
             )
         dataset_file = Path(scraper_wiki.Config.OUTPUT_DIR) / "wikipedia_qa.json"
         if dataset_file.exists() and train:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -94,7 +94,7 @@ def run_plugin(
                     latest = ts if latest is None or ts > latest else latest
             if incremental and latest:
                 storage_sqlite.set_last_processed(key, str(latest))
-    builder.save_dataset(fmt)
+    builder.save_dataset(fmt, incremental=incremental)
     return builder.dataset
 
 

--- a/provenance/__init__.py
+++ b/provenance/__init__.py
@@ -1,4 +1,19 @@
-from .tracker import record_provenance, get_provenance, should_fetch
+from .tracker import (
+    record_provenance,
+    get_provenance,
+    should_fetch,
+    compute_record_hash,
+    dataset_hash_exists,
+    record_dataset_hash,
+)
 from .compliance import check_license
 
-__all__ = ["record_provenance", "get_provenance", "should_fetch", "check_license"]
+__all__ = [
+    "record_provenance",
+    "get_provenance",
+    "should_fetch",
+    "compute_record_hash",
+    "dataset_hash_exists",
+    "record_dataset_hash",
+    "check_license",
+]

--- a/provenance/tracker.py
+++ b/provenance/tracker.py
@@ -3,6 +3,7 @@ import sqlite3
 import hashlib
 from datetime import datetime, timedelta
 from typing import Optional, Dict
+import json
 
 
 def _ensure_db(db_path: str) -> sqlite3.Connection:
@@ -12,6 +13,9 @@ def _ensure_db(db_path: str) -> sqlite3.Connection:
     conn = sqlite3.connect(db_path)
     conn.execute(
         "CREATE TABLE IF NOT EXISTS provenance (url TEXT PRIMARY KEY, ts TEXT, hash TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS dataset_hashes (hash TEXT PRIMARY KEY, ts TEXT)"
     )
     return conn
 
@@ -59,3 +63,38 @@ def should_fetch(
     if datetime.utcnow() - ts > timedelta(hours=max_age_hours):
         return True
     return False
+
+
+def compute_record_hash(record: Dict) -> str:
+    """Return SHA256 hash of ``record`` serialized deterministically."""
+    data = json.dumps(record, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def dataset_hash_exists(record_hash: str, db_path: str = "provenance.sqlite") -> bool:
+    """Check if ``record_hash`` is already stored."""
+    conn = _ensure_db(db_path)
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM dataset_hashes WHERE hash=?",
+            (record_hash,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return row is not None
+
+
+def record_dataset_hash(record: Dict, db_path: str = "provenance.sqlite") -> str:
+    """Store hash of ``record`` and return it."""
+    h = compute_record_hash(record)
+    ts = datetime.utcnow().isoformat()
+    conn = _ensure_db(db_path)
+    try:
+        with conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO dataset_hashes (hash, ts) VALUES (?, ?)",
+                (h, ts),
+            )
+    finally:
+        conn.close()
+    return h

--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -2867,7 +2867,13 @@ class DatasetBuilder:
                         }
                     )
 
-    def save_dataset(self, format: str = "all", output_dir: str = Config.OUTPUT_DIR):
+    def save_dataset(
+        self,
+        format: str = "all",
+        output_dir: str = Config.OUTPUT_DIR,
+        *,
+        incremental: bool = False,
+    ):
         os.makedirs(output_dir, exist_ok=True)
 
         # Optionally generate synthetic question/answer pairs
@@ -2952,6 +2958,24 @@ class DatasetBuilder:
 
             if valid:
                 validated_data.append(item)
+
+        # Skip records already saved when incremental mode is on
+        if incremental:
+            try:
+                from provenance import tracker as prov
+
+                filtered = []
+                for rec in validated_data:
+                    h = prov.compute_record_hash(rec)
+                    if prov.dataset_hash_exists(h):
+                        self.duplicates_removed += 1
+                        continue
+                    prov.record_dataset_hash(rec)
+                    rec.setdefault("metadata", {})["record_hash"] = h
+                    filtered.append(rec)
+                validated_data = filtered
+            except Exception as e:  # pragma: no cover - db errors
+                logger.error(f"Erro verificação incremental: {e}")
 
         # Quality metrics
         try:
@@ -3098,6 +3122,7 @@ def main(
     rev_limit: int = 5,
     translate_to: str | None = None,
     client=None,
+    incremental: bool = False,
 ):
     """Gera o dataset utilizando os parâmetros fornecidos."""
     start_time = time.perf_counter()
@@ -3207,7 +3232,7 @@ def main(
             builder._update_progress()
 
     logger.info("💾 Salvando dataset completo...")
-    builder.save_dataset(format=fmt)
+    builder.save_dataset(format=fmt, incremental=incremental)
 
     logger.info("✅ Dataset finalizado com sucesso!")
     logger.info(f"📊 Estatísticas de cache: {cache.stats()}")
@@ -3225,6 +3250,7 @@ async def main_async(
     revisions: bool = False,
     rev_limit: int = 5,
     translate_to: str | None = None,
+    incremental: bool = False,
 ) -> None:
     """Asynchronous version of :func:`main`."""
     start_time = time.perf_counter()
@@ -3329,7 +3355,7 @@ async def main_async(
             builder._update_progress()
 
     logger.info("💾 Salvando dataset completo...")
-    builder.save_dataset(format=fmt)
+    builder.save_dataset(format=fmt, incremental=incremental)
 
     logger.info("✅ Dataset finalizado com sucesso!")
     logger.info(f"📊 Estatísticas de cache: {cache.stats()}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,6 +398,19 @@ def test_scrape_incremental_option(monkeypatch):
     assert captured.get("inc") is True
 
 
+def test_scrape_incremental_wikipedia(monkeypatch):
+    captured = {}
+
+    def fake_main(*args, **kwargs):
+        captured["inc"] = kwargs.get("incremental")
+
+    monkeypatch.setattr(cli.scraper_wiki, "main", fake_main)
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["scrape", "--incremental"])
+    assert result.exit_code == 0
+    assert captured.get("inc") is True
+
+
 def test_start_crawler_cli(monkeypatch):
     called = {}
     import crawling.distributed as dist

--- a/tests/test_datasetbuilder_dedup.py
+++ b/tests/test_datasetbuilder_dedup.py
@@ -126,3 +126,68 @@ def test_save_dataset_deduplicates(monkeypatch, tmp_path):
     assert len(builder.dataset) == 1
     out = (tmp_path / "wikipedia_qa.json").read_text(encoding="utf-8")
     assert len(json.loads(out)) == 1
+
+
+def test_save_dataset_incremental(monkeypatch, tmp_path):
+    class DummyEmbed:
+        pass
+
+    monkeypatch.setattr(
+        sw.NLPProcessor,
+        "get_embedding_model",
+        classmethod(lambda cls: DummyEmbed()),
+    )
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 1)
+    base_record = {
+        "id": "1",
+        "title": "T",
+        "language": "en",
+        "category": "c",
+        "topic": "ai",
+        "subtopic": "nlp",
+        "keywords": [],
+        "content": "text",
+        "summary": "sum",
+        "content_embedding": [0.1],
+        "summary_embedding": [0.1],
+        "questions": ["q"],
+        "answers": ["a"],
+        "relations": [],
+        "created_at": "now",
+        "metadata": {},
+    }
+
+    import provenance.tracker as tracker
+
+    db = tmp_path / "prov.sqlite"
+
+    monkeypatch.setattr(
+        tracker,
+        "record_dataset_hash",
+        lambda rec, db_path="provenance.sqlite": tracker.record_dataset_hash(
+            rec, db_path=str(db)
+        ),
+    )
+    monkeypatch.setattr(
+        tracker,
+        "dataset_hash_exists",
+        lambda h, db_path="provenance.sqlite": tracker.dataset_hash_exists(
+            h, db_path=str(db)
+        ),
+    )
+
+    monkeypatch.setattr(sw.dq, "strip_credentials", lambda t: t)
+    monkeypatch.setattr(sw.dq, "remove_pii", lambda t: t)
+    monkeypatch.setattr(sw.dq, "detect_code_plagiarism", lambda d: [])
+    monkeypatch.setattr(sw.dq, "deduplicate_by_simhash", lambda d: (d, 0))
+    monkeypatch.setattr(sw, "extract_entities", lambda text: [])
+
+    builder = sw.DatasetBuilder()
+    builder.dataset = [base_record]
+    builder.save_dataset("json", output_dir=tmp_path, incremental=True)
+
+    builder2 = sw.DatasetBuilder()
+    builder2.dataset = [base_record]
+    builder2.save_dataset("json", output_dir=tmp_path, incremental=True)
+
+    assert builder2.duplicates_removed == 1

--- a/tests/test_provenance_tracker.py
+++ b/tests/test_provenance_tracker.py
@@ -21,3 +21,12 @@ def test_should_fetch_logic():
         tracker.record_provenance(url, "c", db_path=str(db))
         assert not tracker.should_fetch(url, db_path=str(db))
         assert tracker.should_fetch(url, max_age_hours=0, db_path=str(db))
+
+
+def test_dataset_hash_tracking(tmp_path):
+    db = tmp_path / "prov.sqlite"
+    record = {"id": "1", "text": "hello"}
+    h = tracker.compute_record_hash(record)
+    assert not tracker.dataset_hash_exists(h, db_path=str(db))
+    tracker.record_dataset_hash(record, db_path=str(db))
+    assert tracker.dataset_hash_exists(h, db_path=str(db))


### PR DESCRIPTION
## Summary
- track dataset record hashes in `provenance.tracker`
- skip records that already exist when saving with `incremental=True`
- propagate incremental option through CLI and plugin runner
- add tests for new behaviour

## Testing
- `black provenance/tracker.py provenance/__init__.py scraper_wiki/__init__.py plugins/__init__.py cli.py tests/test_provenance_tracker.py tests/test_datasetbuilder_dedup.py tests/test_cli.py`
- `pytest -q` *(fails: ModuleNotFoundError due to missing optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_685d498f23e08320aa5cce85c38c27e4