### PR TITLE
Add plugin webui helper and test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,8 @@ requests_stub = ModuleType("requests")
 requests_stub.get = lambda *a, **k: SimpleNamespace(status_code=200, text="")
 requests_stub.post = lambda *a, **k: SimpleNamespace(status_code=200, text="")
 requests_stub.exceptions = SimpleNamespace(RequestException=Exception)
+requests_stub.RequestException = Exception
+requests_stub.Response = object
 sys.modules.setdefault("requests", requests_stub)
 
 sys.modules.setdefault("yaml", SimpleNamespace(safe_load=lambda *a, **k: {}))

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -118,6 +118,35 @@ def test_scrape_endpoint(monkeypatch):
     assert resp.json() == {"status": "ok"}
 
 
+def test_scrape_plugin_execution(monkeypatch, tmp_path):
+    client = create_client(monkeypatch)
+    monkeypatch.setattr(api_app.sw.Config, "OUTPUT_DIR", str(tmp_path))
+
+    called = {}
+
+    def fake_run_plugin(plugin, langs, categories, fmt, incremental=False):
+        called["plugin"] = plugin
+        called["langs"] = langs
+        called["categories"] = categories
+        (tmp_path / "wikipedia_qa.json").write_text("[]", encoding="utf-8")
+        return []
+
+    import plugins
+
+    monkeypatch.setattr(plugins, "run_plugin", fake_run_plugin)
+    monkeypatch.setattr(plugins, "load_plugin", lambda n: "plug")
+
+    resp = client.post(
+        "/scrape",
+        json={"plugin": "plug", "category": "term", "lang": "en", "format": "json"},
+    )
+    assert resp.status_code == 200
+    assert called["plugin"] == "plug"
+    assert called["langs"] == ["en"]
+    assert called["categories"] == ["term"]
+    assert (tmp_path / "wikipedia_qa.json").exists()
+
+
 def test_records_endpoint(monkeypatch):
     client = create_client(monkeypatch)
     resp = client.get("/records")

--- a/webui.py
+++ b/webui.py
@@ -1,0 +1,21 @@
+"""Minimal search web UI using plugins."""
+
+from typing import Any
+
+from plugins import load_plugin, run_plugin
+
+
+def execute_search(term: str, plugin_name: str = "wikipedia") -> list[dict[str, Any]]:
+    """Run ``plugin_name`` for ``term`` and return collected records."""
+    plugin = load_plugin(plugin_name)
+    return run_plugin(plugin, langs=["en"], categories=[term], fmt="json")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run a plugin search")
+    parser.add_argument("term", help="Search term")
+    parser.add_argument("--plugin", default="wikipedia", help="Plugin name")
+    args = parser.parse_args()
+    execute_search(args.term, args.plugin)


### PR DESCRIPTION
## Summary
- add a minimal `webui.py` helper using `load_plugin`/`run_plugin`
- extend requests stub in tests
- test that `/api/scrape` runs plugins and writes output

## Testing
- `pytest tests/test_api_app.py::test_scrape_plugin_execution -q`
- `pytest -q` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d65a7b3b4832092925089689bef34