### PR TITLE
Implement token security utils and rate limiter

### DIFF
--- a/api/api_app.py
+++ b/api/api_app.py
@@ -11,7 +11,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import JSONResponse
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from api.security import auth_scheme, require_token, RateLimitMiddleware
 from pydantic import BaseModel
 from scraper_wiki.models import DatasetRecord
 import scraper_wiki as sw
@@ -27,17 +27,8 @@ from search import indexer
 
 
 app = FastAPI()
+app.add_middleware(RateLimitMiddleware)
 api_router = APIRouter(prefix="/api")
-
-auth_scheme = HTTPBearer(auto_error=False)
-
-
-def require_token(credentials: HTTPAuthorizationCredentials = Depends(auth_scheme)):
-    token = os.environ.get("API_TOKEN")
-    if token and (credentials is None or credentials.credentials != token):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized"
-        )
 
 
 DATA_FILE = os.path.join(sw.Config.OUTPUT_DIR, "wikipedia_qa.json")

--- a/api/security.py
+++ b/api/security.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import time
+from collections import defaultdict
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+auth_scheme = HTTPBearer(auto_error=False)
+
+
+def require_token(
+    credentials: HTTPAuthorizationCredentials = Depends(auth_scheme),
+) -> None:
+    """Validate bearer token if ``API_TOKEN`` is set."""
+    token = os.environ.get("API_TOKEN")
+    if token and (credentials is None or credentials.credentials != token):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized"
+        )
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Naïve per-IP rate limiter."""
+
+    def __init__(
+        self, app, limit: Optional[int] = None, window: Optional[int] = None
+    ) -> None:
+        super().__init__(app)
+        self.limit = int(os.environ.get("API_RATE_LIMIT", str(limit or 100)))
+        self.window = int(os.environ.get("API_RATE_WINDOW", str(window or 60)))
+        self.requests: defaultdict[str, list[float]] = defaultdict(list)
+
+    async def dispatch(self, request: Request, call_next):
+        ip = request.client.host if request.client else "anonymous"
+        now = time.time()
+        window_start = now - self.window
+        times = [t for t in self.requests[ip] if t > window_start]
+        if len(times) >= self.limit:
+            return JSONResponse(
+                {"detail": "Rate limit exceeded"},
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+        times.append(now)
+        self.requests[ip] = times
+        return await call_next(request)

--- a/dashboard.py
+++ b/dashboard.py
@@ -12,11 +12,13 @@ PROGRESS_FILE = Path("logs/progress.json")
 API_BASE = os.environ.get("API_BASE", "http://localhost:8000")
 PROM_URL = os.environ.get("PROMETHEUS_URL", "http://localhost:9090")
 LOG_FILE = Path(os.environ.get("LOG_FILE", "logs/scraper.log"))
+API_TOKEN = os.environ.get("API_TOKEN")
+HEADERS = {"Authorization": f"Bearer {API_TOKEN}"} if API_TOKEN else None
 
 
 def load_progress():
     try:
-        resp = requests.get(f"{API_BASE}/stats", timeout=5)
+        resp = requests.get(f"{API_BASE}/stats", timeout=5, headers=HEADERS)
         resp.raise_for_status()
         return resp.json()
     except Exception:
@@ -31,7 +33,7 @@ def load_progress():
 
 def load_dataset_info():
     try:
-        resp = requests.get(f"{API_BASE}/dataset/summary", timeout=5)
+        resp = requests.get(f"{API_BASE}/dataset/summary", timeout=5, headers=HEADERS)
         resp.raise_for_status()
         return resp.json()
     except Exception:
@@ -47,7 +49,9 @@ def tail_logs(lines: int = 20) -> str:
 
 def enqueue_tasks(tasks: list[dict]) -> bool:
     try:
-        resp = requests.post(f"{API_BASE}/queue/add", json=tasks, timeout=5)
+        resp = requests.post(
+            f"{API_BASE}/queue/add", json=tasks, timeout=5, headers=HEADERS
+        )
         return resp.status_code == 200
     except Exception:
         return False
@@ -55,7 +59,7 @@ def enqueue_tasks(tasks: list[dict]) -> bool:
 
 def clear_tasks() -> bool:
     try:
-        resp = requests.post(f"{API_BASE}/queue/clear", timeout=5)
+        resp = requests.post(f"{API_BASE}/queue/clear", timeout=5, headers=HEADERS)
         return resp.status_code == 200
     except Exception:
         return False

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -20,4 +20,6 @@ Heavy optional dependencies such as `tensorflow` and `transformers` can be skipp
 - `WEAVIATE_URI`: Weaviate endpoint.
 - `USE_GPU`: Set to `1` or `true` to force GPU usage, `0` to disable. When unset,
   GPU availability is detected automatically via `torch.cuda.is_available()`.
+- `API_TOKEN`: Optional bearer token required by the FastAPI server. If unset
+  all requests are accepted without authentication.
 


### PR DESCRIPTION
## Summary
- provide `api/security.py` with shared HTTPBearer auth and simple rate limiter
- apply middleware in FastAPI app
- authorize dashboard API calls using token
- document API_TOKEN environment variable

## Testing
- `pytest tests/test_api_app.py::test_health_endpoint -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_685d85fbd2fc8320b950725b951276a9