### PR TITLE
Fix output name sanitization

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from pathlib import Path
 from typing import List, Optional
 
@@ -11,6 +12,18 @@ import dashboard
 from search import indexer
 
 app = typer.Typer(help="Scraper Wiki command line interface")
+
+
+def _sanitize_output(name: str) -> Path:
+    """Return sanitized output ``Path`` within Config.OUTPUT_DIR."""
+    base = Path(name).name
+    if not re.fullmatch(r"[\w.-]+", base):
+        raise typer.BadParameter("Invalid characters in output name")
+    out_dir = Path(scraper_wiki.Config.OUTPUT_DIR)
+    out_path = out_dir / base
+    if out_path.resolve().parent != out_dir.resolve():
+        raise typer.BadParameter("Output path outside output directory")
+    return out_path
 
 
 @app.callback(invoke_without_command=False)
@@ -386,10 +399,11 @@ def merge_datasets_cmd(
     from processing.aggregator import merge_datasets
 
     merged = merge_datasets(datasets)
-    Path(output).write_text(
+    out_path = _sanitize_output(output)
+    out_path.write_text(
         json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8"
     )
-    typer.echo(f"Salvo {len(merged)} registros em {output}")
+    typer.echo(f"Salvo {len(merged)} registros em {out_path}")
 
 
 @app.command("start-crawler")

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -22,18 +22,32 @@ def test_merge_datasets_deduplicates(tmp_path):
     assert len(merged) == 1
 
 
-def test_cli_merge_datasets(tmp_path):
+def test_cli_merge_datasets(tmp_path, monkeypatch):
     rec = {"id": "1", "language": "en", "content": "print('hi')", "created_at": "now"}
     f1 = tmp_path / "a.json"
     f2 = tmp_path / "b.json"
     f1.write_text(json.dumps([rec]), encoding="utf-8")
     f2.write_text(json.dumps([rec.copy()]), encoding="utf-8")
-    out = tmp_path / "out.json"
+
+    monkeypatch.setattr(cli.scraper_wiki.Config, "OUTPUT_DIR", str(tmp_path))
 
     runner = CliRunner()
     result = runner.invoke(
-        cli.app, ["merge-datasets", str(f1), str(f2), "--output", str(out)]
+        cli.app, ["merge-datasets", str(f1), str(f2), "--output", "out.json"]
     )
     assert result.exit_code == 0
-    data = json.loads(out.read_text(encoding="utf-8"))
+    data = json.loads((tmp_path / "out.json").read_text(encoding="utf-8"))
     assert len(data) == 1
+
+
+def test_cli_merge_datasets_invalid_name(tmp_path, monkeypatch):
+    rec = {"id": "1"}
+    f = tmp_path / "a.json"
+    f.write_text(json.dumps([rec]), encoding="utf-8")
+    monkeypatch.setattr(cli.scraper_wiki.Config, "OUTPUT_DIR", str(tmp_path))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app, ["merge-datasets", str(f), "--output", "../bad.json"]
+    )
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- sanitize output filename in merge-datasets command
- restrict characters and enforce output directory
- test normal and malicious filenames

## Testing
- `pytest tests/test_aggregator.py -q` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pip install --use-pep517 -r requirements.txt` *(failed to complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685d72e19ab48320b9d664d8c96d619e