### PR TITLE
Add dataset diff tracking

### DIFF
--- a/scraper_wiki/__init__.py
+++ b/scraper_wiki/__init__.py
@@ -3026,6 +3026,7 @@ class DatasetBuilder:
                 old_info = {}
         old_version = old_info.get("version", "0.0.0")
         old_size = old_info.get("size", 0)
+        old_ids = set(old_info.get("record_ids", []))
         new_version = _bump(old_version)
 
         backend.save_dataset(
@@ -3054,6 +3055,23 @@ class DatasetBuilder:
             except Exception as e:
                 logger.error(f"Erro ao salvar dataset HuggingFace: {e}")
 
+        # Audit diff between current and previous dataset
+        current_ids = [item.get("id") for item in sorted_data if item.get("id")]
+        diff_path = os.path.join(output_dir, f"diff_{new_version}.json")
+        try:
+            with open(diff_path, "w", encoding="utf-8") as df:
+                json.dump(
+                    {
+                        "added": sorted(set(current_ids) - old_ids),
+                        "removed": sorted(old_ids - set(current_ids)),
+                    },
+                    df,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+        except Exception as e:  # pragma: no cover - unexpected I/O errors
+            logger.error(f"Erro ao salvar diff file: {e}")
+
         # Write metadata about the dataset
         try:
             sources = {
@@ -3072,6 +3090,7 @@ class DatasetBuilder:
                 ),
                 "version": new_version,
                 "size": len(sorted_data),
+                "record_ids": current_ids,
             }
             with open(
                 os.path.join(output_dir, "dataset_info.json"), "w", encoding="utf-8"
@@ -3086,7 +3105,7 @@ class DatasetBuilder:
                     os.path.join(output_dir, "CHANGELOG.txt"), "a", encoding="utf-8"
                 ) as cf:
                     cf.write(
-                        f"{datetime.utcnow().isoformat()} - v{new_version} size changed {old_size}->{len(sorted_data)}\n"
+                        f"{datetime.utcnow().isoformat()} - v{new_version} size changed {old_size}->{len(sorted_data)} diff: diff_{new_version}.json\n"
                     )
             if diff_ratio > 0.5:
                 send_alert(

--- a/tests/test_scraper_wiki.py
+++ b/tests/test_scraper_wiki.py
@@ -2217,3 +2217,50 @@ def test_save_dataset_removes_pii(tmp_path, monkeypatch):
 
     data = json.loads((tmp_path / "wikipedia_qa.json").read_text(encoding="utf-8"))
     assert "<PII>" in data[0]["content"]
+
+
+def _make_record(i: str) -> dict:
+    return {
+        "id": i,
+        "title": "t",
+        "language": "en",
+        "category": "c",
+        "topic": "ai",
+        "subtopic": "nlp",
+        "keywords": [],
+        "content": "c" * 20,
+        "summary": "s" * 20,
+        "content_embedding": [0.0],
+        "summary_embedding": [0.0],
+        "questions": ["q"],
+        "answers": ["a"],
+        "relations": [],
+        "created_at": "now",
+        "metadata": {},
+    }
+
+
+def test_dataset_diff_written(tmp_path, monkeypatch):
+    builder = sw.DatasetBuilder()
+    monkeypatch.setattr(sw.Config, "MIN_TEXT_LENGTH", 5)
+    builder.dataset = [_make_record("1"), _make_record("2")]
+    builder.save_dataset("json", output_dir=tmp_path)
+
+    info = json.loads((tmp_path / "dataset_info.json").read_text(encoding="utf-8"))
+    ver1 = info["version"]
+    diff1 = json.loads((tmp_path / f"diff_{ver1}.json").read_text(encoding="utf-8"))
+    assert set(diff1["added"]) == {"1", "2"}
+    assert diff1["removed"] == []
+
+    builder.dataset = [_make_record("2"), _make_record("3")]
+    builder.save_dataset("json", output_dir=tmp_path)
+
+    info = json.loads((tmp_path / "dataset_info.json").read_text(encoding="utf-8"))
+    ver2 = info["version"]
+    diff2 = json.loads((tmp_path / f"diff_{ver2}.json").read_text(encoding="utf-8"))
+    assert diff2["added"] == ["3"]
+    assert diff2["removed"] == ["1"]
+    changelog = (
+        (tmp_path / "CHANGELOG.txt").read_text(encoding="utf-8").splitlines()[-1]
+    )
+    assert f"diff_{ver2}.json" in changelog


### PR DESCRIPTION
## Summary
- save dataset record IDs and diff files for auditing
- reference diff files from CHANGELOG entries
- test dataset diff functionality

## Testing
- `pip install requests typer datasets numpy aiohttp beautifulsoup4 networkx tqdm wikipedia-api redis prometheus-client`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer', plus other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d4cfecd288320ab26b10adbd8531c