### PR TITLE
Add server usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ See [docs/setup.md](docs/setup.md) for installation and configuration instructio
 
 Additional deployment examples, including Kubernetes manifests and scaling guidance, are available in [docs/scaling.md](docs/scaling.md).
 Scheduling options using Airflow or cron are covered in [docs/scheduling.md](docs/scheduling.md).
+
+## Starting the Interface
+
+Launch the API server with:
+
+```bash
+python cli.py serve
+```
+
+By default it listens on `http://0.0.0.0:8000`. A typical workflow is to start
+the server and then issue requests such as `curl http://localhost:8000/api/plugins`
+or POST jobs to `/api/scrape` as shown in [docs/usage.md](docs/usage.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,6 +40,23 @@ Retrieve records:
 curl "http://localhost:8000/records?lang=pt&category=Programação"
 ```
 
+List plugins:
+
+```bash
+curl http://localhost:8000/api/plugins
+```
+
+Run a scrape via API:
+
+```bash
+curl -X POST http://localhost:8000/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"lang": ["en"], "category": ["Science"], "format": "json"}'
+```
+
+The dashboard and web UI interact with these endpoints to populate options and
+submit scraping tasks on behalf of the user.
+
 ## Plugins
 
 Enable a plugin with `--plugin` or via API payload. Available options include `infobox_parser`, `table_parser`, `github_scraper`, `wikidata`, `stackoverflow` and more.


### PR DESCRIPTION
## Summary
- document how to launch the interface via `python cli.py serve`
- document API endpoints `/api/plugins` and `/api/scrape`

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'ClientError')*

------
https://chatgpt.com/codex/tasks/task_e_685d808a7da8832083df9256ffab5ea0